### PR TITLE
Issue 86 - Updated bastion-instance-principal policy to use compartment id

### DIFF
--- a/docs/configuration.adoc
+++ b/docs/configuration.adoc
@@ -78,7 +78,6 @@ Enter the values for the following parameters in the terraform.tfvars file:
 
 * api_fingerprint
 * api_private_key_path
-* compartment_name
 * compartment_id
 * tenancy_id
 * user_id

--- a/docs/quickstart.adoc
+++ b/docs/quickstart.adoc
@@ -51,7 +51,6 @@ cp terraform.tfvars.example terraform.tfvars
 * api_fingerprint
 * api_private_key_path
 * compartment_id
-* compartment_name
 * tenancy_id
 * user_id
 

--- a/docs/terraformoptions.adoc
+++ b/docs/terraformoptions.adoc
@@ -57,11 +57,6 @@ Configuration Terraform Options:
 |
 |None
 
-|compartment_name
-|Compartment name where the OKE Cluster will be provisioned. *Required*
-|
-|None
-
 |compartment_id
 |Compartment id where the OKE Cluster will be provisioned. *Required*
 |

--- a/locals.tf
+++ b/locals.tf
@@ -6,7 +6,6 @@ locals {
   oci_base_identity = {
     api_fingerprint      = var.api_fingerprint
     api_private_key_path = var.api_private_key_path
-    compartment_name     = var.compartment_name
     compartment_id       = var.compartment_id
     tenancy_id           = var.tenancy_id
     user_id              = var.user_id

--- a/modules/base/bastion/iam.tf
+++ b/modules/base/bastion/iam.tf
@@ -11,14 +11,14 @@ provider "oci" {
   user_ocid        = var.oci_base_identity.user_id
 }
 
-data "oci_identity_compartments" "compartments_name" {
+data "oci_identity_compartments" "compartments_id" {
   access_level              = "ACCESSIBLE"
   compartment_id            = var.oci_base_identity.tenancy_id
   compartment_id_in_subtree = "true"
 
   filter {
-    name   = "name"
-    values = [var.oci_base_identity.compartment_name]
+    name   = "id"
+    values = [var.oci_base_identity.compartment_id]
   }
 }
 
@@ -36,6 +36,6 @@ resource "oci_identity_policy" "bastion_instance_principal" {
   compartment_id = var.oci_base_identity.compartment_id
   description    = "policy to allow bastion host to call services"
   name           = "${var.oci_bastion_general.label_prefix}-bastion_instance_principal"
-  statements     = ["Allow dynamic-group ${oci_identity_dynamic_group.bastion_instance_principal[0].name} to manage all-resources in compartment ${data.oci_identity_compartments.compartments_name.compartments.0.name}"]
+  statements     = ["Allow dynamic-group ${oci_identity_dynamic_group.bastion_instance_principal[0].name} to manage all-resources in compartment id ${data.oci_identity_compartments.compartments_id.compartments.0.id}"]
   count          = var.oci_bastion.enable_instance_principal == true ? 1 : 0
 }

--- a/modules/base/bastion/variables.tf
+++ b/modules/base/bastion/variables.tf
@@ -8,7 +8,6 @@ variable "oci_base_identity" {
     api_fingerprint      = string
     api_private_key_path = string
     compartment_id       = string
-    compartment_name     = string
     tenancy_id           = string
     user_id              = string
   })

--- a/modules/base/variables.tf
+++ b/modules/base/variables.tf
@@ -8,7 +8,6 @@ variable "oci_base_identity" {
     api_fingerprint      = string
     api_private_key_path = string
     compartment_id       = string
-    compartment_name     = string
     tenancy_id           = string
     user_id              = string
   })

--- a/modules/policies/datasources.tf
+++ b/modules/policies/datasources.tf
@@ -13,13 +13,13 @@ data "oci_identity_regions" "home_region" {
   }
 }
 
-data "oci_identity_compartments" "compartments_name" {
+data "oci_identity_compartments" "compartments_id" {
   access_level              = "ACCESSIBLE"
   compartment_id            = var.oci_identity.tenancy_id
   compartment_id_in_subtree = "true"
 
   filter {
-    name   = "name"
-    values = [var.oci_identity.compartment_name]
+    name   = "id"
+    values = [var.oci_identity.compartment_id]
   }
 }

--- a/modules/policies/variables.tf
+++ b/modules/policies/variables.tf
@@ -8,7 +8,6 @@ variable "oci_identity" {
     api_fingerprint      = string
     api_private_key_path = string
     compartment_id       = string
-    compartment_name     = string
     tenancy_id           = string
     user_id              = string
   })

--- a/variables.tf
+++ b/variables.tf
@@ -10,11 +10,6 @@ variable "api_private_key_path" {
   description = "path to oci api private key"
 }
 
-variable "compartment_name" {
-  type        = "string"
-  description = "compartment name"
-}
-
 variable "compartment_id" {
   type        = "string"
   description = "compartment id"


### PR DESCRIPTION
Updated bastion-instance-principal policy to use compartment id instead of compartment name, and removed the compartment_name variable.