### PR TITLE
fix: added lifecycle meta-argument on default security list 

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -3,7 +3,7 @@
 
 module "vcn" {
   source  = "oracle-terraform-modules/vcn/oci"
-  version = "3.5.0"
+  version = "3.5.1"
 
   # general oci parameters
   compartment_id = var.compartment_id


### PR DESCRIPTION
so it doesn't trigger a deletion and recreation of resources if out-of-band modifications are done to it. Closes #417

Signed-off-by: Ali Mukadam <ali.mukadam@oracle.com>