### PR TITLE
Narrow permissions for kubeconfig file

### DIFF
--- a/modules/oke/kubeconfig.tf
+++ b/modules/oke/kubeconfig.tf
@@ -23,6 +23,7 @@ resource "local_file" "kube_config_file" {
   content    = data.oci_containerengine_cluster_kube_config.kube_config.content
   depends_on = [null_resource.create_local_kubeconfig, oci_containerengine_cluster.k8s_cluster]
   filename   = "${path.root}/generated/kubeconfig"
+  file_permission = "0600"
 }
 
 data "template_file" "generate_kubeconfig" {


### PR DESCRIPTION
Some tools don't like the *kubeconfig* file to have to wide permissions. This MR narrows those permissions so only the current user can access the file.