### PR TITLE
Output cluster ID and nodepool IDs

### DIFF
--- a/modules/oke/outputs.tf
+++ b/modules/oke/outputs.tf
@@ -4,3 +4,7 @@
 output "cluster_id" {
     value = oci_containerengine_cluster.k8s_cluster.id
 }
+
+output "nodepool_ids" {
+  value = zipmap( values(oci_containerengine_node_pool.nodepools)[*].name, values(oci_containerengine_node_pool.nodepools)[*].id)
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -3,6 +3,17 @@
 
 # for reuse 
 
+output "cluster_id" {
+  description = "ID of the Kubernetes cluster"
+  value       = module.oke.cluster_id
+}
+
+output "nodepool_ids" {
+  description = "Map of Nodepool names and IDs"
+  value = module.oke.nodepool_ids
+}
+
+
 output "ig_route_id" {
   description = "id of route table to vcn internet gateway"
   value       = module.base.ig_route_id


### PR DESCRIPTION
Useful for other terraform resources/pipelines that would need this information.
For example Cluster autoscaler can use the nodepool ids.

Signed-off-by: Yasser Saleemi <yassersaleemi@gmail.com>