### PR TITLE
Ignore changes made by OKE cluster to security rules.

### DIFF
--- a/modules/okenetwork/security.tf
+++ b/modules/okenetwork/security.tf
@@ -117,6 +117,14 @@ resource "oci_core_security_list" "public_workers_seclist" {
     }
   }
 
+  lifecycle {
+    ignore_changes = [
+      # Ignore changes to ingress_security_rules,
+      # because Kubernetes will dynamically add new ones based on
+      # LoadBalancer requirements
+      ingress_security_rules,
+    ]
+  }
   count = var.oke_network_worker.worker_mode == "private" ? 0 : 1
 }
 
@@ -194,6 +202,14 @@ resource "oci_core_security_list" "private_workers_seclist" {
     }
   }
 
+  lifecycle {
+    ignore_changes = [
+      # Ignore changes to ingress_security_rules,
+      # because Kubernetes will dynamically add new ones based on
+      # LoadBalancer requirements
+      ingress_security_rules,
+    ]
+  }
   count = var.oke_network_worker.worker_mode == "private" ? 1 : 0
 }
 
@@ -217,6 +233,14 @@ resource "oci_core_security_list" "int_lb_seclist" {
     stateless   = false
   }
 
+  lifecycle {
+    ignore_changes = [
+      # Ignore changes to egress_security_rules,
+      # because Kubernetes will dynamically add new ones based on
+      # LoadBalancer requirements
+      egress_security_rules,
+    ]
+  }
   count = var.lb_subnet_type == "internal" || var.lb_subnet_type == "both" ? 1 : 0
 }
 
@@ -249,6 +273,14 @@ resource "oci_core_security_list" "pub_lb_seclist_wo_waf" {
     }
   }
 
+  lifecycle {
+    ignore_changes = [
+      # Ignore changes to egress_security_rules,
+      # because Kubernetes will dynamically add new ones based on
+      # LoadBalancer requirements
+      egress_security_rules,
+    ]
+  }
   count = ((var.lb_subnet_type == "public" || var.lb_subnet_type == "both") && var.waf_enabled == false) ? 1 : 0
 }
 
@@ -276,5 +308,13 @@ resource "oci_core_security_list" "pub_lb_seclist_with_waf" {
     }
   }
 
+  lifecycle {
+    ignore_changes = [
+      # Ignore changes to egress_security_rules,
+      # because Kubernetes will dynamically add new ones based on
+      # LoadBalancer requirements
+      egress_security_rules,
+    ]
+  }
   count = ((var.lb_subnet_type == "public" || var.lb_subnet_type == "both") && var.waf_enabled == true) ? 1 : 0
 }


### PR DESCRIPTION
OKE automatically creates new security rules for load balancers in the security list.
If you use this terraform module to upgrade the clusters OKE version, terraform deletes the new entries from the security list and breaks the load balancers.

This MR is going to address this problem.