### PR TITLE
node_pool_image_id changed as NONE

### DIFF
--- a/terraform.tfvars.example
+++ b/terraform.tfvars.example
@@ -138,7 +138,7 @@ node_pools = {
 
 node_pool_name_prefix = "np"
 
-node_pool_image_id = "none"
+node_pool_image_id = "NONE"
 
 node_pool_os = "Oracle Linux"
 


### PR DESCRIPTION
* Issue 176 fix.
* In order to properly get the list of latest images we need to pass node_pool_image_id as "NONE" instead of "none"

Signed-off-by: kranthi guttikonda <kranthi.guttikonda@b-yond.com>