### PR TITLE
Added option to specify ADs in node pools

### DIFF
--- a/docs/terraformoptions.adoc
+++ b/docs/terraformoptions.adoc
@@ -739,14 +739,9 @@ Refer to {uri-topology}[topology] for more thorough examples.
 node_pools = {
 np1 = { shape = "VM.Standard.E4.Flex", ocpus = 1, memory = 16, node_pool_size = 1, boot_volume_size = 150, label = { app = "frontend", pool = "np1" } }
   np2 = {shape="VM.Standard.E2.2",node_pool_size=2,boot_volume_size=150,label={app="application",name="test"}}
-  np3 = {shape="VM.Standard.E2.2",node_pool_size=1}
-}
-|
-node_pools = {
-  np1 = {shape="VM.Standard.E3.Flex",ocpus=2,node_pool_size=2,boot_volume_size=150}
-  np2 = {shape="VM.Standard.E2.2",node_pool_size=2,boot_volume_size=150,label={app="application",name="test"}}
-  np3 = {shape="VM.Standard.E2.2",node_pool_size=1}
-}
+  np3 = {shape="VM.Standard.E2.2",node_pool_size=1,placement_ads=[1]} 
+} 
+|{}
 
 |node_pool_image_id
 |The OCID of custom image to use when provisioning worker nodes. When no OCID is specified, the worker nodes will use the node_pool_os and node_pool_os_version to identify an image to provision the worker nodes.

--- a/modules/oke/locals.tf
+++ b/modules/oke/locals.tf
@@ -6,10 +6,11 @@ locals {
   # used by cluster
   lb_subnet = var.preferred_load_balancer == "public" ? "pub_lb" : "int_lb"
 
-  ad_names = [
-    for ad_name in data.oci_identity_availability_domains.ad_list.availability_domains :
-    ad_name.name
-  ]
+  ad_number_to_name = {
+    for ad in data.oci_identity_availability_domains.ad_list.availability_domains :
+    parseint(substr(ad.name, -1, -1), 10) => ad.name
+  }
+  ad_numbers = keys(local.ad_number_to_name)
 
   # dynamic group all oke clusters in a compartment
   dynamic_group_rule_all_clusters = "ALL {resource.type = 'cluster', resource.compartment.id = '${var.compartment_id}'}"

--- a/modules/oke/nodepools.tf
+++ b/modules/oke/nodepools.tf
@@ -21,7 +21,8 @@ resource "oci_containerengine_node_pool" "nodepools" {
     # iterating over ADs
     dynamic "placement_configs" {
       iterator = ad_iterator
-      for_each = local.ad_names
+      for_each = [for n in lookup(each.value, "placement_ads", local.ad_numbers):
+                  local.ad_number_to_name[n]]
       content {
         availability_domain = ad_iterator.value
         subnet_id           = var.cluster_subnets["workers"]

--- a/terraform.tfvars.example
+++ b/terraform.tfvars.example
@@ -182,7 +182,7 @@ node_pools = {
   np1 = { shape = "VM.Standard.E4.Flex", ocpus = 1, memory = 16, node_pool_size = 1, boot_volume_size = 150, label = { app = "frontend", pool = "np1" } }
   np2 = { shape = "VM.Standard.E4.Flex", ocpus = 1, memory = 16, node_pool_size = 1, boot_volume_size = 150, label = { app = "frontend", pool = "np2" } }
   # np3 = { shape = "VM.Standard.E4.Flex", ocpus = 1, memory = 16, node_pool_size = 1, boot_volume_size = 150, label = { app = "frontend", pool = "np1" } }
-  # np4 = { shape = "VM.Standard.E4.Flex", ocpus = 1, memory = 16, node_pool_size = 1, boot_volume_size = 150, label = { app = "frontend", pool = "np1" } }
+  # np4 = { shape = "VM.Standard.E4.Flex", ocpus = 1, memory = 16, node_pool_size = 1, placement_ads = [1] }
   # np2 = {shape="VM.Standard.E4.Flex",ocpus=4,memory=16,node_pool_size=1,boot_volume_size=150, label={app="backend",pool="np2"}}
   # np3 = {shape="VM.Standard.A1.Flex",ocpus=8,memory=16,node_pool_size=1,boot_volume_size=150, label={pool="np3"}}
   # np4 = {shape="BM.Standard2.52",node_pool_size=1,boot_volume_size=150}


### PR DESCRIPTION
I haven't been able to test it yet, as I'm still working on getting a test environment up, but in the meantime the maintainers can tell if there are issues with the documentation or the commit message.

----
The `node_pools` argument gained a new optional key `placement_ADs`.
This key can be popolated by a list, like:
`placement_ADs = ["sQTi:EU-FRANKFURT-1-AD-1"]`
to choose the ADs the pool will deploy nodes to.
Default remains to deploy to all ADs of region.

Fixes: #515

Signed-off-by: Andrea Stacchiotti <andreastacchiotti@gmail.com>