### PR TITLE
docs: 'updated description for 1 rule'

### DIFF
--- a/modules/network/locals.tf
+++ b/modules/network/locals.tf
@@ -131,7 +131,7 @@ locals {
       stateless        = false
     },
     {
-      description      = "Allow worker nodes to communicate with OKE",
+      description      = "Allow worker nodes to communicate with OSN so applications can use OCI Streaming, Object Storage, Autonomous",
       destination      = local.osn,
       destination_type = "SERVICE_CIDR_BLOCK",
       protocol         = local.tcp_protocol,


### PR DESCRIPTION
Closes #389

Signed-off-by: Ali Mukadam <ali.mukadam@oracle.com>

The ports that are opened are from a range that are accessible only from within the worker subnet i.e. the source and destination of ingress and egress rules respectively is the worker subnet itself. This is to allow pods to communicate to each other. See the documentation here: https://docs.oracle.com/en-us/iaas/Content/ContEng/Concepts/contengnetworkconfig.htm#securitylistconfig