### PR TITLE
WIP: fix: fixed operator 404 issue while using operator pool volume encryp…

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -127,7 +127,7 @@ module "operator" {
   }
 
   depends_on = [
-    module.vcn
+    module.vcn, module.oke
   ]
 
   count = var.create_operator == true ? 1 : 0


### PR DESCRIPTION
Made sure that operator is created after k8s cluster so that the following required policy is in place before operator is created
`Allow service blockstorage to use keys in compartment id ${var.compartment_id} where target.key.id = '${var.node_pool_volume_kms_key_id}'`

Signed-off-by: Deepak Koli <deepak.koli@oracle.com>