### PR TITLE
removed validation for node_pool_os_version

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -402,10 +402,6 @@ variable "node_pool_os_version" {
   default     = "7.9"
   description = "The version of image Operating System to use."
   type        = string
-  validation {
-    condition     = (var.node_pool_os_version >= 7.9)
-    error_message = "Node_pool_os_version should be equal or greater than 7.9."
-  }
 }
 
 variable "pods_cidr" {


### PR DESCRIPTION
Removed validation as this validation will affect if new versions are released and have to update this in all releases accordingly. Validation works well  mostly for a fixed values.