### PR TITLE
fix: Ignore lifecycle changes, support Resource Manager variables

### DIFF
--- a/datasource.tf
+++ b/datasource.tf
@@ -4,7 +4,7 @@
 data "oci_core_vcns" "vcns" {
   count = var.create_vcn == true ? 0 : 1
 
-  compartment_id = var.compartment_id
+  compartment_id = local.compartment_id
   display_name   = var.vcn_display_name
 
   state = "AVAILABLE"
@@ -13,7 +13,7 @@ data "oci_core_vcns" "vcns" {
 data "oci_core_route_tables" "nat" {
   count = var.create_vcn == true ? 0 : 1
 
-  compartment_id = var.compartment_id
+  compartment_id = local.compartment_id
 
   display_name = var.nat_route_table_display_name
   vcn_id       = local.vcn_id
@@ -24,7 +24,7 @@ data "oci_core_route_tables" "nat" {
 data "oci_core_route_tables" "ig" {
   count = var.create_vcn == true ? 0 : 1
 
-  compartment_id = var.compartment_id
+  compartment_id = local.compartment_id
 
   display_name = var.ig_route_table_display_name
   vcn_id       = local.vcn_id

--- a/docs/instructions.adoc
+++ b/docs/instructions.adoc
@@ -241,6 +241,10 @@ export KUBECONFIG=generated/kubeconfig
 *Ensure you install the same kubectl version as the OKE Kubernetes version for compatibility.*
 ****
 
+****
+*To refresh the generated kubeconfig, run `terraform apply` with `update_kubeconfig: true`.*
+****
+
 == Creating a Secret for OCIR
 
 {uri-oci-ocir}[Oracle Cloud Infrastructure Registry] is a highly available private container registry service for storing and sharing container images within the same regions as the OKE Cluster. Use the following rules to determine if you need to create a Kubernetes Secret for OCIR:

--- a/docs/terraformoptions.adoc
+++ b/docs/terraformoptions.adoc
@@ -16,11 +16,14 @@
 :uri-kubernetes-vpa: https://github.com/kubernetes/autoscaler/tree/master/vertical-pod-autoscaler
 :uri-metrics-server: https://github.com/kubernetes-incubator/metrics-server
 :uri-openpolicyagent-gatekeeper: https://open-policy-agent.github.io/gatekeeper/website/docs/
+:uri-oci-content: https://docs.cloud.oracle.com/iaas/Content
 :uri-oci-images: https://docs.cloud.oracle.com/iaas/images/
-:uri-oci-kms: https://docs.cloud.oracle.com/iaas/Content/KeyManagement/Concepts/keyoverview.htm
+:uri-oci-kms: {uri-oci-content}/KeyManagement/Concepts/keyoverview.htm
 :uri-oci-loadbalancer-annotations: https://github.com/oracle/oci-cloud-controller-manager/blob/master/docs/load-balancer-annotations.md
-:uri-oci-region: https://docs.cloud.oracle.com/iaas/Content/General/Concepts/regions.htm
-:uri-oci-tags: https://docs.oracle.com/en-us/iaas/Content/Tagging/Tasks/managingtagsandtagnamespaces.htm#workdefined
+:uri-oci-provider-config: {uri-oci-content}/API/SDKDocs/terraformproviderconfiguration.htm
+:uri-oci-region: {uri-oci-content}/General/Concepts/regions.htm
+:uri-oci-rm-config: {uri-oci-content}/ResourceManager/Concepts/terraformconfigresourcemanager.htm#configvar
+:uri-oci-tags: {uri-oci-content}/Tagging/Tasks/managingtagsandtagnamespaces.htm#workdefined
 :uri-terraform-cidrsubnet: https://www.terraform.io/docs/configuration/functions/cidrsubnet.html
 :uri-terraform-dependencies: {uri-docs}/dependencies.adoc
 :uri-timezones: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
@@ -31,6 +34,8 @@ Configuration Terraform Options:
 Ensure you review the {uri-terraform-dependencies}[dependencies].
 
 == OCI Provider parameters
+
+See {uri-oci-provider-config}[Terraform OCI Provider] or {uri-oci-rm-config}[Resource Manager] configuration.
 
 [stripes=odd,cols="1m,4d,2m,2m", options=header,width="100%"]
 |===

--- a/docs/terraformoptions.adoc
+++ b/docs/terraformoptions.adoc
@@ -337,6 +337,11 @@ EOT
 |7.9
 |7.9
 
+|`bastion_user`
+|The user for SSH access to the bastion host. Always 'opc' on supported images.
+|opc
+|opc
+
 |bastion_shape
 |The shape of bastion instance. *Required*
 |
@@ -451,6 +456,11 @@ EOT
 |The Oracle Linux version to use for the operator host.
 |e.g. 7.9, 8
 |8
+
+|`operator_user`
+|The user for SSH access to the operator host. Always 'opc' on supported images.
+|opc
+|opc
 
 |`operator_shape`
 |The shape of operator instance. *Required*

--- a/locals.tf
+++ b/locals.tf
@@ -8,7 +8,7 @@ locals {
     var.tenancy_id, var.tenancy_ocid,
   )
 
-  bastion_public_ip                      = var.create_bastion_host == true ? module.bastion[0].bastion_public_ip : ""
+  bastion_public_ip                      = var.create_bastion_host == true ? module.bastion[0].bastion_public_ip : coalesce(var.bastion_public_ip, "")
   operator_private_ip                    = var.create_operator == true ? module.operator[0].operator_private_ip : ""
   operator_instance_principal_group_name = var.create_operator == true ? module.operator[0].operator_instance_principal_group_name : ""
 
@@ -16,5 +16,6 @@ locals {
   ig_route_id  = var.create_vcn == true ? module.vcn[0].ig_route_id : coalesce(var.ig_route_table_id, try(data.oci_core_route_tables.ig[0].route_tables[0].id,""))
   nat_route_id = var.create_vcn == true ? module.vcn[0].nat_route_id : coalesce(var.nat_route_table_id, try(data.oci_core_route_tables.nat[0].route_tables[0].id,""))
 
+  ssh_key_arg                            = var.ssh_private_key_path == "none" ? "" : " -i ${var.ssh_private_key_path}"
   validate_drg_input = var.create_drg && (var.drg_id != null) ? tobool("[ERROR]: create_drg variable can not be true if drg_id is provided.]") : true
 }

--- a/locals.tf
+++ b/locals.tf
@@ -9,7 +9,7 @@ locals {
   )
 
   bastion_public_ip                      = var.create_bastion_host == true ? module.bastion[0].bastion_public_ip : coalesce(var.bastion_public_ip, "")
-  operator_private_ip                    = var.create_operator == true ? module.operator[0].operator_private_ip : ""
+  operator_private_ip                    = var.create_operator == true ? module.operator[0].operator_private_ip : coalesce(var.operator_private_ip, "")
   operator_instance_principal_group_name = var.create_operator == true ? module.operator[0].operator_instance_principal_group_name : ""
 
   vcn_id       = var.create_vcn == true ? module.vcn[0].vcn_id : coalesce(var.vcn_id, try(data.oci_core_vcns.vcns[0].virtual_networks[0].id,""))

--- a/locals.tf
+++ b/locals.tf
@@ -2,6 +2,12 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl
 
 locals {
+  tenancy_id     = coalesce(var.tenancy_id, var.tenancy_ocid)
+  compartment_id = coalesce(
+    var.compartment_id, var.compartment_ocid,
+    var.tenancy_id, var.tenancy_ocid,
+  )
+
   bastion_public_ip                      = var.create_bastion_host == true ? module.bastion[0].bastion_public_ip : ""
   operator_private_ip                    = var.create_operator == true ? module.operator[0].operator_private_ip : ""
   operator_instance_principal_group_name = var.create_operator == true ? module.operator[0].operator_instance_principal_group_name : ""

--- a/main.tf
+++ b/main.tf
@@ -59,7 +59,7 @@ module "drg" {
 
 module "bastion" {
   source  = "oracle-terraform-modules/bastion/oci"
-  version = "3.1.1"
+  version = "3.1.2"
 
   tenancy_id     = local.tenancy_id
   compartment_id = local.compartment_id
@@ -108,7 +108,7 @@ module "bastion" {
 
 module "operator" {
   source  = "oracle-terraform-modules/operator/oci"
-  version = "3.1.0"
+  version = "3.1.1"
 
 
   # general oci parameters

--- a/main.tf
+++ b/main.tf
@@ -347,11 +347,13 @@ module "extensions" {
   # bastion
   create_bastion_host = var.create_bastion_host
   bastion_public_ip   = local.bastion_public_ip
+  bastion_user        = var.bastion_user
   bastion_state       = var.bastion_state
 
   # operator details
   create_operator                    = var.create_operator
   operator_private_ip                = local.operator_private_ip
+  operator_user                      = var.operator_user
   operator_state                     = var.operator_state
   operator_dynamic_group             = local.operator_instance_principal_group_name
   enable_operator_instance_principal = var.enable_operator_instance_principal

--- a/main.tf
+++ b/main.tf
@@ -400,7 +400,8 @@ module "extensions" {
   nodepool_upgrade_method = var.nodepool_upgrade_method
   node_pools_to_drain     = var.node_pools_to_drain
 
-  debug_mode = var.debug_mode
+  debug_mode        = var.debug_mode
+  update_kubeconfig = var.update_kubeconfig
 
   depends_on = [
     module.bastion,

--- a/main.tf
+++ b/main.tf
@@ -6,7 +6,7 @@ module "vcn" {
   version = "3.5.1"
 
   # general oci parameters
-  compartment_id = var.compartment_id
+  compartment_id = local.compartment_id
   label_prefix   = var.label_prefix
 
   # gateways
@@ -35,12 +35,11 @@ module "vcn" {
 }
 
 module "drg" {
-
   source  = "oracle-terraform-modules/drg/oci"
   version = "1.0.3"
 
   # general oci parameters
-  compartment_id = var.compartment_id
+  compartment_id = local.compartment_id
   label_prefix   = var.label_prefix
 
   # drg parameters
@@ -62,8 +61,8 @@ module "bastion" {
   source  = "oracle-terraform-modules/bastion/oci"
   version = "3.1.1"
 
-  tenancy_id     = var.tenancy_id
-  compartment_id = var.compartment_id
+  tenancy_id     = local.tenancy_id
+  compartment_id = local.compartment_id
 
   label_prefix = var.label_prefix
 
@@ -111,10 +110,10 @@ module "operator" {
   source  = "oracle-terraform-modules/operator/oci"
   version = "3.1.0"
 
-  tenancy_id = var.tenancy_id
 
   # general oci parameters
-  compartment_id = var.compartment_id
+  tenancy_id     = local.tenancy_id
+  compartment_id = local.compartment_id
   label_prefix   = var.label_prefix
 
   # networking
@@ -162,7 +161,7 @@ module "bastionsvc" {
   source = "./modules/bastionsvc"
 
   # general oci parameters
-  compartment_id = var.compartment_id
+  compartment_id = local.compartment_id
   label_prefix   = var.label_prefix
 
   # bastion service parameters
@@ -184,7 +183,7 @@ module "network" {
   source = "./modules/network"
 
   # general oci parameters
-  compartment_id = var.compartment_id
+  compartment_id = local.compartment_id
   label_prefix   = var.label_prefix
 
   # oke networking parameters
@@ -233,10 +232,10 @@ module "oke" {
   source = "./modules/oke"
 
   # provider
-  tenancy_id = var.tenancy_id
+  tenancy_id = local.tenancy_id
 
   # general oci parameters
-  compartment_id = var.compartment_id
+  compartment_id = local.compartment_id
   label_prefix   = var.label_prefix
 
   # ssh keys
@@ -301,8 +300,8 @@ module "storage" {
   source = "./modules/storage"
 
   # general oci parameters
-  tenancy_id          = var.tenancy_id
-  compartment_id      = var.compartment_id
+  tenancy_id          = local.tenancy_id
+  compartment_id      = local.compartment_id
   availability_domain = var.availability_domains["fss"]
   label_prefix        = var.label_prefix
 
@@ -330,10 +329,10 @@ module "extensions" {
   source = "./modules/extensions"
 
   # provider
-  tenancy_id = var.tenancy_id
+  tenancy_id = local.tenancy_id
 
   # general oci parameters
-  compartment_id = var.compartment_id
+  compartment_id = local.compartment_id
   label_prefix   = var.label_prefix
 
   # region parameters

--- a/modules/extensions/activeworker.tf
+++ b/modules/extensions/activeworker.tf
@@ -11,10 +11,10 @@ resource "null_resource" "check_worker_active" {
     private_key = local.ssh_private_key
     timeout     = "40m"
     type        = "ssh"
-    user        = "opc"
+    user        = var.operator_user
 
     bastion_host        = var.bastion_public_ip
-    bastion_user        = "opc"
+    bastion_user        = var.bastion_user
     bastion_private_key = local.ssh_private_key
   }
 

--- a/modules/extensions/calico.tf
+++ b/modules/extensions/calico.tf
@@ -7,10 +7,10 @@ resource "null_resource" "install_calico" {
     private_key = local.ssh_private_key
     timeout     = "40m"
     type        = "ssh"
-    user        = "opc"
+    user        = var.operator_user
 
     bastion_host        = var.bastion_public_ip
-    bastion_user        = "opc"
+    bastion_user        = var.bastion_user
     bastion_private_key = local.ssh_private_key
   }
 

--- a/modules/extensions/drain.tf
+++ b/modules/extensions/drain.tf
@@ -7,10 +7,10 @@ resource "null_resource" "drain_nodes" {
     private_key = local.ssh_private_key
     timeout     = "40m"
     type        = "ssh"
-    user        = "opc"
+    user        = var.operator_user
 
     bastion_host        = var.bastion_public_ip
-    bastion_user        = "opc"
+    bastion_user        = var.bastion_user
     bastion_private_key = local.ssh_private_key
   }
 

--- a/modules/extensions/gatekeeper.tf
+++ b/modules/extensions/gatekeeper.tf
@@ -7,10 +7,10 @@ resource "null_resource" "enable_gatekeeper" {
     private_key = local.ssh_private_key
     timeout     = "40m"
     type        = "ssh"
-    user        = "opc"
+    user        = var.operator_user
 
     bastion_host        = var.bastion_public_ip
-    bastion_user        = "opc"
+    bastion_user        = var.bastion_user
     bastion_private_key = local.ssh_private_key
   }
 

--- a/modules/extensions/iam.tf
+++ b/modules/extensions/iam.tf
@@ -55,10 +55,10 @@ resource "null_resource" "update_dynamic_group" {
     private_key = local.ssh_private_key
     timeout     = "40m"
     type        = "ssh"
-    user        = "opc"
+    user        = var.operator_user
 
     bastion_host        = var.bastion_public_ip
-    bastion_user        = "opc"
+    bastion_user        = var.bastion_user
     bastion_private_key = local.ssh_private_key
   }
 

--- a/modules/extensions/k8stools.tf
+++ b/modules/extensions/k8stools.tf
@@ -7,10 +7,10 @@ resource "null_resource" "install_k8stools_on_operator" {
     private_key = local.ssh_private_key
     timeout     = "40m"
     type        = "ssh"
-    user        = "opc"
+    user        = var.operator_user
 
     bastion_host        = var.bastion_public_ip
-    bastion_user        = "opc"
+    bastion_user        = var.bastion_user
     bastion_private_key = local.ssh_private_key
   }
 

--- a/modules/extensions/kubeconfig.tf
+++ b/modules/extensions/kubeconfig.tf
@@ -31,10 +31,10 @@ resource "null_resource" "write_kubeconfig_on_operator" {
     private_key = local.ssh_private_key
     timeout     = "40m"
     type        = "ssh"
-    user        = "opc"
+    user        = var.operator_user
 
     bastion_host        = var.bastion_public_ip
-    bastion_user        = "opc"
+    bastion_user        = var.bastion_user
     bastion_private_key = local.ssh_private_key
   }
 

--- a/modules/extensions/kubeconfig.tf
+++ b/modules/extensions/kubeconfig.tf
@@ -5,7 +5,21 @@ data "oci_containerengine_cluster_kube_config" "kube_config" {
   cluster_id = var.cluster_id
 }
 
+# Terraform doesn't support conditional dynamic blocks for lifecycle, so resource
+# is repeated with and without it based on update_kubeconfig boolean variable
+# Not ideal, but mitigates reported change on every apply
 resource "local_file" "kube_config_file" {
+  count           = var.update_kubeconfig ? 0 : 1
+  content         = data.oci_containerengine_cluster_kube_config.kube_config.content
+  filename        = "${path.root}/generated/kubeconfig"
+  file_permission = "0600"
+  lifecycle {
+    ignore_changes = [content]
+  }
+}
+
+resource "local_file" "kube_config_file_refresh" {
+  count           = var.update_kubeconfig == true ? 1 : 0
   content         = data.oci_containerengine_cluster_kube_config.kube_config.content
   filename        = "${path.root}/generated/kubeconfig"
   file_permission = "0600"
@@ -49,6 +63,10 @@ resource "null_resource" "write_kubeconfig_on_operator" {
       "mv $HOME/token_helper.sh $HOME/bin",
       "if [ -f \"$HOME/kubeconfig_set_credentials.sh\" ]; then bash \"$HOME/kubeconfig_set_credentials.sh\"; rm -f \"$HOME/kubeconfig_set_credentials.sh\";fi",
     ]
+  }
+
+  lifecycle {
+    ignore_changes = all
   }
 
   count = local.post_provisioning_ops == true ? 1 : 0

--- a/modules/extensions/locals.tf
+++ b/modules/extensions/locals.tf
@@ -28,4 +28,6 @@ locals {
   post_provisioning_ops = var.create_bastion_host == true && var.bastion_state == "RUNNING" && var.create_operator == true && var.operator_state == "RUNNING" && var.enable_operator_instance_principal == true ? true : false
 
   dynamic_group_rule_this_cluster = (var.use_cluster_encryption == true) ? "ALL {resource.type = 'cluster', resource.id = '${var.cluster_id}'}" : "null"
+
+  dynamic_group_prefix = (var.label_prefix == "none") ? "" : "${var.label_prefix}"
 }

--- a/modules/extensions/metricserver.tf
+++ b/modules/extensions/metricserver.tf
@@ -7,10 +7,10 @@ resource "null_resource" "enable_metric_server" {
     private_key = local.ssh_private_key
     timeout     = "40m"
     type        = "ssh"
-    user        = "opc"
+    user        = var.operator_user
 
     bastion_host        = var.bastion_public_ip
-    bastion_user        = "opc"
+    bastion_user        = var.bastion_user
     bastion_private_key = local.ssh_private_key
   }
 

--- a/modules/extensions/secrets.tf
+++ b/modules/extensions/secrets.tf
@@ -10,10 +10,10 @@ resource "null_resource" "secret" {
     private_key = local.ssh_private_key
     timeout     = "40m"
     type        = "ssh"
-    user        = "opc"
+    user        = var.operator_user
 
     bastion_host        = var.bastion_public_ip
-    bastion_user        = "opc"
+    bastion_user        = var.bastion_user
     bastion_private_key = local.ssh_private_key
   }
 

--- a/modules/extensions/serviceaccount.tf
+++ b/modules/extensions/serviceaccount.tf
@@ -7,10 +7,10 @@ resource "null_resource" "create_service_account" {
     private_key = local.ssh_private_key
     timeout     = "40m"
     type        = "ssh"
-    user        = "opc"
+    user        = var.operator_user
 
     bastion_host        = var.bastion_public_ip
-    bastion_user        = "opc"
+    bastion_user        = var.bastion_user
     bastion_private_key = local.ssh_private_key
   }
 

--- a/modules/extensions/variables.tf
+++ b/modules/extensions/variables.tf
@@ -138,3 +138,7 @@ variable "node_pools_to_drain" {
 variable "debug_mode" {
   type = bool
 }
+
+variable "update_kubeconfig" {
+  type    = bool
+}

--- a/modules/extensions/variables.tf
+++ b/modules/extensions/variables.tf
@@ -27,6 +27,8 @@ variable "create_bastion_host" {
 
 variable "bastion_public_ip" {}
 
+variable "bastion_user" {}
+
 variable "bastion_state" {}
 
 # operator
@@ -35,6 +37,8 @@ variable "create_operator" {
 }
 
 variable "operator_private_ip" {}
+
+variable "operator_user" {}
 
 variable "operator_state" {}
 

--- a/modules/network/nsgs.tf
+++ b/modules/network/nsgs.tf
@@ -103,26 +103,6 @@ resource "oci_core_network_security_group_security_rule" "cp_ingress_additional_
   }
 
   count = length(var.control_plane_allowed_cidrs)
-
-}
-
-resource "oci_core_network_security_group_security_rule" "cp_ingress_additional_cidrs_icmp" {
-  network_security_group_id = oci_core_network_security_group.cp.id
-  description               = "Allow additional CIDR block access to control plane. Required for kubectl/helm."
-  direction                 = "INGRESS"
-  protocol                  = local.icmp_protocol
-  source                    = element(var.control_plane_allowed_cidrs, count.index)
-  source_type               = "CIDR_BLOCK"
-
-  stateless = false
-
-  icmp_options {
-    type = 3
-    code = 4
-  }
-
-  count = length(var.control_plane_allowed_cidrs)
-
 }
 
 # workers nsg and rules

--- a/modules/oke/cluster.tf
+++ b/modules/oke/cluster.tf
@@ -74,6 +74,10 @@ resource "oci_containerengine_cluster" "k8s_cluster" {
     service_lb_subnet_ids = var.preferred_load_balancer == "public" ? [var.cluster_subnets["pub_lb"]] : [var.cluster_subnets["int_lb"]]
   }
 
+  lifecycle {
+    ignore_changes = [defined_tags, freeform_tags]
+  }
+
   vcn_id = var.vcn_id
 
 }

--- a/modules/oke/datasources.tf
+++ b/modules/oke/datasources.tf
@@ -2,7 +2,7 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl
 
 data "oci_identity_availability_domains" "ad_list" {
-  compartment_id = var.tenancy_id
+  compartment_id = var.compartment_id
 }
 
 data "oci_containerengine_node_pool_option" "node_pool_options" {

--- a/modules/oke/nodepools.tf
+++ b/modules/oke/nodepools.tf
@@ -118,7 +118,13 @@ resource "oci_containerengine_node_pool" "nodepools" {
   # do not destroy the node pool if the kubernetes version has changed as part of the upgrade
 
   lifecycle {
-    ignore_changes = [kubernetes_version]
+    ignore_changes = [
+      kubernetes_version,
+      defined_tags, # automatic tagging after apply
+      node_metadata["user_data"], # templated cloud-init
+      node_config_details["placement_configs"], # dynamic placement configs
+      node_source_details # dynamic image lookup
+    ]
   }
 
   # initial node labels for the different node pools

--- a/modules/storage/datasource.tf
+++ b/modules/storage/datasource.tf
@@ -3,7 +3,7 @@
 
 # query ADs
 data "oci_identity_availability_domain" "ad" {
-  compartment_id = var.tenancy_id
+  compartment_id = var.compartment_id
   ad_number      = var.availability_domain
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -77,15 +77,16 @@ output "ssh_to_bastion" {
   value       = "ssh -i ${var.ssh_private_key_path} opc@${local.bastion_public_ip}"
 }
 
+# Suppress reported output change on clean destroy
 output "kubeconfig" {
   description = "convenient command to set KUBECONFIG environment variable before running kubectl locally"
-  value       = "export KUBECONFIG=generated/kubeconfig"
+  value       = length(module.oke.cluster_id) == 0 ? null : "export KUBECONFIG=generated/kubeconfig"
 }
 
 output "bastion_service_instance_id" {
-  value = var.create_bastion_service == true ? module.bastionsvc[0].bastion_id : "null"
+  value = var.create_bastion_service == true ? module.bastionsvc[0].bastion_id : null
 }
 
 output "fss_id" {
-  value = var.create_fss == true ? module.storage[0].fss_id : "null"
+  value = var.create_fss == true ? module.storage[0].fss_id : null
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -69,12 +69,12 @@ output "operator_private_ip" {
 
 output "ssh_to_operator" {
   description = "convenient command to ssh to the operator host"
-  value       = "ssh -i ${var.ssh_private_key_path} -J opc@${local.bastion_public_ip} opc@${local.operator_private_ip}"
+  value       = "ssh${local.ssh_key_arg} -J opc@${local.bastion_public_ip} opc@${local.operator_private_ip}"
 }
 
 output "ssh_to_bastion" {
   description = "convenient command to ssh to the bastion host"
-  value       = "ssh -i ${var.ssh_private_key_path} opc@${local.bastion_public_ip}"
+  value       = "ssh${local.ssh_key_arg} opc@${local.bastion_public_ip}"
 }
 
 # Suppress reported output change on clean destroy

--- a/outputs.tf
+++ b/outputs.tf
@@ -69,12 +69,12 @@ output "operator_private_ip" {
 
 output "ssh_to_operator" {
   description = "convenient command to ssh to the operator host"
-  value       = "ssh${local.ssh_key_arg} -J opc@${local.bastion_public_ip} opc@${local.operator_private_ip}"
+  value       = "ssh${local.ssh_key_arg} -J ${var.bastion_user}@${local.bastion_public_ip} ${var.operator_user}@${local.operator_private_ip}"
 }
 
 output "ssh_to_bastion" {
   description = "convenient command to ssh to the bastion host"
-  value       = "ssh${local.ssh_key_arg} opc@${local.bastion_public_ip}"
+  value       = "ssh${local.ssh_key_arg} ${var.bastion_user}@${local.bastion_public_ip}"
 }
 
 # Suppress reported output change on clean destroy

--- a/terraform.tfvars.example
+++ b/terraform.tfvars.example
@@ -90,6 +90,7 @@ create_bastion_host = true
 bastion_access      = ["anywhere"]
 bastion_image_id    = "Autonomous"
 bastion_os_version  = "7.9"
+bastion_user        = "opc"
 bastion_shape = {
   shape            = "VM.Standard.E4.Flex",
   ocpus            = 1,
@@ -101,8 +102,9 @@ bastion_timezone = "Etc/UTC"
 bastion_type     = "public"
 upgrade_bastion  = false
 
-# Use an existing bastion with create_bastion_host = false
-bastion_public_ip = "" 
+# Use an existing bastion. If create_bastion_host = false and set
+# to non-empty string, will be used for SSH access into the VCN.
+bastion_public_ip = ""
 
 ## bastion notification
 enable_bastion_notification   = false
@@ -122,6 +124,7 @@ operator_image_id                  = "Oracle"
 enable_operator_instance_principal = true
 operator_nsg_ids                   = []
 operator_os_version                = "8"
+operator_user                      = "opc"
 operator_shape = {
   shape            = "VM.Standard.E4.Flex",
   ocpus            = 1,
@@ -131,6 +134,10 @@ operator_shape = {
 operator_state    = "RUNNING"
 operator_timezone = "Etc/UTC"
 upgrade_operator  = false
+
+# Use an existing operator. If create_operator = false and set
+# to non-empty string, will be used for k8s access within the VCN.
+operator_private_ip = ""
 
 # Operator in-transit encryption for the data volume's paravirtualized attachment.
 enable_operator_pv_encryption_in_transit = false

--- a/terraform.tfvars.example
+++ b/terraform.tfvars.example
@@ -101,6 +101,9 @@ bastion_timezone = "Etc/UTC"
 bastion_type     = "public"
 upgrade_bastion  = false
 
+# Use an existing bastion with create_bastion_host = false
+bastion_public_ip = "" 
+
 ## bastion notification
 enable_bastion_notification   = false
 bastion_notification_endpoint = ""

--- a/variables.tf
+++ b/variables.tf
@@ -250,6 +250,12 @@ variable "create_bastion_host" {
   type        = bool
 }
 
+variable "bastion_public_ip" {
+  default     = ""
+  description = "The IP address of an existing bastion host, if create_bastion_host: false."
+  type        = string
+}
+
 variable "bastion_access" {
   default     = ["anywhere"]
   description = "A list of CIDR blocks to which ssh access to the bastion host must be restricted. *anywhere* is equivalent to 0.0.0.0/0 and allows ssh access from anywhere."

--- a/variables.tf
+++ b/variables.tf
@@ -986,3 +986,9 @@ variable "debug_mode" {
   description = "Whether to turn on debug mode."
   type        = bool
 }
+
+variable "update_kubeconfig" {
+  default     = false
+  description = "Whether to refresh the generated kubeconfig file."
+  type        = bool
+}

--- a/variables.tf
+++ b/variables.tf
@@ -274,6 +274,12 @@ variable "bastion_os_version" {
   type        = string
 }
 
+variable "bastion_user" {
+  default     = "opc"
+  description = "User for SSH access through bastion host."
+  type        = string
+}
+
 variable "bastion_shape" {
   default = {
     shape            = "VM.Standard.E4.Flex",
@@ -412,6 +418,12 @@ variable "operator_os_version" {
   type        = string
 }
 
+variable "operator_user" {
+  default     = "opc"
+  description = "User for SSH access to operator host."
+  type        = string
+}
+
 variable "operator_shape" {
   default = {
     shape            = "VM.Standard.E4.Flex",
@@ -444,6 +456,12 @@ variable "upgrade_operator" {
   default     = true
   description = "Whether to upgrade the operator packages after provisioning. It’s useful to set this to false during development so the operator is provisioned faster."
   type        = bool
+}
+
+variable "operator_private_ip" {
+  default     = ""
+  description = "The IP address of an existing operator host, if create_operator: false."
+  type        = string
 }
 
 ## operator notification parameters

--- a/variables.tf
+++ b/variables.tf
@@ -34,27 +34,54 @@ variable "home_region" {
   type        = string
 }
 
+# Automatically populated by Resource Manager
 variable "region" {
   # List of regions: https://docs.cloud.oracle.com/iaas/Content/General/Concepts/regions.htm#ServiceAvailabilityAcrossRegions
   description = "The OCI region where OKE resources will be created."
   type        = string
 }
 
+# Overrides Resource Manager
 variable "tenancy_id" {
   description = "The tenancy id of the OCI Cloud Account in which to create the resources."
   type        = string
+  default     = ""
 }
 
+variable "tenancy_ocid" {
+  description = "A tenancy OCID automatically populated by Resource Manager."
+  type        = string
+  default     = ""
+}
+
+# Overrides Resource Manager
 variable "user_id" {
   description = "The id of the user that terraform will use to create the resources."
   type        = string
   default     = ""
 }
 
+# Automatically populated by Resource Manager
+variable "current_user_ocid" {
+  description = "A user OCID automatically populated by Resource Manager."
+  type        = string
+  default     = ""
+}
+
 # General OCI parameters
+
+# Overrides Resource Manager
 variable "compartment_id" {
   description = "The compartment id where to create all resources."
   type        = string
+  default     = ""
+}
+
+# Automatically populated by Resource Manager
+variable "compartment_ocid" {
+  description = "A compartment OCID automatically populated by Resource Manager."
+  type        = string
+  default     = ""
 }
 
 variable "label_prefix" {


### PR DESCRIPTION
## Summary
- Ignore lifecycle changes for automatic tagging and dynamic variables/templates
- Support variable names populated by [Resource Manager](https://docs.oracle.com/en-us/iaas/Content/ResourceManager/Concepts/terraformconfigresourcemanager.htm#configvar)
- Use specific compartment for AD listing in case different
- Use stable random suffix for dynamic group name (resolves #556)
- Fall back to provided bastion/operator addresses, SSH user (resolves #555)

## Related
Some lifecycle changes are reported from other modules:
https://github.com/oracle-terraform-modules/terraform-oci-operator/pull/68
https://github.com/oracle-terraform-modules/terraform-oci-operator/pull/69
https://github.com/oracle-terraform-modules/terraform-oci-bastion/pull/50

## Samples

### Before
Repeated apply:
```
# module.vcn[0].oci_core_service_gateway.service_gateway[0] will be updated in-place
~ resource "oci_core_service_gateway" "service_gateway" {
  ~ defined_tags   = {
      - "Oracle-Tags.CreatedBy" = "user" -> null
      - "Oracle-Tags.CreatedOn" = "2022-10-02T01:54:23.637Z" -> null
    }
```

Repeated destroy:
```
Changes to Outputs:
  - bastion_service_instance_id = "null" -> null
  - fss_id                      = "null" -> null
  - kubeconfig                  = "export KUBECONFIG=generated/kubeconfig" -> null

Destroy complete! Resources: 0 destroyed.
```

### After
Repeated apply:
```
No changes. Your infrastructure matches the configuration.

Terraform has compared your real infrastructure against your configuration and found no differences, so no changes are needed.

Apply complete! Resources: 0 added, 0 changed, 0 destroyed.
```

Repeated destroy:
```
Destroy complete! Resources: 59 destroyed.

terraform destroy

Changes to Outputs:

Destroy complete! Resources: 0 destroyed.
```