### PR TITLE
create_policies variable to turn off any potential policy creation tempt (#325)

### DIFF
--- a/docs/configuration.adoc
+++ b/docs/configuration.adoc
@@ -272,7 +272,7 @@ create_operator = true
 enable_operator_instance_principal = true
 enable_operator_pv_encryption_in_transit = false
 operator_volume_kms_id = <operator_volume_kms_id>
-----
+create_policies = true
 
 OKE also supports enforcing the use of signed images. You can enforce the use of signed image using the following parameters:
 

--- a/docs/configuration.adoc
+++ b/docs/configuration.adoc
@@ -77,7 +77,7 @@ Alternatively, you can also specify these using Terraform environment variables 
 export TF_api_fingerprint = "1a:bc:23:45:6d:78:e9:f0:gh:ij:kl:m1:23:no:4p:5q"
 ----
 
-You would have obtained your values when doing the {uri-prereqs}[Prerequisites]. 
+You would have obtained your values when doing the {uri-prereqs}[Prerequisites].
 
 {uri-terraform-options}#identity-and-access[Reference]
 
@@ -129,7 +129,7 @@ The list of regions can be found {uri-oci-region}[here].
 
 == Configure OCI Networking parameters
 
-The networking parameters concern the VCN and the subnets network configuration as well as whether to enable some specific features such as the NAT Gateway. 
+The networking parameters concern the VCN and the subnets network configuration as well as whether to enable some specific features such as the NAT Gateway.
 
 You can leave most of the default options. However, you may want to change the following 2 parameters:
 
@@ -273,6 +273,7 @@ enable_operator_instance_principal = true
 enable_operator_pv_encryption_in_transit = false
 operator_volume_kms_id = <operator_volume_kms_id>
 create_policies = true
+----
 
 OKE also supports enforcing the use of signed images. You can enforce the use of signed image using the following parameters:
 

--- a/docs/instructions.adoc
+++ b/docs/instructions.adoc
@@ -74,9 +74,9 @@ If you wish to use {uri-oci-kms}[OCI KMS] to encrypt Kubernetes secrets, the fol
 ** {uri-oci-manage-policies}[manage policies in root tenancy]
 * link:#adding-the-bastion-host[bastion must be enabled]
 * link:#enabling-instance_principal-on-the-operator-host[operator instance_principal must be enabled]
-
 * use_cluster_encryption must be set to _true_
 * cluster_kms_key_id must be provided
+* create_policies should be set to _true_ if policies for cluster access to KMS are not already in place
 
 If you wish to use {uri-oci-kms}[OCI KMS] to encrypt OKE nodepool boot/block volume, the following is required:
 

--- a/docs/terraformoptions.adoc
+++ b/docs/terraformoptions.adoc
@@ -616,6 +616,7 @@ EOT
 |true/false
 |false
 
+<<<<<<< HEAD
 |cluster_kms_key_id
 |The id of the OCI KMS key to be used as the master encryption key for encrypting Kubernetes' etcd . *Required* if _use_cluster_encryption_ is set to *true*
 
@@ -638,6 +639,17 @@ EOT
 |Whether to encrypt data in transit between the instance, the boot volume, and the block volumes.
 |true/false
 |false
+=======
+|kms_key_id
+|The id of the OCI KMS key to be used as the master encryption key for Kubernetes secrets encryption.. *Required* if _use_encryption_ is set to *true*
+|`ocid1.key.oc1....`
+|
+
+|create_policies
+|Whether to create dynamic group for cluster with policies to access {uri-oci-kms}[OCI KMS] when using encryption.
+|true/false
+|true
+>>>>>>> create_policies  > review feedback (#325)
 
 |`use_signed_images`
 |Whether to enforce the use of signed images. If set to true, at least 1 RSA key must be provided through image_signing_keys.

--- a/docs/terraformoptions.adoc
+++ b/docs/terraformoptions.adoc
@@ -31,7 +31,7 @@ Ensure you review the {uri-terraform-dependencies}[dependencies].
 
 == OCI Provider parameters
 
-[stripes=odd,cols="1m,4d,2m,2m", options=header,width="100%"] 
+[stripes=odd,cols="1m,4d,2m,2m", options=header,width="100%"]
 |===
 |Parameter
 |Description
@@ -88,7 +88,7 @@ region = "ap-sydney-1"
 
 == General OCI
 
-[stripes=odd,cols="1m,4d,2m,2m", options=header,width="100%"] 
+[stripes=odd,cols="1m,4d,2m,2m", options=header,width="100%"]
 |===
 |Parameter
 |Description
@@ -109,7 +109,7 @@ region = "ap-sydney-1"
 
 == SSH Keys
 
-[stripes=odd,cols="1m,4d,2m,2m", options=header,width="100%"] 
+[stripes=odd,cols="1m,4d,2m,2m", options=header,width="100%"]
 |===
 |Parameter
 |Description
@@ -146,7 +146,7 @@ EOT
 
 == OCI Networking
 
-[stripes=odd,cols="1m,4d,2m,2m", options=header,width="100%"] 
+[stripes=odd,cols="1m,4d,2m,2m", options=header,width="100%"]
 |===
 |Parameter
 |Description
@@ -171,10 +171,10 @@ EOT
 |internet_gateway_route_rules
 |(Updatable) List of routing rules to add to Internet Gateway Route Table.
 |
-[ 
+[
   {
     destination       = "192.168.0.0/16"
-    destination_type  = "CIDR_BLOCK"     
+    destination_type  = "CIDR_BLOCK"
     network_entity_id = "drg"
     description       = "Terraformed"
   },
@@ -184,7 +184,7 @@ EOT
 |local_peering_gateways
 |Map of Local Peering Gateways to attach to the VCN.
 |
-    to_spoke2 = { 
+    to_spoke2 = {
       route_table_id = ""
       peer_id        = ""
     }
@@ -198,10 +198,10 @@ EOT
 |nat_gateway_route_rules
 |(Updatable) List of routing rules to add to Internet Gateway Route Table.
 |
-[ 
+[
   {
     destination       = "192.168.0.0/16"
-    destination_type  = "CIDR_BLOCK"     
+    destination_type  = "CIDR_BLOCK"
     network_entity_id = "drg"
     description       = "Terraformed"
   },
@@ -254,7 +254,7 @@ EOT
 
 == Bastion Host
 
-[stripes=odd,cols="1m,4d,2m,2m", options=header,width="100%"] 
+[stripes=odd,cols="1m,4d,2m,2m", options=header,width="100%"]
 |===
 |Parameter
 |Description
@@ -334,7 +334,7 @@ EOT
 
 == OCI Bastion Service
 
-[stripes=odd,cols="1m,4d,2m,2m", options=header,width="100%"] 
+[stripes=odd,cols="1m,4d,2m,2m", options=header,width="100%"]
 |===
 |Parameter
 |Description
@@ -364,7 +364,7 @@ EOT
 
 == Operator Host
 
-[stripes=odd,cols="1m,4d,2m,2m", options=header,width="100%"] 
+[stripes=odd,cols="1m,4d,2m,2m", options=header,width="100%"]
 |===
 |Parameter
 |Description
@@ -451,7 +451,7 @@ EOT
 
 == Availability Domain
 
-[stripes=odd,cols="1m,4d,2m,2m", options=header,width="100%"] 
+[stripes=odd,cols="1m,4d,2m,2m", options=header,width="100%"]
 |===
 |Parameter
 |Description
@@ -475,7 +475,7 @@ EOT
 
 == Tagging
 
-[stripes=odd,cols="1m,4d,2m,2m", options=header,width="100%"] 
+[stripes=odd,cols="1m,4d,2m,2m", options=header,width="100%"]
 |===
 |Parameter
 |Description
@@ -528,7 +528,7 @@ EOT
 
 == OKE
 
-[stripes=odd,cols="1m,4d,2m,2m", options=header,width="100%"] 
+[stripes=odd,cols="1m,4d,2m,2m", options=header,width="100%"]
 |===
 |Parameter
 |Description
@@ -604,7 +604,7 @@ EOT
 
 == KMS integration
 
-[stripes=odd,cols="1m,4d,2m,2m", options=header,width="100%"] 
+[stripes=odd,cols="1m,4d,2m,2m", options=header,width="100%"]
 |===
 |Parameter
 |Description
@@ -616,7 +616,6 @@ EOT
 |true/false
 |false
 
-<<<<<<< HEAD
 |cluster_kms_key_id
 |The id of the OCI KMS key to be used as the master encryption key for encrypting Kubernetes' etcd . *Required* if _use_cluster_encryption_ is set to *true*
 
@@ -639,17 +638,6 @@ EOT
 |Whether to encrypt data in transit between the instance, the boot volume, and the block volumes.
 |true/false
 |false
-=======
-|kms_key_id
-|The id of the OCI KMS key to be used as the master encryption key for Kubernetes secrets encryption.. *Required* if _use_encryption_ is set to *true*
-|`ocid1.key.oc1....`
-|
-
-|create_policies
-|Whether to create dynamic group for cluster with policies to access {uri-oci-kms}[OCI KMS] when using encryption.
-|true/false
-|true
->>>>>>> create_policies  > review feedback (#325)
 
 |`use_signed_images`
 |Whether to enforce the use of signed images. If set to true, at least 1 RSA key must be provided through image_signing_keys.
@@ -657,7 +645,7 @@ EOT
 |false
 
 |`image_signing_keys`
-|A list of KMS key ids used by the worker nodes to verify signed images. The keys must use RSA algorithm. *Required* if _use_signed_images_ is set to *true* 
+|A list of KMS key ids used by the worker nodes to verify signed images. The keys must use RSA algorithm. *Required* if _use_signed_images_ is set to *true*
 |
 `["ocid1.key.oc1....", "ocid1.key.oc1...."]`
 |[]
@@ -665,7 +653,7 @@ EOT
 
 == Node pools
 
-[stripes=odd,cols="1m,4d,2m,2m", options=header,width="100%"] 
+[stripes=odd,cols="1m,4d,2m,2m", options=header,width="100%"]
 |===
 |Parameter
 |Description
@@ -686,8 +674,8 @@ Refer to {uri-topology}[topology] for more thorough examples.
 node_pools = {
 np1 = { shape = "VM.Standard.E4.Flex", ocpus = 1, memory = 16, node_pool_size = 1, boot_volume_size = 150, label = { app = "frontend", pool = "np1" } }
   np2 = {shape="VM.Standard.E2.2",node_pool_size=2,boot_volume_size=150,label={app="application",name="test"}}
-  np3 = {shape="VM.Standard.E2.2",node_pool_size=1} 
-} 
+  np3 = {shape="VM.Standard.E2.2",node_pool_size=1}
+}
 |
 node_pools = {
   np1 = {shape="VM.Standard.E3.Flex",ocpus=2,node_pool_size=2,boot_volume_size=150}
@@ -729,7 +717,7 @@ node_pools = {
 
 == File Storage
 
-[stripes=odd,cols="1m,4d,2m,2m", options=header,width="100%"] 
+[stripes=odd,cols="1m,4d,2m,2m", options=header,width="100%"]
 |===
 |Parameter
 |Description
@@ -760,7 +748,7 @@ node_pools = {
 
 == Upgrade cluster
 
-[stripes=odd,cols="1m,4d,2m,2m", options=header,width="100%"] 
+[stripes=odd,cols="1m,4d,2m,2m", options=header,width="100%"]
 |===
 |Parameter
 |Description
@@ -791,7 +779,7 @@ node_pools = {
 
 == OKE Load Balancers
 
-[stripes=odd,cols="1m,4d,2m,2m", options=header,width="100%"] 
+[stripes=odd,cols="1m,4d,2m,2m", options=header,width="100%"]
 |===
 |Parameter
 |Description
@@ -799,7 +787,7 @@ node_pools = {
 |Default
 
 |load_balancers
-|The type of load balancer subnets to create. 
+|The type of load balancer subnets to create.
 
 Even if you set the load balancer subnets to be internal, you still need to set the correct {uri-oci-loadbalancer-annotations}[annotations] when creating internal load balancers. Just setting this value to internal is *_not_* sufficient.
 
@@ -841,7 +829,7 @@ Refer to {uri-topology}[topology] for more thorough examples.
 
 == OCIR
 
-[stripes=odd,cols="1m,4d,2m,2m", options=header,width="100%"] 
+[stripes=odd,cols="1m,4d,2m,2m", options=header,width="100%"]
 |===
 |Parameter
 |Description
@@ -877,7 +865,7 @@ Refer to {uri-topology}[topology] for more thorough examples.
 
 == Calico
 
-[stripes=odd,cols="1m,4d,2m,2m", options=header,width="100%"] 
+[stripes=odd,cols="1m,4d,2m,2m", options=header,width="100%"]
 |===
 |Parameter
 |Description
@@ -898,7 +886,7 @@ Refer to {uri-topology}[topology] for more thorough examples.
 
 == Kubernetes Metrics Server
 
-[stripes=odd,cols="1m,4d,2m,2m", options=header,width="100%"] 
+[stripes=odd,cols="1m,4d,2m,2m", options=header,width="100%"]
 |===
 |Parameter
 |Description
@@ -924,7 +912,7 @@ Refer to {uri-topology}[topology] for more thorough examples.
 
 == Gatekeeper
 
-[stripes=odd,cols="1m,4d,2m,2m", options=header,width="100%"] 
+[stripes=odd,cols="1m,4d,2m,2m", options=header,width="100%"]
 |===
 |Parameter
 |Description
@@ -945,7 +933,7 @@ Refer to {uri-topology}[topology] for more thorough examples.
 
 == Service Account
 
-[stripes=odd,cols="1m,4d,2m,2m", options=header,width="100%"] 
+[stripes=odd,cols="1m,4d,2m,2m", options=header,width="100%"]
 |===
 |Parameter
 |Description

--- a/docs/terraformoptions.adoc
+++ b/docs/terraformoptions.adoc
@@ -618,8 +618,11 @@ EOT
 
 |cluster_kms_key_id
 |The id of the OCI KMS key to be used as the master encryption key for encrypting Kubernetes' etcd . *Required* if _use_cluster_encryption_ is set to *true*
-|`ocid1.key.oc1....`
-|
+
+|create_policies
+|Whether to create dynamic group for cluster with policies to access {uri-oci-kms}[OCI KMS] when using encryption.
+|true/false
+|true
 
 |use_node_pool_volume_encryption
 |Whether to use {uri-oci-kms}[OCI KMS] to encrypt Kubernetes Nodepool's boot/block volume.

--- a/main.tf
+++ b/main.tf
@@ -227,10 +227,10 @@ module "oke" {
   vcn_id                                                  = module.vcn.vcn_id
   use_cluster_encryption                                  = var.use_cluster_encryption
   cluster_kms_key_id                                      = var.cluster_kms_key_id
+  create_policies                                         = var.create_policies
   use_signed_images                                       = var.use_signed_images
   image_signing_keys                                      = var.image_signing_keys
   admission_controller_options                            = var.admission_controller_options
-  create_policies                                         = var.create_policies
 
   # oke node pool parameters
   node_pools                      = var.node_pools
@@ -330,6 +330,7 @@ module "extensions" {
   use_cluster_encryption       = var.use_cluster_encryption
   cluster_kms_key_id           = var.cluster_kms_key_id
   cluster_kms_dynamic_group_id = module.oke.cluster_kms_dynamic_group_id
+  create_policies      = var.create_policies
 
   # ocir parameters
   email_address    = var.email_address

--- a/main.tf
+++ b/main.tf
@@ -64,7 +64,7 @@ module "bastion" {
   upgrade_bastion     = var.upgrade_bastion
 
   # bastion notification
-  enable_bastion_notification   = var.enable_bastion_notification
+  enable_bastion_notification   = var.enable_bastion_notification && var.create_policies
   bastion_notification_endpoint = var.bastion_notification_endpoint
   bastion_notification_protocol = var.bastion_notification_protocol
   bastion_notification_topic    = var.bastion_notification_topic
@@ -102,7 +102,7 @@ module "operator" {
 
   # operator host parameters
   operator_image_id                  = var.operator_image_id
-  enable_operator_instance_principal = var.enable_operator_instance_principal
+  enable_operator_instance_principal = var.enable_operator_instance_principal && var.create_policies
   enable_pv_encryption_in_transit    = var.enable_operator_pv_encryption_in_transit
   operator_os_version                = var.operator_os_version
   operator_shape                     = var.operator_shape

--- a/main.tf
+++ b/main.tf
@@ -230,6 +230,7 @@ module "oke" {
   use_signed_images                                       = var.use_signed_images
   image_signing_keys                                      = var.image_signing_keys
   admission_controller_options                            = var.admission_controller_options
+  create_policies                                         = var.create_policies
 
   # oke node pool parameters
   node_pools                      = var.node_pools

--- a/modules/extensions/iam.tf
+++ b/modules/extensions/iam.tf
@@ -19,7 +19,7 @@ resource "oci_identity_policy" "operator_instance_principal_dynamic_group" {
   description    = "policy to allow operator host to manage dynamic group"
   name           = var.label_prefix == "none" ? "operator-instance-principal-dynamic-group-${substr(uuid(), 0, 8)}" : "${var.label_prefix}-operator-instance-principal-dynamic-group-${substr(uuid(), 0, 8)}"
   statements     = ["Allow dynamic-group ${var.operator_dynamic_group} to use dynamic-groups in tenancy"]
-  count          = (var.use_cluster_encryption == true && var.create_bastion_host == true && var.enable_operator_instance_principal == true) ? 1 : 0
+  count          = (var.use_cluster_encryption == true && var.create_policies == true && var.create_bastion_host == true && var.enable_operator_instance_principal == true) ? 1 : 0
 }
 
 # 30s delay to allow policies to take effect globally
@@ -58,5 +58,5 @@ resource "null_resource" "update_dynamic_group" {
     ]
   }
 
-  count = (var.use_cluster_encryption == true && var.create_bastion_host == true && var.bastion_state == "RUNNING" && var.enable_operator_instance_principal == true) ? 1 : 0
+  count = (var.use_cluster_encryption == true && var.create_policies == true && var.create_bastion_host == true && var.bastion_state == "RUNNING" && var.enable_operator_instance_principal == true) ? 1 : 0
 }

--- a/modules/extensions/variables.tf
+++ b/modules/extensions/variables.tf
@@ -64,8 +64,6 @@ variable "cluster_kms_key_id" {}
 variable "cluster_kms_dynamic_group_id" {}
 
 variable "create_policies" {
-  description = "Whether to create OIM policies"
-  default     = true
   type        = bool
 }
 

--- a/modules/extensions/variables.tf
+++ b/modules/extensions/variables.tf
@@ -60,7 +60,15 @@ variable "use_cluster_encryption" {
 
 variable "cluster_kms_key_id" {}
 
+
 variable "cluster_kms_dynamic_group_id" {}
+
+variable "create_policies" {
+  description = "Whether to create OIM policies"
+  default     = true
+  type        = bool
+}
+
 # ocir
 variable "email_address" {}
 

--- a/modules/oke/iam.tf
+++ b/modules/oke/iam.tf
@@ -19,7 +19,7 @@ resource "oci_identity_dynamic_group" "oke_kms_cluster" {
   description    = "dynamic group to allow cluster to use KMS to encrypt etcd"
   matching_rule  = local.dynamic_group_rule_all_clusters
   name           = var.label_prefix == "none" ? "oke-kms-cluster" : "${var.label_prefix}-oke-kms-cluster"
-  count          = var.use_cluster_encryption == true ? 1 : 0
+  count          = var.use_cluster_encryption == true && var.create_policies == true ? 1 : 0
 
   lifecycle {
     ignore_changes = [matching_rule]
@@ -33,7 +33,7 @@ resource "oci_identity_policy" "oke_kms" {
   depends_on     = [oci_identity_dynamic_group.oke_kms_cluster]
   name           = var.label_prefix == "none" ? "oke-kms" : "${var.label_prefix}-oke-kms"
   statements     = [local.cluster_kms_policy_statement]
-  count          = var.use_cluster_encryption == true ? 1 : 0
+  count          = var.use_cluster_encryption == true && var.create_policies == true ? 1 : 0
 }
 
 resource "oci_identity_policy" "oke_volume_kms" {
@@ -42,5 +42,5 @@ resource "oci_identity_policy" "oke_volume_kms" {
   description    = "Policies for block volumes to access kms key"
   name           = var.label_prefix == "none" ? "oke-volume-kms" : "${var.label_prefix}-oke-volume-kms"
   statements     = local.oke_volume_kms_policy_statements
-  count          = var.use_node_pool_volume_encryption == true ? 1 : 0
+  count          = var.use_node_pool_volume_encryption == true && var.create_policies == true ? 1 : 0
 }

--- a/modules/oke/locals.tf
+++ b/modules/oke/locals.tf
@@ -15,10 +15,10 @@ locals {
   dynamic_group_rule_all_clusters = "ALL {resource.type = 'cluster', resource.compartment.id = '${var.compartment_id}'}"
 
   # policy to allow dynamic group of all clusters to use kms 
-  cluster_kms_policy_statement = (var.use_cluster_encryption == true) ? "Allow dynamic-group ${oci_identity_dynamic_group.oke_kms_cluster[0].name} to use keys in compartment id ${var.compartment_id} where target.key.id = '${var.cluster_kms_key_id}'" : ""
+  cluster_kms_policy_statement = (var.use_cluster_encryption == true && var.create_policies) ? "Allow dynamic-group ${oci_identity_dynamic_group.oke_kms_cluster[0].name} to use keys in compartment id ${var.compartment_id} where target.key.id = '${var.cluster_kms_key_id}'" : ""
 
   # policy to allow block volumes inside oke to use kms
-  oke_volume_kms_policy_statements = (var.use_node_pool_volume_encryption == true) ? [
+  oke_volume_kms_policy_statements = (var.use_node_pool_volume_encryption == true && var.create_policies) ? [
     "Allow service oke to use key-delegates in compartment id ${var.compartment_id} where target.key.id = '${var.node_pool_volume_kms_key_id}'",
     "Allow service blockstorage to use keys in compartment id ${var.compartment_id} where target.key.id = '${var.node_pool_volume_kms_key_id}'"
   ] : []

--- a/modules/oke/outputs.tf
+++ b/modules/oke/outputs.tf
@@ -6,7 +6,7 @@ output "cluster_id" {
 }
 
 output "cluster_kms_dynamic_group_id" {
-  value = var.use_cluster_encryption == true ? oci_identity_dynamic_group.oke_kms_cluster[0].id : "null"
+  value = var.use_cluster_encryption == true && var.create_policies ? oci_identity_dynamic_group.oke_kms_cluster[0].id : "null"
 }
 
 output "nodepool_ids" {

--- a/modules/oke/variables.tf
+++ b/modules/oke/variables.tf
@@ -94,3 +94,9 @@ variable "worker_nsgs" {
 variable "freeform_tags" {
   type = map(any)
 }
+
+variable "create_policies" {
+  description = "whether to create dynamic group for KMS access when using encryption"
+  default     = true
+  type        = bool
+}

--- a/modules/oke/variables.tf
+++ b/modules/oke/variables.tf
@@ -57,6 +57,12 @@ variable "enable_pv_encryption_in_transit" {
   type = bool
 }
 
+variable "create_policies" {
+  description = "Whether to create dynamic group for KMS access when using encryption"
+  default     = true
+  type        = bool
+}
+
 # signed images
 variable "use_signed_images" {
   type = bool

--- a/modules/oke/variables.tf
+++ b/modules/oke/variables.tf
@@ -58,8 +58,6 @@ variable "enable_pv_encryption_in_transit" {
 }
 
 variable "create_policies" {
-  description = "Whether to create dynamic group for KMS access when using encryption"
-  default     = true
   type        = bool
 }
 
@@ -99,10 +97,4 @@ variable "worker_nsgs" {
 
 variable "freeform_tags" {
   type = map(any)
-}
-
-variable "create_policies" {
-  description = "whether to create dynamic group for KMS access when using encryption"
-  default     = true
-  type        = bool
 }

--- a/terraform.tfvars.example
+++ b/terraform.tfvars.example
@@ -142,7 +142,7 @@ services_cidr                = "10.96.0.0/16"
 
 ## oke cluster kms integration
 use_encryption  = false
-kms_key_id      = ""
+cluster_kms_key_id      = ""
 create_policies = true
 
 ## oke cluster container image policy and keys

--- a/terraform.tfvars.example
+++ b/terraform.tfvars.example
@@ -141,12 +141,9 @@ pods_cidr                    = "10.244.0.0/16"
 services_cidr                = "10.96.0.0/16"
 
 ## oke cluster kms integration
-use_cluster_encryption = false
-cluster_kms_key_id     = ""
-
-### oke node pool volume kms integration
-use_node_pool_volume_encryption = false
-node_pool_volume_kms_key_id     = ""
+use_encryption  = false
+kms_key_id      = ""
+create_policies = true
 
 ## oke cluster container image policy and keys
 use_signed_images = false

--- a/variables.tf
+++ b/variables.tf
@@ -479,7 +479,7 @@ variable "services_cidr" {
 
 ## oke cluster kms integration
 variable "create_policies" {
-  description = "Whether to create dynamic group for cluster with policies to access KMS when using encryption"
+  description = "Whether to create OCI IAM policies for KMS or dynamic groups."
   default     = true
   type        = bool
 }
@@ -635,8 +635,8 @@ variable "load_balancers" {
 }
 
 variable "preferred_load_balancer" {
-  # values: public, internal. 
-  # When creating an internal load balancer, the internal annotation must still be specified regardless 
+  # values: public, internal.
+  # When creating an internal load balancer, the internal annotation must still be specified regardless
   default     = "public"
   description = "The preferred load balancer subnets that OKE will automatically choose when creating a load balancer. valid values are public or internal. if 'public' is chosen, the value for load_balancers must be either 'public' or 'both'. If 'private' is chosen, the value for load_balancers must be either 'internal' or 'both'."
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -478,6 +478,11 @@ variable "services_cidr" {
 }
 
 ## oke cluster kms integration
+variable "create_policies" {
+  description = "Whether to create dynamic group for cluster with policies to access KMS when using encryption"
+  default     = true
+  type        = bool
+}
 
 variable "use_cluster_encryption" {
   description = "Whether to use OCI KMS to encrypt Kubernetes secrets."


### PR DESCRIPTION
- revived create_policies variable
- if create_policies is false - no OIM changes will be done. Neither dynamic group nor policies/
- This is very useful when OIM is managed by another team and you don't have rights to change or query it.