### PR TITLE
fix: fixed empty policy issue and added oke-tags to freeform_tags in terraform.tfvars.example

### DIFF
--- a/docs/configuration.adoc
+++ b/docs/configuration.adoc
@@ -261,7 +261,7 @@ OKE Variables:-
 ----
 use_encryption = true
 kms_key_id = <kms_key_id>
-enable_pv_encryption_in_transit = false
+use_node_pool_volume_encryption = true
 node_pool_volume_kms_key_id = <node_pool_volume_kms_key_id>
 ----
 

--- a/docs/instructions.adoc
+++ b/docs/instructions.adoc
@@ -74,11 +74,12 @@ If you wish to use {uri-oci-kms}[OCI KMS] to encrypt Kubernetes secrets, the fol
 * link:#adding-the-bastion-host[bastion must be enabled]
 * link:#enabling-instance_principal-on-the-operator-host[operator instance_principal must be enabled]
 
-use_encryption must be set to _true_
-kms_key_id must be provided
+* use_encryption must be set to _true_
+* kms_key_id must be provided
 
 If you wish to use {uri-oci-kms}[OCI KMS] to encrypt OKE nodepool boot/block volume, the following is required:
 
+* use_node_pool_volume_encryption must be set to true
 * node_pool_volume_kms_key_id must be provided
 
 If you wish to encrypt data in transit between the instance, the boot volume, and the block volumes in OKE node pool.

--- a/docs/terraformoptions.adoc
+++ b/docs/terraformoptions.adoc
@@ -621,8 +621,8 @@ EOT
 |`ocid1.key.oc1....`
 |
 
-|enable_pv_encryption_in_transit
-|Whether to encrypt data in transit between the instance, the boot volume, and the block volumes.
+|use_node_pool_volume_encryption
+|Whether to use {uri-oci-kms}[OCI KMS] to encrypt Kubernetes Nodepool's boot/block volume.
 |true/false
 |false
 
@@ -630,6 +630,11 @@ EOT
 |The id of the OCI KMS key to be used as the master encryption key for nodepools boot volume/block volume encryption..
 |`ocid1.key.oc1....`
 |
+
+|enable_pv_encryption_in_transit
+|Whether to encrypt data in transit between the instance, the boot volume, and the block volumes.
+|true/false
+|false
 
 |`use_signed_images`
 |Whether to enforce the use of signed images. If set to true, at least 1 RSA key must be provided through image_signing_keys.

