### PR TITLE
Multiple issues: 183, 190, 191, 192, 193, 194

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -7,6 +7,24 @@ All notable changes to this project are documented in this file.
 
 The format is based on {uri-changelog}[Keep a Changelog].
 
+== 2.3.1 (August 13, 2020)
+* Missing security rule when workers are in public mode (#186)
+* Updated docs for terraform options and for resetting nodepool_drain (#190)
+* Upgraded base module to 1.3.0 (#191)
+* Removed nat_gateway_enabled variable. Determination of whether the NAT gateway is needed is now done automatically (#192)
+* Removed "LATEST" from acceptable values for kubernetes_version so that upgrade can be performed (#193)
+* Internal load balancer subnet uses wrong routing table (#194)
+
+== 2.3.0 (August 5, 2020)
+
+* Added option to enable admission controllers and PodSecurityPolicy (#150)
+* Added ability to upgrade OKE cluster and worker nodes using out-of-place method (#178)
+* Changed node pools specification from list to map so the specific node pool is deleted when removed from the variable (#179)
+* Made minimum worker node pool to 1 to allow experimentation on free tier ( #180 )
+* Made label_prefix optional (#181)
+* Added trigger for check_worker_node_active (#182)
+* Removed disable_auto_retries in quick start guide (#185)
+
 == 2.2.2 (June 10, 2020)
 * Upgraded base module to 1.2.3 (#169)
 

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -8,7 +8,7 @@ All notable changes to this project are documented in this file.
 The format is based on {uri-changelog}[Keep a Changelog].
 
 == 2.3.1 (August 13, 2020)
-* Missing security rule when workers are in public mode (#186)
+* Missing security rule when workers are in public mode (#183)
 * Updated docs for terraform options and for resetting nodepool_drain (#190)
 * Upgraded base module to 1.3.0 (#191)
 * Removed nat_gateway_enabled variable. Determination of whether the NAT gateway is needed is now done automatically (#192)

--- a/docs/terraformoptions.adoc
+++ b/docs/terraformoptions.adoc
@@ -130,11 +130,6 @@ Ensure you review the {uri-terraform-dependencies}[dependencies].
 |Values
 |Default
 
-|`nat_gateway_enabled`
-|Whether to create a NAT gateway. *Required* for private worker mode.
-|true/false
-|true
-
 |`netnum`
 |0-based index of the subnets when the VCN's CIDR is masked with the corresponding newbit value and specified in the form of a map. Used to define the boundaries of the subnets. The values of the map are used as the netnum parameter in the {uri-terraform-cidrsubnet}[cidrsubnet] Terraform function. CIDR blocks for workers and load balancer subnets must not overlap with the CIDR blocks for Kubernetes pods (specified with _pods_cidr_ parameter).
 |e.g.
@@ -456,9 +451,9 @@ admission_controller_options = {
 |false
 
 |`kubernetes_version`
-|The version of Kubernetes to provision. This is based on the available versions in OKE. By default, the available versions will be queries and the latest version selected. To provision a specific version, choose from available versions and override the 'LATEST' value.
-|LATEST, v1.14.8,v1.15.7, v1.16.8
-|LATEST
+|The version of Kubernetes to provision. This is based on the available versions in OKE. By default, the latest version is selected. The use of 'LATEST' is no longer permitted in order to facilitate upgrades.
+|v1.14.8,v1.15.7, v1.16.8
+|v1.16.8
 
 |`node_pools`
 |The number, shape and quantities per subnets of node pools to create. Each key and tuple pair corresponds to 1 node pool. The first parameter in the tuple sets the shape of the worker node and the 2nd parameter sets the size of the node pool. A minimum of 3 worker worker nodes per node pool will be created.  Refer to {uri-topology}[topology] for more thorough examples.

--- a/docs/upgrade.adoc
+++ b/docs/upgrade.adoc
@@ -120,3 +120,5 @@ node_pools = {
 ----
 terraform apply --auto-approve
 ----
+
+. This completes the upgrade process. Now, set ```nodepool_drain = false``` to prevent draining from current nodes.

--- a/locals.tf
+++ b/locals.tf
@@ -4,8 +4,9 @@
 locals {
 
   oci_base_general = {
-    compartment_id = var.compartment_id
-    label_prefix   = var.label_prefix
+    compartment_id      = var.compartment_id
+    label_prefix        = var.label_prefix
+    root_compartment_id = var.tenancy_id
   }
 
   oci_base_provider = {
@@ -45,6 +46,7 @@ locals {
     notification_protocol = var.bastion_notification_protocol
     notification_topic    = var.bastion_notification_topic
     ssh_private_key_path  = var.ssh_private_key_path
+    ssh_public_key        = var.ssh_public_key
     ssh_public_key_path   = var.ssh_public_key_path
     tags                  = var.tags["bastion"]
     timezone              = var.bastion_timezone
@@ -64,6 +66,7 @@ locals {
     notification_protocol     = var.operator_notification_protocol
     notification_topic        = var.operator_notification_topic
     ssh_private_key_path      = var.ssh_private_key_path
+    ssh_public_key            = var.ssh_public_key
     ssh_public_key_path       = var.ssh_public_key_path
     tags                      = var.tags["bastion"]
     timezone                  = var.operator_timezone

--- a/locals.tf
+++ b/locals.tf
@@ -19,7 +19,7 @@ locals {
 
   oci_base_vcn = {
     internet_gateway_enabled = true
-    nat_gateway_enabled      = var.nat_gateway_enabled
+    nat_gateway_enabled      = var.worker_mode == "private" || var.operator_enabled == true ? true : false
     service_gateway_enabled  = true
     tags                     = var.tags["vcn"]
     vcn_cidr                 = var.vcn_cidr

--- a/locals.tf
+++ b/locals.tf
@@ -19,7 +19,7 @@ locals {
 
   oci_base_vcn = {
     internet_gateway_enabled = true
-    nat_gateway_enabled      = var.worker_mode == "private" || var.operator_enabled == true ? true : false
+    nat_gateway_enabled      = var.worker_mode == "private" || var.operator_enabled == true || (var.lb_subnet_type == "internal" || var.lb_subnet_type == "both") ? true : false
     service_gateway_enabled  = true
     tags                     = var.tags["vcn"]
     vcn_cidr                 = var.vcn_cidr

--- a/main.tf
+++ b/main.tf
@@ -7,7 +7,7 @@ terraform {
 
 module "base" {
   source  = "oracle-terraform-modules/base/oci"
-  version = "1.2.4"
+  version = "1.3.0"
 
   # general oci parameters
   oci_base_general = local.oci_base_general
@@ -34,8 +34,9 @@ module "policies" {
   label_prefix   = var.label_prefix
 
   # provider
-  oci_provider = local.oci_base_provider
-
+  region = var.region
+  tenancy_id = var.tenancy_id
+  
   ssh_keys = local.oci_base_ssh_keys
 
   operator = local.oke_operator

--- a/modules/oke/cluster.tf
+++ b/modules/oke/cluster.tf
@@ -3,7 +3,7 @@
 
 resource "oci_containerengine_cluster" "k8s_cluster" {
   compartment_id     = var.compartment_id
-  kubernetes_version = local.kubernetes_version
+  kubernetes_version = var.oke_cluster.cluster_kubernetes_version
   kms_key_id         = var.oke_cluster.use_encryption == true ? var.oke_cluster.kms_key_id : null
   name               = var.label_prefix == "none" ? var.oke_cluster.cluster_name : "${var.label_prefix}-${var.oke_cluster.cluster_name}"
 

--- a/modules/oke/datasources.tf
+++ b/modules/oke/datasources.tf
@@ -10,10 +10,6 @@ data "oci_core_images" "latest_images" {
   sort_by                  = "TIMECREATED"
 }
 
-data "oci_containerengine_cluster_option" "k8s_cluster_option" {
-  cluster_option_id = "all"
-}
-
 data "oci_containerengine_node_pools" "all_node_pools" {
   compartment_id = var.compartment_id
   cluster_id     = oci_containerengine_cluster.k8s_cluster.id

--- a/modules/oke/locals.tf
+++ b/modules/oke/locals.tf
@@ -5,11 +5,6 @@ locals {
   # used by cluster
   lb_subnet = var.lbs.preferred_lb_subnets == "public" ? "pub_lb" : "int_lb"
 
-  # used by datasources
-  available_kubernetes_versions = data.oci_containerengine_cluster_option.k8s_cluster_option.kubernetes_versions
-  num_kubernetes_versions       = length(local.available_kubernetes_versions)
-  kubernetes_version            = var.oke_cluster.cluster_kubernetes_version == "LATEST" ? element(sort(local.available_kubernetes_versions), (local.num_kubernetes_versions - 1)) : var.oke_cluster.cluster_kubernetes_version
-
   node_pools_size_list = [
     for node_pool in data.oci_containerengine_node_pools.all_node_pools.node_pools :
     node_pool.node_config_details[0].size

--- a/modules/oke/nodepools.tf
+++ b/modules/oke/nodepools.tf
@@ -7,7 +7,7 @@ resource "oci_containerengine_node_pool" "nodepools" {
   compartment_id = var.compartment_id
   depends_on     = [oci_containerengine_cluster.k8s_cluster]
 
-  kubernetes_version = local.kubernetes_version
+  kubernetes_version = var.oke_cluster.cluster_kubernetes_version
   name               = var.label_prefix == "none" ? each.key : "${var.label_prefix}-${each.key}"
 
   node_config_details {

--- a/modules/okenetwork/locals.tf
+++ b/modules/okenetwork/locals.tf
@@ -37,7 +37,7 @@ locals {
 
   worker_egress = [
     {
-      description      = "Allow ingress for all traffic to allow pods to communicate between each other on different worker nodes on the worker subnet",
+      description      = "Allow egress for all traffic to allow pods to communicate between each other on different worker nodes on the worker subnet",
       destination      = local.worker_subnet,
       destination_type = "CIDR_BLOCK",
       protocol         = local.all_protocols,

--- a/modules/okenetwork/security.tf
+++ b/modules/okenetwork/security.tf
@@ -29,6 +29,13 @@ resource "oci_core_security_list" "public_workers_seclist" {
     }
   }
 
+  egress_security_rules {
+    description = "Allow all outbound traffic to the internet. Required for getting container images or using external services"
+    destination = local.anywhere
+    protocol    = local.all_protocols
+    stateless   = false
+  }
+  
   dynamic "ingress_security_rules" {
     iterator = public_worker_ingress_iterator
     for_each = local.public_worker_ingress

--- a/modules/okenetwork/subnets.tf
+++ b/modules/okenetwork/subnets.tf
@@ -18,7 +18,7 @@ resource "oci_core_subnet" "int_lb" {
   display_name               = var.label_prefix == "none" ? "int_lb" : "${var.label_prefix}-int_lb"
   dns_label                  = "intlb"
   prohibit_public_ip_on_vnic = true
-  route_table_id             = var.oke_network_vcn.ig_route_id
+  route_table_id             = var.oke_network_vcn.nat_route_id
   security_list_ids          = [oci_core_security_list.int_lb_seclist[0].id]
   vcn_id                     = var.oke_network_vcn.vcn_id
 

--- a/modules/policies/datasources.tf
+++ b/modules/policies/datasources.tf
@@ -2,7 +2,7 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl
 
 data "oci_identity_tenancy" "tenancy" {
-  tenancy_id = var.oci_provider.tenancy_id  
+  tenancy_id = var.tenancy_id  
 }
 
 # get the tenancy's home region

--- a/modules/policies/groups.tf
+++ b/modules/policies/groups.tf
@@ -3,7 +3,7 @@
 
 resource "oci_identity_dynamic_group" "oke-kms-cluster" {
   provider       = oci.home
-  compartment_id = var.oci_provider.tenancy_id
+  compartment_id = var.tenancy_id
   description    = "dynamic group to allow cluster to use kms"
   matching_rule  = local.dynamic_group_rule_all_clusters
   name           = var.label_prefix == "none" ? "oke-kms-cluster" : "${var.label_prefix}-oke-kms-cluster"

--- a/modules/policies/policies.tf
+++ b/modules/policies/policies.tf
@@ -3,7 +3,7 @@
 
 resource "oci_identity_policy" "operator_instance_principal_dynamic_group" {
   provider       = oci.home
-  compartment_id = var.oci_provider.tenancy_id
+  compartment_id = var.tenancy_id
   description    = "policy to allow operator host to manage dynamic group"
   name           = var.label_prefix == "none" ? "operator-instance-principal-dynamic-group" : "${var.label_prefix}-operator-instance-principal-dynamic-group"
   statements     = ["Allow dynamic-group ${var.dynamic_group} to use dynamic-groups in tenancy"]

--- a/modules/policies/provider.tf
+++ b/modules/policies/provider.tf
@@ -4,9 +4,5 @@
 # create a home region provider for identity operations
 provider "oci" {
   alias            = "home"
-  fingerprint      = var.oci_provider.api_fingerprint
-  private_key_path = var.oci_provider.api_private_key_path
   region           = lookup(data.oci_identity_regions.home_region.regions[0], "name")
-  tenancy_ocid     = var.oci_provider.tenancy_id
-  user_ocid        = var.oci_provider.user_id
 }

--- a/modules/policies/variables.tf
+++ b/modules/policies/variables.tf
@@ -7,15 +7,9 @@ variable "compartment_id" {}
 variable "label_prefix" {}
 
 # provider
-variable "oci_provider" {
-  type = object({
-    api_fingerprint      = string
-    api_private_key_path = string
-    region               = string
-    tenancy_id           = string
-    user_id              = string
-  })
-}
+variable "region" {}
+
+variable "tenancy_id" {}
 
 # ssh keys
 variable "ssh_keys" {

--- a/terraform.tfvars.example
+++ b/terraform.tfvars.example
@@ -22,8 +22,6 @@ ssh_public_key_path = ""
 
 # networking
 
-nat_gateway_enabled = true
-
 netnum = {
   bastion    = 32
   int_lb     = 16
@@ -132,7 +130,7 @@ check_node_active = "none"
 
 dashboard_enabled = false
 
-kubernetes_version = "LATEST"
+kubernetes_version = "v.16.8"
 
 node_pools = {
   np1 = ["VM.Standard.E2.2", 1]

--- a/variables.tf
+++ b/variables.tf
@@ -60,12 +60,6 @@ variable "ssh_public_key_path" {
 }
 
 # networking parameters
-variable "nat_gateway_enabled" {
-  default     = true
-  description = "Whether to create a nat gateway in the vcn."
-  type        = bool
-}
-
 variable "netnum" {
   description = "0-based index of the subnet when the network is masked with the newbit. Used as netnum parameter for cidrsubnet function."
   default = {
@@ -281,7 +275,7 @@ variable "dashboard_enabled" {
 }
 
 variable "kubernetes_version" {
-  default     = "LATEST"
+  default     = "v.16.8"
   description = "The version of kubernetes to use when provisioning OKE or to upgrade an existing OKE cluster to."
   type        = string
 }

--- a/variables.tf
+++ b/variables.tf
@@ -47,6 +47,12 @@ variable "ssh_private_key_path" {
   type        = string
 }
 
+variable "ssh_public_key" {
+  default     = ""
+  description = "The ssh public key."
+  type        = string
+}
+
 variable "ssh_public_key_path" {
   default     = "none"
   description = "The path to ssh public key."


### PR DESCRIPTION
* Missing security rule when workers are in public mode (#183)
* Updated docs for terraform options and for resetting nodepool_drain (#190)
* Upgraded base module to 1.3.0 (#191)
* Removed nat_gateway_enabled variable. Determination of whether the NAT gateway is needed is now done automatically (#192)
* Removed "LATEST" from acceptable values for kubernetes_version so that upgrade can be performed (#193)
* Internal load balancer subnet uses wrong routing table (#194)

