### PR TITLE
Fix node pool size definition

### DIFF
--- a/modules/oke/nodepools.tf
+++ b/modules/oke/nodepools.tf
@@ -20,7 +20,7 @@ resource "oci_containerengine_node_pool" "nodepools" {
         subnet_id           = var.cluster_subnets["workers"]
       }
     }
-    # We do not enforce consumer to create a node pool with the actual workers in it,
+    # We do not enforce consumers to create a node pool with a single worker node in it if no pool size was defined,
     # but instead we allow zero-sized node pool allowed by OKE API.
     size = max(0, lookup(each.value, "node_pool_size", 0))
   }

--- a/modules/oke/nodepools.tf
+++ b/modules/oke/nodepools.tf
@@ -20,8 +20,9 @@ resource "oci_containerengine_node_pool" "nodepools" {
         subnet_id           = var.cluster_subnets["workers"]
       }
     }
-    # set quantity to a minimum of 1 to allow small clusters. 
-    size = max(1, lookup(each.value, "node_pool_size", 1))
+    # We do not enforce consumer to create a node pool with the actual workers in it,
+    # but instead we allow zero-sized node pool allowed by OKE API.
+    size = max(0, lookup(each.value, "node_pool_size", 0))
   }
   dynamic "node_shape_config" {
     for_each = length(regexall("Flex", lookup(each.value, "shape", "VM.Standard.E4.Flex"))) > 0 ? [1] : []


### PR DESCRIPTION
Do not enforce consumers to create a node pool with a single worker in it, just create an empty node pool and let people decide what do to with that.

Closes: https://github.com/oracle-terraform-modules/terraform-oci-oke/issues/400