### PR TITLE
Make module capable of handling multiple clusters

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -37,6 +37,9 @@ module "base" {
   image_operating_system         = "${var.image_operating_system}"
   image_operating_system_version = "${var.image_operating_system_version}"
 
+  # kubeconfig
+  config_output_path   = "${var.config_output_path}"
+
   # availability_domains
   availability_domains = "${var.availability_domains}"
 }

--- a/main.tf
+++ b/main.tf
@@ -4,7 +4,7 @@
 module "base" {
   source = "./modules/base"
 
-  # identity 
+  # identity
   api_fingerprint      = "${var.api_fingerprint}"
   api_private_key_path = "${var.api_private_key_path}"
   compartment_name     = "${var.compartment_name}"
@@ -106,6 +106,9 @@ module "oke" {
   enable_instance_principal = "${var.enable_instance_principal}"
   image_operating_system    = "${var.image_operating_system}"
 
+  # kubeconfig
+  config_output_path        = "${var.config_output_path}"
+
   # networking
   vcn_id = "${module.base.vcn_id}"
 
@@ -143,5 +146,5 @@ module "oke" {
 
   # calico
   calico_version = "${var.calico_version}"
-  install_calico = "${var.install_calico}" 
+  install_calico = "${var.install_calico}"
 }

--- a/modules/base/bastion/variables.tf
+++ b/modules/base/bastion/variables.tf
@@ -36,7 +36,6 @@ variable "image_operating_system_version" {}
 variable "config_output_path" {
   type        = "string"
   description = "output path for configuration files"
-  default     = "./generated/"
 }
 
 # networking

--- a/modules/base/bastion/variables.tf
+++ b/modules/base/bastion/variables.tf
@@ -30,8 +30,16 @@ variable "image_operating_system" {}
 
 variable "image_operating_system_version" {}
 
-# networking
 
+
+# kubeconfig
+variable "config_output_path" {
+  type        = "string"
+  description = "output path for configuration files"
+  default     = "./generated/"
+}
+
+# networking
 variable "ig_route_id" {}
 
 variable "newbits" {

--- a/modules/base/main.tf
+++ b/modules/base/main.tf
@@ -35,4 +35,5 @@ module "bastion" {
   vcn_id                         = "${module.vcn.vcn_id}"
   ad_names                       = "${data.template_file.ad_names.*.rendered}"
   availability_domains           = "${var.availability_domains}"
+  config_output_path             = "${var.config_output_path}"
 }

--- a/modules/base/variables.tf
+++ b/modules/base/variables.tf
@@ -153,6 +153,7 @@ variable "image_operating_system_version" {
 variable "config_output_path" {
   type        = "string"
   description = "output path for configuration files"
+}
 
 # availability domains
 

--- a/modules/base/variables.tf
+++ b/modules/base/variables.tf
@@ -149,6 +149,10 @@ variable "image_operating_system_version" {
   description = "version of selected operating system"
 }
 
+# kubeconfig
+variable "config_output_path" {
+  type        = "string"
+  description = "output path for configuration files"
 
 # availability domains
 

--- a/modules/oke/helm.tf
+++ b/modules/oke/helm.tf
@@ -3,7 +3,7 @@
 
 provider "helm" {
   kubernetes {
-    config_path = "${var.config_output_path}/kubeconfig_oke_${var.cluster_name}"
+    config_path = "${var.config_output_path}/kubeconfig_${var.cluster_name}"
   }
 }
 

--- a/modules/oke/helm.tf
+++ b/modules/oke/helm.tf
@@ -3,7 +3,7 @@
 
 provider "helm" {
   kubernetes {
-    config_path = "${path.root}/generated/kubeconfig"
+    config_path = "${var.config_output_path}/kubeconfig_oke_${var.cluster_name}"
   }
 }
 

--- a/modules/oke/kubeconfig.tf
+++ b/modules/oke/kubeconfig.tf
@@ -10,7 +10,7 @@ data "oci_containerengine_cluster_kube_config" "kube_config" {
 resource "local_file" "kube_config_file" {
   content    = "${data.oci_containerengine_cluster_kube_config.kube_config.content}"
   depends_on = ["oci_containerengine_cluster.k8s_cluster"]
-  filename   = "${var.config_output_path}/kubeconfig_oke_${var.cluster_name}"
+  filename   = "${var.config_output_path}/kubeconfig_${var.cluster_name}"
 }
 
 data "template_file" "install_kubectl" {
@@ -63,7 +63,7 @@ resource "null_resource" "write_kubeconfig_bastion" {
   }
 
   provisioner "file" {
-    source      = "${var.config_output_path}/kubeconfig_oke_${var.cluster_name}"
+    source      = "${var.config_output_path}/kubeconfig_${var.cluster_name}"
     destination = "~/.kube/config"
   }
 

--- a/modules/oke/kubeconfig.tf
+++ b/modules/oke/kubeconfig.tf
@@ -9,7 +9,7 @@ data "oci_containerengine_cluster_kube_config" "kube_config" {
 
 resource "local_file" "kube_config_file" {
   content    = "${data.oci_containerengine_cluster_kube_config.kube_config.content}"
-  depends_on = ["null_resource.create_local_kubeconfig", "oci_containerengine_cluster.k8s_cluster"]
+  depends_on = ["oci_containerengine_cluster.k8s_cluster"]
   filename   = "${var.config_output_path}/kubeconfig_oke_${var.cluster_name}"
 }
 

--- a/modules/oke/kubeconfig.tf
+++ b/modules/oke/kubeconfig.tf
@@ -7,24 +7,10 @@ data "oci_containerengine_cluster_kube_config" "kube_config" {
   token_version = "${var.cluster_kube_config_token_version}"
 }
 
-resource "null_resource" "create_local_kubeconfig" {
-  provisioner "local-exec" {
-    command = "rm -rf generated"
-  }
-
-  provisioner "local-exec" {
-    command = "mkdir generated"
-  }
-
-  provisioner "local-exec" {
-    command = "touch generated/kubeconfig"
-  }
-}
-
 resource "local_file" "kube_config_file" {
   content    = "${data.oci_containerengine_cluster_kube_config.kube_config.content}"
   depends_on = ["null_resource.create_local_kubeconfig", "oci_containerengine_cluster.k8s_cluster"]
-  filename   = "${path.root}/generated/kubeconfig"
+  filename   = "${var.config_output_path}/kubeconfig_oke_${var.cluster_name}"
 }
 
 data "template_file" "install_kubectl" {
@@ -77,7 +63,7 @@ resource "null_resource" "write_kubeconfig_bastion" {
   }
 
   provisioner "file" {
-    source      = "generated/kubeconfig"
+    source      = "${var.config_output_path}/kubeconfig_oke_${var.cluster_name}"
     destination = "~/.kube/config"
   }
 

--- a/modules/oke/outputs.tf
+++ b/modules/oke/outputs.tf
@@ -1,3 +1,3 @@
 output "cluster_endpoint" {
-  value = "${oci_containerengine_cluster.k8s_cluster.endpoints.*.kubernetes[count.index]}"
+  value = "${oci_containerengine_cluster.k8s_cluster.endpoints.0.kubernetes}"
 }

--- a/modules/oke/outputs.tf
+++ b/modules/oke/outputs.tf
@@ -1,0 +1,3 @@
+output "cluster_endpoint" {
+  value = "${oci_containerengine_cluster.k8s_cluster.endpoints.kubernetes}"
+}

--- a/modules/oke/outputs.tf
+++ b/modules/oke/outputs.tf
@@ -1,3 +1,3 @@
 output "cluster_endpoint" {
-  value = "${oci_containerengine_cluster.k8s_cluster.endpoints.0.kubernetes}"
+  value = "https://${oci_containerengine_cluster.k8s_cluster.endpoints.0.kubernetes}"
 }

--- a/modules/oke/outputs.tf
+++ b/modules/oke/outputs.tf
@@ -1,3 +1,3 @@
 output "cluster_endpoint" {
-  value = "${oci_containerengine_cluster.k8s_cluster.endpoints.kubernetes}"
+  value = "${oci_containerengine_cluster.k8s_cluster.endpoints.*.kubernetes[count.index]}"
 }

--- a/modules/oke/variables.tf
+++ b/modules/oke/variables.tf
@@ -78,6 +78,10 @@ variable "cluster_kube_config_expiration" {
 variable "cluster_kube_config_token_version" {
   default = "1.0.0"
 }
+variable "config_output_path" {
+  type        = "string"
+  description = "output path for configuration files"
+}
 
 # ocir
 variable "auth_token" {}

--- a/outputs.tf
+++ b/outputs.tf
@@ -5,6 +5,10 @@ output "bastion_public_ip" {
   value = "${module.base.bastion_public_ip}"
 }
 
+output "cluster_endpoint" {
+  value = "${module.oke.cluster_endpoint}"
+}
+
 output "ssh_to_bastion" {
   value = "${module.base.ssh_to_bastion}"
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -9,8 +9,12 @@ output "ssh_to_bastion" {
   value = "${module.base.ssh_to_bastion}"
 }
 
-output "kubeconfig" {
-  value = "export KUBECONFIG=generated/kubeconfig"
+output "kubeconfig_env" {
+  value = "export KUBECONFIG=${var.config_output_path}/kubeconfig_oke_${var.cluster_name}"
+}
+
+output "kubeconfig_file" {
+  value = "${var.config_output_path}/kubeconfig_oke_${var.cluster_name}"
 }
 
 output "ocirtoken" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -14,11 +14,11 @@ output "ssh_to_bastion" {
 }
 
 output "kubeconfig_env" {
-  value = "export KUBECONFIG=${var.config_output_path}/kubeconfig_oke_${var.cluster_name}"
+  value = "export KUBECONFIG=${var.config_output_path}/kubeconfig_${var.cluster_name}"
 }
 
 output "kubeconfig_file" {
-  value = "${var.config_output_path}/kubeconfig_oke_${var.cluster_name}"
+  value = "${var.config_output_path}/kubeconfig_${var.cluster_name}"
 }
 
 output "ocirtoken" {

--- a/scripts/dashboard.sh
+++ b/scripts/dashboard.sh
@@ -2,10 +2,10 @@
 #  Copyright 2017, 2019, Oracle Corporation and/or affiliates.  All rights reserved.
 # Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl
 
-export KUBECONFIG=generated/kubeconfig
+export KUBECONFIG="${var.config_output_path}/kubeconfig_oke_${var.cluster_name}"
 
 echo 'Access K8s Dashboard: http://localhost:8001/api/v1/namespaces/kube-system/services/https:kubernetes-dashboard:/proxy/'
 
-echo 'Login with the kubeconfig in generated/kubeconfig file'
+echo 'Login with the generated kubeconfig file'
 
 kubectl proxy

--- a/scripts/dashboard.sh
+++ b/scripts/dashboard.sh
@@ -2,7 +2,7 @@
 #  Copyright 2017, 2019, Oracle Corporation and/or affiliates.  All rights reserved.
 # Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl
 
-export KUBECONFIG="${var.config_output_path}/kubeconfig_oke_${var.cluster_name}"
+export KUBECONFIG="${var.config_output_path}/kubeconfig_${var.cluster_name}"
 
 echo 'Access K8s Dashboard: http://localhost:8001/api/v1/namespaces/kube-system/services/https:kubernetes-dashboard:/proxy/'
 

--- a/variables.tf
+++ b/variables.tf
@@ -13,6 +13,7 @@ variable "api_private_key_path" {
 variable "compartment_name" {
   type        = "string"
   description = "compartment name"
+
 }
 
 variable "compartment_ocid" {
@@ -28,6 +29,13 @@ variable "tenancy_ocid" {
 variable "user_ocid" {
   type        = "string"
   description = "user ocid"
+}
+
+# config
+variable "config_output_path" {
+  type        = "string"
+  description = "output path for configuration files"
+  default     = "generated/"
 }
 
 # ssh keys


### PR DESCRIPTION
This PR includes a few related changes:

- Replace kubeconfig output with kubeconfig_env (current behaviour) and kubeconfig_file (basically the same as previous but without the 'export KUBECONFIG=' stuff.)

- Added variable for config_output_path (in-line with other provider modules) and defaulted that to generated/ (in-line with your current implementation.)

- Replaced all hard-coded references to kubeconfig with the new dynamic filenaming strategy.

- Adds output value of the API endpoint (incl. HTTPS)

These changes combined should allow k8s clusters to be easily provisioned and then instantly used within a single TF deployment.