### PR TITLE
fix: File provisioner path ~ changed to /home/opc

### DIFF
--- a/examples/verrazzano/verrazzano.tf
+++ b/examples/verrazzano/verrazzano.tf
@@ -18,12 +18,12 @@ resource "null_resource" "install_verrazzano" {
 
   provisioner "file" {
     content     = local.install_verrazzano_operator_template
-    destination = "~/install_verrazzano_operator"
+    destination = "/home/opc/install_verrazzano_operator"
   }
 
   provisioner "file" {
     content     = local.install_verrazzano_template
-    destination = "~/install_verrazzano"
+    destination = "/home/opc/install_verrazzano"
   }
 
   provisioner "remote-exec" {

--- a/modules/extensions/activeworker.tf
+++ b/modules/extensions/activeworker.tf
@@ -22,7 +22,7 @@ resource "null_resource" "check_worker_active" {
 
   provisioner "file" {
     content     = local.check_active_worker_template
-    destination = "~/check_active_worker.sh"
+    destination = "/home/opc/check_active_worker.sh"
   }
 
   provisioner "remote-exec" {

--- a/modules/extensions/calico.tf
+++ b/modules/extensions/calico.tf
@@ -18,14 +18,14 @@ resource "null_resource" "install_calico" {
 
   provisioner "file" {
     content     = local.install_calico_template
-    destination = "/home/opc/install_sh"
+    destination = "/home/opc/install_calico.sh"
   }
 
   provisioner "remote-exec" {
     inline = [
-      "chmod +x $HOME/install_sh",
-      "$HOME/install_sh",
-      # "rm -f $HOME/install_sh"
+      "chmod +x $HOME/install_calico.sh",
+      "$HOME/install_calico.sh",
+      "rm -f $HOME/install_calico.sh"
     ]
   }
 

--- a/modules/extensions/calico.tf
+++ b/modules/extensions/calico.tf
@@ -18,7 +18,7 @@ resource "null_resource" "install_calico" {
 
   provisioner "file" {
     content     = local.install_calico_template
-    destination = "~/install_sh"
+    destination = "/home/opc/install_sh"
   }
 
   provisioner "remote-exec" {

--- a/modules/extensions/drain.tf
+++ b/modules/extensions/drain.tf
@@ -16,12 +16,12 @@ resource "null_resource" "drain_nodes" {
 
   provisioner "file" {
     content     = local.drain_list_template
-    destination = "~/drainlist.py"
+    destination = "/home/opc/drainlist.py"
   }
 
   provisioner "file" {
     content     = local.drain_template
-    destination = "~/drain.sh"
+    destination = "/home/opc/drain.sh"
   }
 
   provisioner "remote-exec" {

--- a/modules/extensions/gatekeeper.tf
+++ b/modules/extensions/gatekeeper.tf
@@ -18,7 +18,7 @@ resource "null_resource" "enable_gatekeeper" {
 
   provisioner "file" {
     content     = local.gatekeeper_template
-    destination = "~/enable_gatekeeper.sh"
+    destination = "/home/opc/enable_gatekeeper.sh"
   }
 
   provisioner "remote-exec" {

--- a/modules/extensions/iam.tf
+++ b/modules/extensions/iam.tf
@@ -46,7 +46,7 @@ resource "null_resource" "update_dynamic_group" {
 
   provisioner "file" {
     content     = local.update_dynamic_group_template
-    destination = "~/update_dynamic_group.sh"
+    destination = "/home/opc/update_dynamic_group.sh"
   }
 
   provisioner "remote-exec" {

--- a/modules/extensions/k8stools.tf
+++ b/modules/extensions/k8stools.tf
@@ -16,7 +16,7 @@ resource "null_resource" "install_kubectl_on_operator" {
 
   provisioner "file" {
     content     = local.install_kubectl_template
-    destination = "~/install_kubectl.sh"
+    destination = "/home/opc/install_kubectl.sh"
   }
 
   provisioner "remote-exec" {
@@ -48,7 +48,7 @@ resource "null_resource" "install_helm_on_operator" {
 
   provisioner "file" {
     content     = local.install_helm_template
-    destination = "~/install_helm.sh"
+    destination = "/home/opc/install_helm.sh"
   }
 
   provisioner "remote-exec" {

--- a/modules/extensions/kubeconfig.tf
+++ b/modules/extensions/kubeconfig.tf
@@ -43,17 +43,17 @@ resource "null_resource" "write_kubeconfig_on_operator" {
 
   provisioner "file" {
     content     = local.generate_kubeconfig_template
-    destination = "~/generate_kubeconfig.sh"
+    destination = "/home/opc/generate_kubeconfig.sh"
   }
 
   provisioner "file" {
     content     = local.token_helper_template
-    destination = "~/token_helper.sh"
+    destination = "/home/opc/token_helper.sh"
   }
 
   provisioner "file" {
     content     = local.set_credentials_template
-    destination = "~/kubeconfig_set_credentials.sh"
+    destination = "/home/opc/kubeconfig_set_credentials.sh"
   }
 
   provisioner "remote-exec" {

--- a/modules/extensions/metricserver.tf
+++ b/modules/extensions/metricserver.tf
@@ -18,7 +18,7 @@ resource "null_resource" "enable_metric_server" {
 
   provisioner "file" {
     content     = local.metric_server_template
-    destination = "~/enable_metric_server.sh"
+    destination = "/home/opc/enable_metric_server.sh"
   }
 
   provisioner "remote-exec" {

--- a/modules/extensions/secrets.tf
+++ b/modules/extensions/secrets.tf
@@ -21,7 +21,7 @@ resource "null_resource" "secret" {
 
   provisioner "file" {
     content     = local.secret_template
-    destination = "~/secret.sh"
+    destination = "/home/opc/secret.sh"
   }
 
   provisioner "remote-exec" {

--- a/modules/extensions/serviceaccount.tf
+++ b/modules/extensions/serviceaccount.tf
@@ -17,8 +17,8 @@ resource "null_resource" "create_service_account" {
   depends_on = [null_resource.install_kubectl_on_operator, null_resource.write_kubeconfig_on_operator]
 
   provisioner "file" {
-    content = local.create_service_account_template
-    destination = "~/create_service_account.sh"
+    content     = local.create_service_account_template
+    destination = "/home/opc/create_service_account.sh"
   }
 
   provisioner "remote-exec" {


### PR DESCRIPTION
Closes #447 
Terraform file provisioner accept only absolute path . Changed path ~ to /home/opc  in all provisioner file in extensions module since its not working in terraform latest version .