### PR TITLE
fix for vcn_cidr to have correct variable name

### DIFF
--- a/modules/okenetwork/security.tf
+++ b/modules/okenetwork/security.tf
@@ -97,7 +97,7 @@ resource "oci_core_security_list" "public_workers_seclist" {
 
     content {
       protocol  = local.tcp_protocol
-      source    = var.vcn_cidr
+      source    = var.oke_network_vcn.vcn_cidr
       stateless = false
 
       tcp_options {
@@ -165,7 +165,7 @@ resource "oci_core_security_list" "private_workers_seclist" {
 
     content {
       protocol  = local.tcp_protocol
-      source    = var.vcn_cidr
+      source    = var.oke_network_vcn.vcn_cidr
       stateless = false
 
       tcp_options {


### PR DESCRIPTION
Fix for vcn_cidr to have a correct variable in okenetwork security. This is reproducible when 'allow_worker_ssh_access = true' 

Having it false it produces below error:
Error: Reference to undeclared input variable

  on modules/okenetwork/security.tf line 168, in resource "oci_core_security_list" "private_workers_seclist":
 168:       source    = var.vcn_cidr

An input variable with the name "vcn_cidr" has not been declared. This
variable can be declared with a variable "vcn_cidr" {} block.