### PR TITLE
feat: adds a separate nodepool to run cluster autoscaling

### DIFF
--- a/docs/clusterautoscaler.adoc
+++ b/docs/clusterautoscaler.adoc
@@ -1,0 +1,310 @@
+= Using the Oracle Container Engine for Kubernetes Cluster Autoscaler
+:idprefix:
+:idseparator: -
+:sectlinks:
+:sectnums:
+:toc: auto
+
+
+:uri-repo: https://github.com/oracle-terraform-modules/terraform-oci-oke
+:uri-rel-file-base: link:{uri-repo}/blob/main
+:uri-rel-tree-base: link:{uri-repo}/tree/main
+:uri-docs: {uri-rel-file-base}/docs
+:uri-cluster-autoscaler-parameters: https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#what-are-the-parameters-to-ca
+:uri-instructions: {uri-docs}/instructions.adoc
+:uri-oci-keys: https://docs.cloud.oracle.com/iaas/Content/API/Concepts/apisigningkey.htm
+:uri-oci-ocids: https://docs.cloud.oracle.com/iaas/Content/API/Concepts/apisigningkey.htm#five
+:uri-oci-okepolicy: https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengpolicyconfig.htm#PolicyPrerequisitesService
+:uri-oci-cluster-autoscaler: https://docs.oracle.com/en-us/iaas/Content/ContEng/Tasks/contengusingclusterautoscaler.htm#Working_with_the_Cluster_Autoscaler
+:uri-terraform: https://www.terraform.io
+:uri-terraform-oci: https://www.terraform.io/docs/providers/oci/index.html
+:uri-terraform-options: {uri-docs}/terraformoptions.adoc
+:uri-topology: {uri-docs}/topology.adoc
+:uri-upgrade-oke: https://docs.cloud.oracle.com/en-us/iaas/Content/ContEng/Tasks/contengupgradingk8sworkernode.htm
+:uri-variables: {uri-rel-file-base}/variables.tf
+
+This section documents how to deploy the Oracle Container Engine for Kubernetes (OKE) Cluster Autoscaler when using this project. At a high level, deploying the Kubernetes Cluster Autoscaler consists of 3 steps:
+
+1. Deploy an _unmanaged_ node pool i.e. a node pool that is not managed by the Kubernetes Cluster Autoscaler. We'll refer to this node pool as the _autoscaler_ node pool.
+2. Create a dynamic group and policy to allow worker nodes to manage node pools. The dynamic group uses defined tags to add worker nodes from the autoscaler node pool to the managed node pools.
+3. Configure and deploy the Kubernetes Cluster Autoscaler.
+
+== Prerequisites
+
+=== Tag namespace and tag key
+
+. Create a tag namespace named `oke` .
+. Create a tag key named `pool` in the `oke` tag namespace:
+.. Set the description to "Tag key to indicate node pool purpose"
+.. Set the value type to "String"
+.. Set the value to `autoscaler` which assigns any node pool with this tag to the Kubernetes Cluster Autoscaler.
+
+To use this list to indicate other purposes besides the Kubernetes Cluster Autoscaler, set the value type to "A list of values" instead of "String" and add your own customer purposes. 
+
+
+. bastion host is created
+. operator host is created
+. instance_principal is enabled on operator
+. set `enable_cluster_autoscaler=true`
+
+== Create required OCI resources
+
+The Kubernetes Cluster Autoscaler is installed to the `autoscaler` node pool and the required Oracle Identity and Access Management policies are created to allow the Kubernetes Cluster Autoscaler to resize the managed node pools based on application workload.
+
+=== Create the `autoscaler` node pool
+
+. Add the following configuration parameters to your `terraform.tfvars`:
+
++
+----
+enable_cluster_autoscaler = true
+autoscaler_pools = {
+  # only 1 pool is needed at a time unless:
+  # 1. you are in the process of upgrading of your cluster
+  # 2. you are running multiple Kubernetes versions of node pools after a cluster upgrade
+  asp_v124 = {}
+}
+----
+. The `_v124` suffix to the node pool name indicates the version of Kubernetes running in that node pool.
+	. Run `terraform apply` to create the `autoscaler` node pools.
+	. Verify that the `asp_v124` node pool of three nodes has been created. Each node in the pool should have the `oke.pool = autoscaler` tag assigned.
+
+
+=== Create an OCI dynamic group
+
+. Create a dynamic group `cluster-autoscaler-group` which contains the following matching rule:
+
++
+----
+tag.oke.pool.value='autoscaler'
+----
+
+=== Create an OCI policy
+
+. Replace `<compartment-name>` in the following policy statements with the name of the compartment in which the managed node pools must be or have been created.
+. Create a policy named `cluster-autoscaler-policy` in the root of your tenancy with the policy statements created in the previous step. 
+
++
+----
+Allow dynamic-group cluster-autoscaler-group to manage cluster-node-pools in compartment <compartment-name>
+Allow dynamic-group cluster-autoscaler-group to manage instance-family in compartment <compartment-name>
+Allow dynamic-group cluster-autoscaler-group to use subnets in compartment <compartment-name>
+Allow dynamic-group cluster-autoscaler-group to read virtual-network-family in compartment <compartment-name>
+Allow dynamic-group cluster-autoscaler-group to use vnics in compartment <compartment-name>
+Allow dynamic-group cluster-autoscaler-group to inspect compartments in compartment <compartment-name>
+----
+
+== Deploy the Kubernetes Cluster Autoscaler
+
+=== Create a Kubernetes manifest
+
+To simplify deployment, only Kubernetes v1.24 and higher are tested with this module. Using the module with an older version of Kubernetes requires amending the OCI provider configuration and applying a valid image tag as documented in the {uri-oci-cluster-autoscaler}[cluster autoscaler documentation].
+
+. On the operator host, a file called `cluster-autoscaler.yaml` will be created. It will only include the list of that should be automatically scaled by the Kubernetes Cluster Autoscaler:
+
++
+----
+  # node pool not managed by Kubernetes Cluster Autoscaler
+  np1 = {
+    shape              = "VM.Standard.E4.Flex",
+    ocpus              = 2,
+    memory             = 32,
+    node_pool_size     = 1,
+    max_node_pool_size = 5,
+    boot_volume_size   = 150,
+    autoscale          = false,
+  }
+
+  # node pool managed by Kubernetes Cluster Autoscaler
+  np2 = {
+    shape              = "VM.Standard.E4.Flex",
+    ocpus              = 2,
+    memory             = 32,
+    node_pool_size     = 1,
+    max_node_pool_size = 5,
+    boot_volume_size   = 150,
+    autoscale          = true,
+  }  
+----
+
+. The `cluster-autoscaler.yaml` file can be used to configure other {uri-cluster-autoscaler-parameters}[Kubernetes Cluster Autoscaler parameters], if required e.g.
+
++
+----
+--scale-down-unneeded-time=5m
+----
+
+. The following parameters are not currently supported by the Kubernetes Cluster Autoscaler:
+	.. `--node-group-auto-discovery`
+	.. `--node-autoprovisioning-enabled=true`
+	.. `--gpu-total`
+	.. `--expander=price`
+
+== Upgrading the OKE cluster when cluster autoscaler is deployed
+
+Assume the following cluster:
+
+- Cluster version: 1.24.1
+- Node pools : np1, np2 (1.24.1)
+- Autoscaler pools : asp_v124 (1.24.1)
+
+and we need to upgade to 1.25.1.
+
+****
+Note that at this time, OKE is not yet supporting Kubernetes 1.25. This is just to illustrate the procedure.
+****
+
+=== Upgrading the control plane nodes
+
+. Locate your `kubernetes_version` in your Terraform variable file and change:
+
++
+----
+kubernetes_version = "v1.24.1" 
+----
+to 
+
++
+----
+kubernetes_version = "v1.25.1"
+----
+
+. Run terraform:
+
++
+----
+terraform apply
+----
+
+This will upgrade the control plane nodes. You can verify this in the OCI Console.
+
+****
+If you have modified the default resources e.g. security lists, you will need to use a targeted apply:
+
+----
+terraform apply --target=module.oke.k8s_cluster
+----
+****
+
+=== Add new node pools
+1. Add new node pools in your list of node pools e.g. change
++
+[source,bash]
+----
+node_pools = {
+  np1 = {
+    ...
+  }
+  np2 = {
+    ...
+  }
+}
+----
+to
+
++
+----
+node_pools = {
+  np1 = {
+    ...
+  }
+  np2 = {
+    ...
+  }
+  np3 = {
+    ...
+  }
+  np4 = {
+    ...
+  }  
+}
+----
+
+and run `terraform apply` again. (See note above about targeted apply). If you are using Kubernetes labels or defined tags for your existing applications, you will need to ensure the new node pools also have the same labels. Refer to the `terraform.tfvars.example` file for the format to specify the labels.
+
+When node pools 3 and 4 are created, they will be created with the newer cluster version of Kubernetes. Since you have already upgrade your cluster to `v1.25.1`, node pools 3 and 4 will be running Kubernetes v1.25.1.
+
+=== Add 1 new autoscaler pool
+1. Add 1 new autoscaler pool in your autoscaler_pools e.g. change
++
+[source,bash]
+----
+autoscaler_pools = {
+  asp_v124 = {
+    ...
+  }
+}
+----
+to
+
++
+----
+autoscaler_pools = {
+  asp_v124 = {
+    ...
+  }
+  asp_v125 = {
+    ...
+  }
+}
+----
+
+and run `terraform apply` again.
+
+When node pools asp_v125 is created, it will be created with the newer cluster version of Kubernetes. Since you have already upgrade your cluster to `v1.25.1`, node pool asp_v125 will be running Kubernetes v1.25.1.
+
+=== Drain the node pools
+
+. Set `upgrade_nodepool=true`. This will instruct the OKE cluster that some node pools will be drained.
+
+. Provide the list of node pools to drain. This should usually be only the old node pools. You don't need to upgrade all the node pools at once.
+
++
+----
+node_pools_to_drain = [ "np1", "np2", "asp_v124"] 
+----
+
+. Run `terraform apply` (see note above about targeted apply):
+
++
+----
+terraform apply
+----
+
+. This will ensure that the all the node pools from 1.24 have been drained.
+
+=== Destroy old node pools
+
+When you are ready, you can now delete the old node pools by removing them from the list of node pools:
+
++
+----
+node_pools = {
+  np3 = {
+    ...
+  }
+  np4 = {
+    ...
+  }
+  asp_v124 = {}
+}
+----
+
+. Run terraform again:
+
++
+----
+terraform apply
+----
+
+=== Upgrade the cluster autoscaler
+
+1. Modify the `cluster-autoscaler.yaml`
+
+2. Change the image version to the corresponding Kubernetes version
+
+3. Change the OCIDs of the node pools to manage to those of np3 and np4.
+
+4. Run Terraform apply again.
+
+. This completes the upgrade process. Now, set ```upgrade_nodepool = false``` to prevent draining from current nodes by mistake.