--- a/main.tf
+++ b/main.tf
@@ -234,6 +234,7 @@ module "oke" {
   node_pool_os                        = var.node_pool_os
   node_pool_os_version                = var.node_pool_os_version
   enable_pv_encryption_in_transit     = var.enable_pv_encryption_in_transit
+  use_node_pool_volume_encryption      = var.use_node_pool_volume_encryption
   node_pool_volume_kms_key_id         = var.node_pool_volume_kms_key_id
 
   # oke load balancer parameters

--- a/modules/oke/iam.tf
+++ b/modules/oke/iam.tf
@@ -41,4 +41,5 @@ resource "oci_identity_policy" "oke_volume_kms" {
   description    = "Policies for block volumes to access kms key"
   name           = var.label_prefix == "none" ? "oke-volume-kms" : "${var.label_prefix}-oke-volume-kms"
   statements     = local.oke_volume_kms_policy_statements
+  count          = var.use_node_pool_volume_encryption == true ? 1 : 0
 }

--- a/modules/oke/locals.tf
+++ b/modules/oke/locals.tf
@@ -18,10 +18,10 @@ locals {
   policy_statement = (var.use_encryption == true) ? "Allow dynamic-group ${oci_identity_dynamic_group.oke_kms_cluster[0].name} to use keys in compartment id ${var.compartment_id} where target.key.id = '${var.kms_key_id}'" : ""
 
   # policy to allow block volumes inside oke to use kms
-  oke_volume_kms_policy_statements = (var.node_pool_volume_kms_key_id == "") ? []: [
+  oke_volume_kms_policy_statements = (var.use_node_pool_volume_encryption == true) ? [
     "Allow service oke to use key-delegates in compartment id ${var.compartment_id} where target.key.id = '${var.node_pool_volume_kms_key_id}'",
     "Allow service blockstorage to use keys in compartment id ${var.compartment_id} where target.key.id = '${var.node_pool_volume_kms_key_id}'"
-  ]
+  ]: []
 
   # 1. get a list of available images for this cluster
   # 2. filter by version

--- a/modules/oke/variables.tf
+++ b/modules/oke/variables.tf
@@ -47,11 +47,15 @@ variable "use_encryption" {
 
 variable "kms_key_id" {}
 
-variable "enable_pv_encryption_in_transit" {
+variable "use_node_pool_volume_encryption" {
   type = bool
 }
 
 variable "node_pool_volume_kms_key_id" {}
+
+variable "enable_pv_encryption_in_transit" {
+  type = bool
+}
 
 # signed images
 variable "use_signed_images" {

--- a/terraform.tfvars.example
+++ b/terraform.tfvars.example
@@ -130,7 +130,7 @@ allow_node_port_access       = false
 allow_worker_internet_access = true
 allow_worker_ssh_access      = false
 cluster_name                 = "oke"
-control_plane_type         = "private"
+control_plane_type           = "private"
 control_plane_allowed_cidrs  = ["0.0.0.0/0"]
 control_plane_nsgs           = []
 dashboard_enabled            = false
@@ -143,8 +143,8 @@ use_encryption = false
 kms_key_id     = ""
 
 ### oke node pool volume kms integration
-enable_pv_encryption_in_transit = false
-node_pool_volume_kms_key_id = ""
+use_node_pool_volume_encryption = false
+node_pool_volume_kms_key_id     = ""
 
 ## oke cluster container image policy and keys
 use_signed_images = false
@@ -152,6 +152,7 @@ image_signing_keys = []
 
 # node pools
 check_node_active = "all"
+enable_pv_encryption_in_transit = false
 node_pools = {
   np1 = { shape = "VM.Standard.E4.Flex", ocpus = 1, memory = 16, node_pool_size = 1, boot_volume_size = 150, label = { app = "frontend", pool = "np1" } }
   np2 = { shape = "VM.Standard.E4.Flex", ocpus = 1, memory = 16, node_pool_size = 1, boot_volume_size = 150, label = { app = "frontend", pool = "np2" } }
@@ -233,6 +234,12 @@ freeform_tags = {
     environment = "dev",
     role        = "operator",
     security    = "high"
+  }
+  oke = {
+    service_lb  = {
+      environment = "dev"
+      role        = "load balancer"
+    }
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -489,8 +489,8 @@ variable "kms_key_id" {
   type        = string
 }
 
-variable "enable_pv_encryption_in_transit" {
-  description = "Whether to enable in-transit encryption for the data volume's paravirtualized attachment. This field applies to both block volumes and boot volumes. The default value is false"
+variable "use_node_pool_volume_encryption" {
+  description = "Whether to use OCI KMS to encrypt Kubernetes Nodepool's boot/block volume."
   type        = bool
   default     = false
 }
@@ -524,6 +524,12 @@ variable "check_node_active" {
     condition     = contains(["none", "one", "all"], var.check_node_active)
     error_message = "Accepted values are none, one or all."
   }
+}
+
+variable "enable_pv_encryption_in_transit" {
+  description = "Whether to enable in-transit encryption for the data volume's paravirtualized attachment. This field applies to both block volumes and boot volumes. The default value is false"
+  type        = bool
+  default     = false
 }
 
 variable "node_pools" {


### PR DESCRIPTION
Fixed empty policy bug by adding new use_node_pool_volume_encryption variable
added oke-tags to freeform_tags in terraform.tfvars.example
Signed-off-by: Nikhil Kota <srinivasa.nikhil.kota@oracle.com>