### PR TITLE
Bring variables.tf in-line with documentation

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -85,6 +85,7 @@ variable "vcn_dns_name" {
 variable "vcn_name" {
   type        = "string"
   description = "name of vcn"
+  default     = "oke vcn"
 }
 
 # nat
@@ -249,7 +250,8 @@ variable "create_auth_token" {
 }
 
 variable "email_address" {
-  description = "email address used for ocir "
+  description = "email address used for OICR"
+  default = ""
 }
 
 variable "ocir_urls" {
@@ -267,10 +269,12 @@ variable "ocir_urls" {
 
 variable "tenancy_name" {
   description = "tenancy name"
+  default = ""
 }
 
 variable "username" {
-  description = "username to access ocir"
+  description = "username to access OICR"
+  default = ""
 }
 
 # helm

--- a/variables.tf
+++ b/variables.tf
@@ -152,6 +152,7 @@ variable "image_operating_system" {
 
 variable "image_operating_system_version" {
   # Versions of available operating systems can be found here: https://docs.cloud.oracle.com/iaas/images/
+  default = "7.6"
   description = "version of selected operating system"
 }
 


### PR DESCRIPTION
A lot of the variables do not have a default value set which they should in order to keep in-line with what the documentation specifies is required.