### PR TITLE
Update modules, support base64-encoded SSH key

### DIFF
--- a/docs/terraformoptions.adoc
+++ b/docs/terraformoptions.adoc
@@ -50,7 +50,7 @@ See {uri-oci-provider-config}[Terraform OCI Provider] or {uri-oci-rm-config}[Res
 |none
 
 |api_private_key
-|The contents of the private key file to use with OCI API. This takes precedence over private_key_path if both are specified in the provider. *Maybe required depending on your authentication method.* Use the heredoc format if you are specifying the key with this variable.
+|The contents of the private key file to use with OCI API. This takes precedence over private_key_path if both are specified in the provider. *Maybe required depending on your authentication method.* Use the heredoc format if you are specifying the key with this variable. This value may be optionally base64-encoded.
 |<<EOT
 -----BEGIN RSA PRIVATE KEY-----
 content+of+api+key
@@ -123,7 +123,7 @@ region = "ap-sydney-1"
 |Default
 
 |ssh_private_key
-|The contents of the private ssh key file. Use the heredoc format if you are specifying the private key.
+|The contents of the private ssh key file. Use the heredoc format if you are specifying the private key. This value may be optionally base64-encoded.
 |
 <<EOT
 -----BEGIN RSA PRIVATE KEY-----

--- a/locals.tf
+++ b/locals.tf
@@ -7,6 +7,14 @@ locals {
     var.compartment_id, var.compartment_ocid,
     var.tenancy_id, var.tenancy_ocid,
   )
+  user_id = coalesce(var.user_id, var.current_user_ocid)
+
+  api_private_key = (
+    var.api_private_key != ""
+    ? try(base64decode(var.api_private_key), var.api_private_key)
+    : var.api_private_key_path != ""
+      ? file(var.api_private_key_path)
+      : null)
 
   bastion_public_ip                      = var.create_bastion_host == true ? module.bastion[0].bastion_public_ip : var.bastion_public_ip != "" ? var.bastion_public_ip: ""
   operator_private_ip                    = var.create_operator == true ? module.operator[0].operator_private_ip : var.operator_private_ip !="" ? var.operator_private_ip: ""

--- a/main.tf
+++ b/main.tf
@@ -3,7 +3,7 @@
 
 module "vcn" {
   source  = "oracle-terraform-modules/vcn/oci"
-  version = "3.5.1"
+  version = "3.5.2"
 
   # general oci parameters
   compartment_id = local.compartment_id
@@ -59,7 +59,7 @@ module "drg" {
 
 module "bastion" {
   source  = "oracle-terraform-modules/bastion/oci"
-  version = "3.1.2"
+  version = "3.1.3"
 
   tenancy_id     = local.tenancy_id
   compartment_id = local.compartment_id
@@ -108,7 +108,7 @@ module "bastion" {
 
 module "operator" {
   source  = "oracle-terraform-modules/operator/oci"
-  version = "3.1.1"
+  version = "3.1.2"
 
 
   # general oci parameters

--- a/main.tf
+++ b/main.tf
@@ -108,7 +108,7 @@ module "bastion" {
 
 module "operator" {
   source  = "oracle-terraform-modules/operator/oci"
-  version = "3.1.2"
+  version = "3.1.3"
 
 
   # general oci parameters

--- a/modules/extensions/locals.tf
+++ b/modules/extensions/locals.tf
@@ -2,7 +2,13 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl
 
 locals {
-  ssh_private_key = var.ssh_private_key != "" ? var.ssh_private_key : var.ssh_private_key_path != "none" ? file(var.ssh_private_key_path) : null
+  ssh_private_key = (
+    var.ssh_private_key != ""
+    ? try(base64decode(var.ssh_private_key), var.ssh_private_key)
+    : var.ssh_private_key_path != "none"
+      ? file(var.ssh_private_key_path)
+      : null)
+
   node_pools_size_list = [
     for node_pool in data.oci_containerengine_node_pools.all_node_pools.node_pools :
     node_pool.node_config_details[0].size

--- a/provider.tf.example
+++ b/provider.tf.example
@@ -1,0 +1,16 @@
+provider "oci" {
+  fingerprint      = var.api_fingerprint
+  private_key      = var.api_private_key
+  region           = var.region
+  tenancy_ocid     = local.tenancy_id
+  user_ocid        = local.user_id
+}
+
+provider "oci" {
+  fingerprint      = var.api_fingerprint
+  private_key      = var.api_private_key
+  region           = var.home_region
+  tenancy_ocid     = local.tenancy_id
+  user_ocid        = local.user_id
+  alias = "home"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -10,7 +10,7 @@ variable "api_fingerprint" {
 
 variable "api_private_key" {
   default     = ""
-  description = "The contents of the private key file to use with OCI API. This takes precedence over private_key_path if both are specified in the provider."
+  description = "The contents of the private key file to use with OCI API, optionally base64-encoded. This takes precedence over private_key_path if both are specified in the provider."
   sensitive   = true
   type        = string
 }
@@ -93,7 +93,7 @@ variable "label_prefix" {
 # ssh keys
 variable "ssh_private_key" {
   default     = ""
-  description = "The contents of the private ssh key file."
+  description = "The contents of the private ssh key file, optionally base64-encoded."
   sensitive   = true
   type        = string
 }


### PR DESCRIPTION
* Update modules: vcn 3.5.2, bastion 3.1.3, operator 3.1.2
* Support base64-encoded SSH, API keys
* Add `provider.tf.example` for convenience