--- a/locals.tf
+++ b/locals.tf
@@ -1,4 +1,4 @@
-# Copyright 2017, 2021 Oracle Corporation and/or affiliates.
+# Copyright (c) 2017, 2022 Oracle Corporation and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl
 
 locals {
@@ -20,9 +20,9 @@ locals {
   operator_private_ip                    = var.create_operator == true ? module.operator[0].operator_private_ip : var.operator_private_ip !="" ? var.operator_private_ip: ""
   operator_instance_principal_group_name = var.create_operator == true ? module.operator[0].operator_instance_principal_group_name : ""
 
-  vcn_id       = var.create_vcn == true ? module.vcn[0].vcn_id : coalesce(var.vcn_id, try(data.oci_core_vcns.vcns[0].virtual_networks[0].id,""))
-  ig_route_id  = var.create_vcn == true ? module.vcn[0].ig_route_id : coalesce(var.ig_route_table_id, try(data.oci_core_route_tables.ig[0].route_tables[0].id,""))
-  nat_route_id = var.create_vcn == true ? module.vcn[0].nat_route_id : coalesce(var.nat_route_table_id, try(data.oci_core_route_tables.nat[0].route_tables[0].id,""))
+  vcn_id       = var.create_vcn == true ? module.vcn[0].vcn_id : coalesce(var.vcn_id, try(data.oci_core_vcns.vcns[0].virtual_networks[0].id, ""))
+  ig_route_id  = var.create_vcn == true ? module.vcn[0].ig_route_id : coalesce(var.ig_route_table_id, try(data.oci_core_route_tables.ig[0].route_tables[0].id, ""))
+  nat_route_id = var.create_vcn == true ? module.vcn[0].nat_route_id : coalesce(var.nat_route_table_id, try(data.oci_core_route_tables.nat[0].route_tables[0].id, ""))
 
   ssh_key_arg                            = var.ssh_private_key_path == "none" ? "" : " -i ${var.ssh_private_key_path}"
   validate_drg_input = var.create_drg && (var.drg_id != null) ? tobool("[ERROR]: create_drg variable can not be true if drg_id is provided.]") : true

--- a/main.tf
+++ b/main.tf
@@ -291,6 +291,10 @@ module "oke" {
   freeform_tags = var.freeform_tags["oke"]
   defined_tags  = var.defined_tags["oke"]
 
+  # cluster autoscaler
+  enable_cluster_autoscaler = var.enable_cluster_autoscaler
+  autoscaler_pools          = var.autoscaler_pools
+
   depends_on = [
     module.network
   ]
@@ -415,6 +419,12 @@ module "extensions" {
   upgrade_nodepool        = var.upgrade_nodepool
   nodepool_upgrade_method = var.nodepool_upgrade_method
   node_pools_to_drain     = var.node_pools_to_drain
+
+  # cluster autoscaler
+  enable_cluster_autoscaler = var.enable_cluster_autoscaler
+  autoscaler_pools          = var.autoscaler_pools
+
+  autoscaling_nodepools = module.oke.autoscaling_nodepools
 
   debug_mode = var.debug_mode
 

--- a/modules/extensions/autoscaler.tf
+++ b/modules/extensions/autoscaler.tf
@@ -1,0 +1,74 @@
+# Copyright (c) 2022 Oracle Corporation and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl
+
+# taint the nodes in the autoscaler pool to restrict deployment of pods to nodes with the autoscaler toleration
+resource "null_resource" "taint_nodes" {
+  connection {
+    host        = var.operator_private_ip
+    private_key = local.ssh_private_key
+    timeout     = "40m"
+    type        = "ssh"
+    user        = "opc"
+
+    bastion_host        = var.bastion_public_ip
+    bastion_user        = "opc"
+    bastion_private_key = local.ssh_private_key
+  }
+
+  provisioner "file" {
+    content     = local.create_autoscaler_pool_taint_list_template
+    destination = "/home/opc/create_autoscaler_pool_taint_list.py"
+  }
+
+  provisioner "file" {
+    content     = local.taint_autoscaler_pool_template
+    destination = "/home/opc/taint_autoscaler_pools.sh"
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "rm -f \"$HOME/taint_autoscaler_pool_list.txt\"",
+      "if [ -f \"$HOME/create_autoscaler_pool_taint_list.py\" ]; then python3 \"$HOME/create_autoscaler_pool_taint_list.py\"; rm -f \"$HOME/create_autoscaler_pool_taint_list.py\";fi",
+      "if [ -f \"$HOME/taint_autoscaler_pools.sh\" ]; then bash \"$HOME/taint_autoscaler_pools.sh\"; rm -f \"$HOME/taint_autoscaler_pools.sh\";fi",
+      "if [ -f \"$HOME/taint_autoscaler_pool_list.txt\" ]; then cat \"$HOME/taint_autoscaler_pool_list.txt\" >> \"$HOME/taint_autoscaler_pool_list.txt\"; rm -f \"$HOME/taint_autoscaler_pool_list.txt\";fi",
+    ]
+  }
+
+  depends_on = [null_resource.install_k8stools_on_operator, null_resource.write_kubeconfig_on_operator]  
+
+  triggers = {
+    autoscaler_pools = length(var.autoscaler_pools)
+  }
+
+  count = local.post_provisioning_ops == true && var.enable_cluster_autoscaler == true ? 1 : 0
+}
+
+
+resource "null_resource" "deploy_cluster_autoscaler" {
+  connection {
+    host        = var.operator_private_ip
+    private_key = local.ssh_private_key
+    timeout     = "40m"
+    type        = "ssh"
+    user        = "opc"
+
+    bastion_host        = var.bastion_public_ip
+    bastion_user        = "opc"
+    bastion_private_key = local.ssh_private_key
+  }
+
+  provisioner "file" {
+    content     = local.cluster_autoscaler_yaml_template
+    destination = "/home/opc/cluster-autoscaler.yaml"
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "if [ -f \"$HOME/cluster-autoscaler.yaml\" ]; then kubectl apply -f \"$HOME/cluster-autoscaler.yaml\";fi",
+    ]
+  }
+
+  count = local.post_provisioning_ops == true && var.enable_cluster_autoscaler == true ? 1 : 0
+
+  triggers = {bla="blabla"}
+}

--- a/modules/extensions/resources/clusterautoscaler.template.yaml
+++ b/modules/extensions/resources/clusterautoscaler.template.yaml
@@ -1,0 +1,176 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    k8s-addon: cluster-autoscaler.addons.k8s.io
+    k8s-app: cluster-autoscaler
+  name: cluster-autoscaler
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cluster-autoscaler
+  labels:
+    k8s-addon: cluster-autoscaler.addons.k8s.io
+    k8s-app: cluster-autoscaler
+rules:
+  - apiGroups: [""]
+    resources: ["events", "endpoints"]
+    verbs: ["create", "patch"]
+  - apiGroups: [""]
+    resources: ["pods/eviction"]
+    verbs: ["create"]
+  - apiGroups: [""]
+    resources: ["pods/status"]
+    verbs: ["update"]
+  - apiGroups: [""]
+    resources: ["endpoints"]
+    resourceNames: ["cluster-autoscaler"]
+    verbs: ["get", "update"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["watch", "list", "get", "patch", "update"]
+  - apiGroups: [""]
+    resources:
+      - "namespaces"
+      - "pods"
+      - "services"
+      - "replicationcontrollers"
+      - "persistentvolumeclaims"
+      - "persistentvolumes"      
+    verbs: ["watch", "list", "get"]
+  - apiGroups: ["extensions"]
+    resources: ["replicasets", "daemonsets"]
+    verbs: ["watch", "list", "get"]
+  - apiGroups: ["policy"]
+    resources: ["poddisruptionbudgets"]
+    verbs: ["watch", "list"]
+  - apiGroups: ["apps"]
+    resources: ["statefulsets", "replicasets", "daemonsets"]
+    verbs: ["watch", "list", "get"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses", "csinodes", "csidrivers", "csistoragecapabilities", "csistoragecapacities"]
+    verbs: ["watch", "list", "get"]
+  - apiGroups: ["batch", "extensions"]
+    resources: ["jobs"]
+    verbs: ["get", "list", "watch", "patch"]
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["create"]
+  - apiGroups: ["coordination.k8s.io"]
+    resourceNames: ["cluster-autoscaler"]
+    resources: ["leases"]
+    verbs: ["get", "update"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cluster-autoscaler
+  namespace: kube-system
+  labels:
+    k8s-addon: cluster-autoscaler.addons.k8s.io
+    k8s-app: cluster-autoscaler
+rules:
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["create","list","watch"]
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    resourceNames: ["cluster-autoscaler-status", "cluster-autoscaler-priority-expander"]
+    verbs: ["delete", "get", "update", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cluster-autoscaler
+  labels:
+    k8s-addon: cluster-autoscaler.addons.k8s.io
+    k8s-app: cluster-autoscaler
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-autoscaler
+subjects:
+  - kind: ServiceAccount
+    name: cluster-autoscaler
+    namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cluster-autoscaler
+  namespace: kube-system
+  labels:
+    k8s-addon: cluster-autoscaler.addons.k8s.io
+    k8s-app: cluster-autoscaler
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cluster-autoscaler
+subjects:
+  - kind: ServiceAccount
+    name: cluster-autoscaler
+    namespace: kube-system
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cluster-autoscaler
+  namespace: kube-system
+  labels:
+    app: cluster-autoscaler
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: cluster-autoscaler
+  template:
+    metadata:
+      labels:
+        app: cluster-autoscaler
+      annotations:
+        prometheus.io/scrape: 'true'
+        prometheus.io/port: '8085'
+    spec:
+      nodeSelector:
+        app: cluster-autoscaler
+      serviceAccountName: cluster-autoscaler
+      containers:
+        - image: iad.ocir.io/oracle/oci-cluster-autoscaler:1.24.0-5
+          name: cluster-autoscaler
+          resources:
+            limits:
+              cpu: 100m
+              memory: 300Mi
+            requests:
+              cpu: 100m
+              memory: 300Mi
+          command:
+            - ./cluster-autoscaler
+            - --v=4
+            - --stderrthreshold=info
+            - --cloud-provider=oci-oke
+            - --max-node-provision-time=25m
+%{ for pool in autoscaling_nodepools ~}
+            - --nodes=${pool.node_pool_size}:${pool.max_node_pool_size}:${pool.id}
+%{ endfor ~}            
+            - --scale-down-unneeded-time=2m
+            - --unremovable-node-recheck-timeout=5m
+            - --balance-similar-node-groups
+            - --balancing-ignore-label=displayName
+            - --balancing-ignore-label=hostname
+            - --balancing-ignore-label=internal_addr
+            - --balancing-ignore-label=oci.oraclecloud.com/fault-domain
+          imagePullPolicy: "Always"
+          env:
+          - name: OKE_USE_INSTANCE_PRINCIPAL
+            value: "true"
+          - name: OCI_SDK_APPEND_USER_AGENT
+            value: "oci-oke-cluster-autoscaler"
+      tolerations:
+      - key: "autoscaler"
+        operator: "Exists"
+        effect: "NoSchedule"            

--- a/modules/extensions/scripts/create_autoscaler_pool_taint_list.py
+++ b/modules/extensions/scripts/create_autoscaler_pool_taint_list.py
@@ -1,0 +1,60 @@
+#!/usr/bin/python3
+# Copyright (c) 2017, 2022, Oracle Corporation and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl
+# Derived and adapted from https://www.ateam-oracle.com/secure-way-of-managing-secrets-in-oci
+
+import os
+import oci
+from oci.container_engine import ContainerEngineClient
+
+compartment_id = '${compartment_id}'
+cluster_id = '${cluster_id}'
+region = '${region}'
+pools_to_taint = ['${pools_to_taint}']
+
+signer = oci.auth.signers.InstancePrincipalsSecurityTokenSigner()
+
+oce = oci.container_engine.ContainerEngineClient(config={'region': region}, signer=signer)
+
+# Get list of node pools
+list_pools = []
+
+for p in pools_to_taint:
+    list_pools = oce.list_node_pools(compartment_id,cluster_id=cluster_id,name=p)
+
+# Count number of node pools to taint
+    number_of_node_pools = len(list_pools.data)
+
+# Get list of node pool ids to taint
+    pool_ids = []
+
+    for n in range(0,number_of_node_pools):
+        pool_ids.append(list_pools.data[n].id)
+
+# for all node pool ids to taint, get a list of node pools
+    node_pools = []
+
+    for node_pool_id in pool_ids:
+        resp = oce.get_node_pool(node_pool_id)
+        node_pools.append(resp.data)
+
+# for all node pools to taint, get a list of their worker nodes
+    all_nodes = []
+
+    for nodepool in node_pools:
+        try:
+            nodes = nodepool.nodes
+            for node in nodes:
+                all_nodes.append(node)
+        except TypeError:
+            continue
+
+# for each node in the node pool, get their private_ip and write to file
+    with open('taint_autoscaler_pool_list.txt', 'a') as filehandle:
+      for nodepool in node_pools:
+          try:
+              nodes = nodepool.nodes
+              for node in nodes:
+                  filehandle.write('%s\n' % node.private_ip)
+          except TypeError:
+              continue

--- a/modules/extensions/scripts/taint_autoscaler_pool.template.sh
+++ b/modules/extensions/scripts/taint_autoscaler_pool.template.sh
@@ -1,0 +1,8 @@
+ #!/usr/bin/bash
+# Copyright (c) 2022, Oracle Corporation and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl
+
+for NODE in $(taint_autoscaler_pool_list.txt); do
+  kubectl taint nodes $NODE autoscaler=true:NoSchedule
+  echo $NODE tainted with autoscaler=true:NoSchedule
+done

--- a/modules/extensions/templates.tf
+++ b/modules/extensions/templates.tf
@@ -95,6 +95,23 @@ locals {
     }
   )
 
+  taint_autoscaler_pool_template = templatefile("${path.module}/scripts/taint_autoscaler_pool.template.sh", {})
+
+  create_autoscaler_pool_taint_list_template = templatefile("${path.module}/scripts/create_autoscaler_pool_taint_list.py",
+    {
+      cluster_id     = var.cluster_id
+      compartment_id = var.compartment_id
+      region         = var.region
+      pools_to_taint = var.label_prefix == "none" ? trim(join(",", formatlist("'%s'", keys(var.autoscaler_pools))), "'") : trim(join(",", formatlist("'%s-%s'", var.label_prefix, keys(var.autoscaler_pools))), "'")
+    }
+  )
+
+  cluster_autoscaler_yaml_template = templatefile("${path.module}/resources/clusterautoscaler.template.yaml",
+    {
+      autoscaling_nodepools = var.autoscaling_nodepools
+    }
+  )
+
   token_helper_template = templatefile("${path.module}/scripts/token_helper.template.sh",
     {
       cluster-id = var.cluster_id

--- a/modules/extensions/variables.tf
+++ b/modules/extensions/variables.tf
@@ -1,4 +1,4 @@
-# Copyright 2017, 2019 Oracle Corporation and/or affiliates.
+# Copyright (c) 2017, 2022 Oracle Corporation and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl
 
 # oci provider
@@ -148,6 +148,20 @@ variable "nodepool_upgrade_method" {
 
 variable "node_pools_to_drain" {
   type = list(string)
+}
+
+# cluster autoscaler
+variable "enable_cluster_autoscaler" {
+  type = bool
+}
+
+variable "autoscaler_pools" {
+  type = any
+}
+
+
+variable "autoscaling_nodepools" {
+  type = any
 }
 
 variable "debug_mode" {

--- a/modules/network/subnets.tf
+++ b/modules/network/subnets.tf
@@ -1,4 +1,4 @@
-# Copyright 2017, 2022 Oracle Corporation and/or affiliates.
+# Copyright (c) 2017, 2022 Oracle Corporation and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl
 
 resource "oci_core_subnet" "cp" {

--- a/modules/oke/autoscaler.tf
+++ b/modules/oke/autoscaler.tf
@@ -1,0 +1,122 @@
+# Copyright (c) 2022 Oracle Corporation and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl
+
+# The cluster autoscaler pods are deployed to the autoscaler node pool
+resource "oci_containerengine_node_pool" "autoscaler_pool" {
+  for_each       = var.enable_cluster_autoscaler == true ? var.autoscaler_pools : {}
+  cluster_id     = oci_containerengine_cluster.k8s_cluster.id
+  compartment_id = var.compartment_id
+  depends_on     = [oci_containerengine_cluster.k8s_cluster]
+
+  kubernetes_version = var.cluster_kubernetes_version
+  name               = var.label_prefix == "none" ? each.key : "${var.label_prefix}-${each.key}"
+
+  freeform_tags = merge(var.freeform_tags["node_pool"], { app = "cluster-autoscaler", pool = "autoscaler" })
+  defined_tags  = merge(var.defined_tags["node_pool"], { "oke.pool" = "autoscaler" })
+
+  node_config_details {
+
+    is_pv_encryption_in_transit_enabled = var.enable_pv_encryption_in_transit
+
+    kms_key_id = var.node_pool_volume_kms_key_id
+
+    # iterating over ADs
+    dynamic "placement_configs" {
+      iterator = ad_iterator
+      for_each = [for n in lookup(each.value, "placement_ads", local.ad_numbers) :
+      local.ad_number_to_name[n]]
+      content {
+        availability_domain = ad_iterator.value
+        subnet_id           = var.cluster_subnets["workers"]
+      }
+    }
+
+    nsg_ids = var.worker_nsgs
+
+    # flannel requires cni type only
+    dynamic "node_pool_pod_network_option_details" {
+      for_each = var.cni_type == "flannel" ? [1] : []
+      content {
+        cni_type = "FLANNEL_OVERLAY"
+      }
+    }
+
+    # native requires max pods/node, nsg ids, subnet ids
+    dynamic "node_pool_pod_network_option_details" {
+      for_each = var.cni_type == "npn" ? [1] : []
+      content {
+        cni_type          = "OCI_VCN_IP_NATIVE"
+        max_pods_per_node = var.max_pods_per_node
+        # pick the 1st pod nsg here until https://github.com/oracle/terraform-provider-oci/issues/1662 is clarified and resolved
+        pod_nsg_ids    = element(var.pod_nsgs, 0)
+        pod_subnet_ids = tolist([var.cluster_subnets["pods"]])
+      }
+    }
+
+    size = 1
+
+    freeform_tags = merge(var.freeform_tags["node"], { app = "cluster-autoscaler", pool = "autoscaler" })
+
+    # hardcoded defined tags are used to determine dynamic group membership and permissions
+    defined_tags = merge(var.defined_tags["node"], { "oke.pool" = "autoscaler" })
+  }
+
+  # setting shape
+  node_shape = "VM.Standard.E4.Flex"
+
+  node_shape_config {
+    ocpus         = 2
+    memory_in_gbs = 32
+  }
+
+  # cloud-init
+  node_metadata = {
+    user_data = var.cloudinit_nodepool_common == "" && lookup(var.cloudinit_nodepool, each.key, null) == null ? data.cloudinit_config.worker.rendered : lookup(var.cloudinit_nodepool, each.key, null) != null ? filebase64(lookup(var.cloudinit_nodepool, each.key, null)) : filebase64(var.cloudinit_nodepool_common)
+  }
+
+  # optimized OKE images
+  dynamic "node_source_details" {
+    for_each = var.node_pool_image_type == "oke" ? [1] : []
+    content {
+      boot_volume_size_in_gbs = lookup(each.value, "boot_volume_size", 50)
+
+      # image fixed to E4.flex, no need to lookup
+      image_id    = (element([for source in local.node_pool_image_ids : source.image_id if length(regexall("Oracle-Linux-${var.node_pool_os_version}-20[0-9]*.*-OKE-${local.k8s_version_only}", source.source_name)) > 0], 0))
+      source_type = data.oci_containerengine_node_pool_option.node_pool_options.sources[0].source_type
+    }
+  }
+
+  # OCI platform images
+  dynamic "node_source_details" {
+    for_each = var.node_pool_image_type == "platform" ? [1] : []
+    content {
+      boot_volume_size_in_gbs = lookup(each.value, "boot_volume_size", 50)
+      # image fixed to E4.flex, no need to lookup
+      image_id    = element([for source in local.node_pool_image_ids : source.image_id if length(regexall("^(Oracle-Linux-${var.node_pool_os_version}-\\d{4}.\\d{2}.\\d{2}-[0-9]*)$", source.source_name)) > 0], 0)
+      source_type = data.oci_containerengine_node_pool_option.node_pool_options.sources[0].source_type
+    }
+  }
+
+  # custom images 
+  dynamic "node_source_details" {
+    for_each = var.node_pool_image_type == "custom" ? [1] : []
+    content {
+      boot_volume_size_in_gbs = lookup(each.value, "boot_volume_size", 50)
+      image_id                = var.node_pool_image_id
+      source_type             = data.oci_containerengine_node_pool_option.node_pool_options.sources[0].source_type
+    }
+  }
+
+  ssh_public_key = (var.ssh_public_key != "") ? var.ssh_public_key : (var.ssh_public_key_path != "none") ? file(var.ssh_public_key_path) : ""
+
+  # do not destroy the node pool if the kubernetes version has changed as part of the upgrade
+  lifecycle {
+    ignore_changes = [kubernetes_version]
+  }
+
+  # initial node labels for the autoscaler pool
+  initial_node_labels {
+    key   = "app"
+    value = "cluster-autoscaler"
+  }
+}

--- a/modules/oke/datasources.tf
+++ b/modules/oke/datasources.tf
@@ -1,4 +1,4 @@
-# Copyright 2017, 2021 Oracle Corporation and/or affiliates.
+# Copyright (c) 2017, 2022 Oracle Corporation and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl
 
 data "oci_identity_availability_domains" "ad_list" {
@@ -7,4 +7,22 @@ data "oci_identity_availability_domains" "ad_list" {
 
 data "oci_containerengine_node_pool_option" "node_pool_options" {
   node_pool_option_id = oci_containerengine_cluster.k8s_cluster.id
+}
+
+# get the list of node pools for the cluster
+data "oci_containerengine_node_pools" "nodepools" {
+  compartment_id = var.compartment_id
+
+  cluster_id = oci_containerengine_cluster.k8s_cluster.id
+
+  filter {
+    name   = "name"
+    values = ["${var.label_prefix}*"]
+    regex  = true
+  }
+
+  depends_on = [
+    oci_containerengine_node_pool.nodepools,
+    oci_containerengine_node_pool.autoscaler_pool
+  ]
 }

--- a/modules/oke/locals.tf
+++ b/modules/oke/locals.tf
@@ -1,4 +1,4 @@
-# Copyright 2017, 2021 Oracle Corporation and/or affiliates.
+# Copyright (c) 2017, 2022 Oracle Corporation and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl
 
 locals {
@@ -31,6 +31,16 @@ locals {
 
   # kubernetes string version length
   k8s_version_length = length(var.cluster_kubernetes_version)
-  k8s_version_only = substr(var.cluster_kubernetes_version,1,local.k8s_version_length)
+  k8s_version_only   = substr(var.cluster_kubernetes_version, 1, local.k8s_version_length)
 
+  # build a list  of nodepools to autoscale in the format expected by cluster autoscaler:
+  # - --nodes:min:max:nodepool_id
+  autoscaling_nodepools = [
+    for nodepool_name, nodepool_parameters in var.node_pools : { 
+      "name" = "${nodepool_name}", 
+      "node_pool_size" = "${nodepool_parameters.node_pool_size}", 
+      "max_node_pool_size" = "${nodepool_parameters.max_node_pool_size}", 
+      "id" = "${lookup(lookup(oci_containerengine_node_pool.nodepools, nodepool_name), "id")}"       
+    } if nodepool_parameters.autoscale == true
+  ]
 }

--- a/modules/oke/outputs.tf
+++ b/modules/oke/outputs.tf
@@ -1,4 +1,4 @@
-# Copyright 2017, 2021 Oracle Corporation and/or affiliates.
+# Copyright (c) 2017, 2022 Oracle Corporation and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl
 
 output "cluster_id" {
@@ -15,4 +15,8 @@ output "nodepool_ids" {
 
 output "endpoints" {
   value = oci_containerengine_cluster.k8s_cluster.endpoints
+}
+
+output "autoscaling_nodepools" {
+  value = local.autoscaling_nodepools
 }

--- a/modules/oke/variables.tf
+++ b/modules/oke/variables.tf
@@ -1,4 +1,4 @@
-# Copyright 2017, 2019 Oracle Corporation and/or affiliates.
+# Copyright (c) 2017, 2022 Oracle Corporation and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl
 
 # oci provider
@@ -68,7 +68,7 @@ variable "enable_pv_encryption_in_transit" {
 }
 
 variable "create_policies" {
-  type        = bool
+  type = bool
 }
 
 # signed images
@@ -88,7 +88,15 @@ variable "admission_controller_options" {
 variable "kubeproxy_mode" {}
 
 variable "max_pods_per_node" {
-  type        = number
+  type = number
+}
+
+variable "enable_cluster_autoscaler" {
+  type = bool
+}
+
+variable "autoscaler_pools" {
+  type = any
 }
 
 variable "node_pools" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,4 +1,5 @@
-# Copyright 2017, 2021 Oracle Corporation and/or affiliates.
+# Copyright (c) 2017, 2022 Oracle Corporation and/or its affiliates.
+
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl
 
 # for reuse 
@@ -88,4 +89,8 @@ output "fss_id" {
 output "cluster_endpoints" {
   description = "Endpoints for the Kubernetes cluster"
   value       = module.oke.endpoints
+}
+
+output "autoscaling_nodepools" {
+  value = module.oke.autoscaling_nodepools
 }

--- a/terraform.tfvars.example
+++ b/terraform.tfvars.example
@@ -1,4 +1,4 @@
-# Copyright 2017, 2022 Oracle Corporation and/or affiliates.
+# Copyright (c) 2017, 2022 Oracle Corporation and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl
 
 # Identity and access parameters
@@ -208,7 +208,7 @@ node_pools = {
   #   boot_volume_size = 150,
   #   label            = { app = "frontend", pool = "np2" },
   # }
-  # # node pool with freeform tags 
+  # # node pool with freeform tags
   # np3 = {
   #   shape                  = "VM.Standard.E4.Flex",
   #   ocpus                  = 2,
@@ -267,7 +267,18 @@ node_pools = {
   #   boot_volume_size = 150,
   #   placement_ads    = [1]
   # }
+  # # node pool managed by Kubernetes Cluster Autoscaler
+  # np12 = {
+  #   shape              = "VM.Standard.E4.Flex",
+  #   ocpus              = 2,
+  #   memory             = 32,
+  #   node_pool_size     = 1,
+  #   max_node_pool_size = 5,
+  #   boot_volume_size   = 150,
+  #   autoscale          = true,
+  # }
 }
+
 node_pool_image_id    = "none"
 node_pool_image_type  = "oke"
 node_pool_name_prefix = "np"
@@ -361,7 +372,7 @@ freeform_tags = {
   #   }
   #   persistent_volume = {
   #     environment = "dev"
-  #   }    
+  #   }
   #   service_lb = {
   #     environment = "dev"
   #     role        = "load balancer"
@@ -391,7 +402,7 @@ defined_tags = {
   #   }
   #   persistent_volume = {
   #     "cn.environment" = "dev"
-  #   }    
+  #   }
   #   service_lb = {
   #     "cn.environment" = "dev"
   #     "cn.role"        = "load balancer"
@@ -405,6 +416,13 @@ defined_tags = {
   #     "cn.role"        = "worker"
   #   }
   # }
+}
+
+# cluster autoscaler
+enable_cluster_autoscaler = false
+autoscaler_pools = {
+  # only 1 pool is needed at a time unless during upgrade
+  asp_v124 = {}
 }
 
 # placeholder variable for debugging scripts. To be implemented in future

--- a/variables.tf
+++ b/variables.tf
@@ -1,4 +1,4 @@
-# Copyright 2017, 2022 Oracle Corporation and/or affiliates.
+# Copyright (c) 2017, 2022 Oracle Corporation and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl
 
 # OCI Provider parameters
@@ -174,7 +174,7 @@ variable "drg_display_name" {
   default     = "drg"
 }
 
-variable "drg_id" {
+variable "drg_id"  {
   description = "ID of an external created Dynamic Routing Gateway to be attached to the VCN"
   type        = string
   default     = null
@@ -1092,6 +1092,22 @@ variable "defined_tags" {
     vcn = map(any),
     oke = map(any)
   })
+}
+
+# Cluster autoscaler
+variable "enable_cluster_autoscaler" {
+  description = "Enable Kubernetes Cluster Autoscaler"
+  type        = bool
+  default     = false
+}
+
+variable "autoscaler_pools" {
+  description = "Node pool for the Kubernetes Cluster Autoscaler"
+  type        = any
+  default = {
+    # 1 autoscaler pool by Kubernetes version
+    asp_v123 = {}
+  }
 }
 
 # placeholder variable for debugging scripts. To be implemented in future


### PR DESCRIPTION
Resolves #273

This PR adds a separate unmanaged node pool for the purpose of deploying the cluster autoscaler. The node pool has the following characteristics:

- deployed separately from other nodepools
- defined tags (oke.pool = ~~"syspool"~~ "autoscaler") applied to nodepool and its nodes so that the nodes will be part of autoscaler dynamic group
- fixed shape to Flex E4, 2 OCPUs and 32 GB memory
- fixed size of 3 worker nodes so we can deploy 3 replicas
- fixed labels (app="cluster-autoscaler"). ~~Autoscaler will need to implement this as nodeSelector.~~
- taints (autoscaler=true:NoSchedule). ~~Autoscaler deployment will need to implement this as tolerations.~~ This will help restrict other deployments from this node. Need to change the taint and update the toleration.
- should work through a cluster upgrade and then a node pool upgrade.

To test:

1. Create a local branch
2. Pull the latest form this branch
3. Set `enable_cluster_autoscaler=true`
4. Ensure you have a tag namespace called `oke` and a key `pool` created
5. Run terraform apply to create a normal node pool of size (5) +1 more node pool (asp_v12x) is already created.
6. Manually create a dynamic group for autoscaler and use tags instead for its rules (instead of compartment). See https://docs.oracle.com/en-us/iaas/Content/Identity/Tasks/managingdynamicgroups.htm#Writing
7. Manually create autoscaling policy: https://docs.oracle.com/en-us/iaas/Content/ContEng/Tasks/contengusingclusterautoscaler.htm#Working_with_the_Cluster_Autoscaler
8. ~~Deploy the autoscaler (ensure you have the necessary tolerations and nodeSelector).~~
9. Wait 10 minutes and check if scaling event is triggered

At this point, I'm seeking feedback:

- [x] I'm looking for a better name than "syspool" to reflect its purpose. Outcome: Changed value to `autoscaler`
- [x] Do we want the tag namespace, key and value to be customizable? Outcome: Lock it down.
- [x] Do we want the shape to be configurable like for other node pools? Outcome: Yes. To be completed.
- [ ]Do we want the node pool size to be be configurable like for other node pools but set to a minimum of 1? 
- [ ]Do we want the taint and labels to be configurable? No, but look at well known taints and labels for inspiration/reuse.

@aibarbetta @mschmidt291 @shapeofarchitect @styledigger @DanielDingTR @Pixy123 @oraclespainpresales @godot @icy @valireds @damithkothlawala: 





Signed-off-by: Ali Mukadam <ali.mukadam@oracle.com>