### PR TITLE
feat: enhancements to token_helper for kubectl. Closes #429

### DIFF
--- a/modules/extensions/kubeconfig.tf
+++ b/modules/extensions/kubeconfig.tf
@@ -61,7 +61,7 @@ resource "null_resource" "write_kubeconfig_on_operator" {
       "chmod +x $HOME/generate_kubeconfig.sh",
       "$HOME/generate_kubeconfig.sh",
       "chmod +x $HOME/token_helper.sh",
-      "sudo mv $HOME/token_helper.sh /usr/local/bin",
+      "sudo mv $HOME/token_helper.sh $HOME/bin",
       "chmod +x $HOME/kubeconfig_set_credentials.sh",
       "$HOME/kubeconfig_set_credentials.sh",
       "rm -f $HOME/generate_kubeconfig.sh",

--- a/modules/extensions/scripts/kubeconfig_set_credentials.template.sh
+++ b/modules/extensions/scripts/kubeconfig_set_credentials.template.sh
@@ -2,7 +2,7 @@
 # Copyright 2021 Oracle Corporation and/or affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl
 
-kubectl config set-credentials "user-${cluster-id-11}" --exec-command="./token_helper.sh" \
+kubectl config set-credentials "user-${cluster-id-11}" --exec-command="/usr/local/bin/token_helper.sh" \
   --exec-arg="ce" \
   --exec-arg="cluster" \
   --exec-arg="generate-token" \

--- a/modules/extensions/scripts/kubeconfig_set_credentials.template.sh
+++ b/modules/extensions/scripts/kubeconfig_set_credentials.template.sh
@@ -2,7 +2,7 @@
 # Copyright 2021 Oracle Corporation and/or affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl
 
-kubectl config set-credentials "user-${cluster-id-11}" --exec-command="/usr/local/bin/token_helper.sh" \
+kubectl config set-credentials "user-${cluster-id-11}" --exec-command="$HOME/bin/token_helper.sh" \
   --exec-arg="ce" \
   --exec-arg="cluster" \
   --exec-arg="generate-token" \

--- a/modules/extensions/scripts/token_helper.template.sh
+++ b/modules/extensions/scripts/token_helper.template.sh
@@ -2,11 +2,14 @@
 # Copyright 2021 Oracle Corporation and/or affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl
 
-TOKEN_FILE=~/.kube/TOKEN
+CLUSTER=$5
+REGION=$7
+
+TOKEN_FILE=~/.kube/TOKEN-$CLUSTER
 
 if ! test -f "$TOKEN_FILE" || test $(( `date +%s` - `stat -L -c %Y $TOKEN_FILE` )) -gt 240; then
   umask 022
-  oci ce cluster generate-token --cluster-id ${cluster-id} --region ${region} >$TOKEN_FILE
+  oci ce cluster generate-token --cluster-id "$CLUSTER" --region "$REGION" > $TOKEN_FILE
 fi
 
 cat $TOKEN_FILE

--- a/modules/extensions/scripts/token_helper.template.sh
+++ b/modules/extensions/scripts/token_helper.template.sh
@@ -5,7 +5,7 @@
 CLUSTER=$5
 REGION=$7
 
-TOKEN_FILE=~/.kube/TOKEN-$CLUSTER
+TOKEN_FILE=$HOME/.kube/TOKEN-$CLUSTER
 
 if ! test -f "$TOKEN_FILE" || test $(( `date +%s` - `stat -L -c %Y $TOKEN_FILE` )) -gt 240; then
   umask 022


### PR DESCRIPTION
Closes #429. Removed hard-coded region and cluster id parameters so the operator can be used to
manage more than 1 OKE cluster. The presence of the token improves the performance of issuing 
kubectl commands to clusters in different regions considerably.

Signed-off-by: Ali Mukadam <ali.mukadam@oracle.com>