### PR TITLE
feat: Remove local kubeconfig file creation and `update_kubeconfig` input var

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -7,6 +7,65 @@ All notable changes to this project are documented in this file.
 
 The format is based on {uri-changelog}[Keep a Changelog].
 
+== 4.2.14 (not released)
+=== Changes
+* feat: Removed local kubeconfig file creation and `update_kubeconfig` input variable by @slok in #602
+
+== 4.2.13
+=== Changes
+* network: use label_prefix in subnets dns_label by @ooraini in #590
+* chore: cosmetic changes to load balancer subnet names and labels by @hyder in #592
+* feat: upgraded operator module to 3.1.4 by @hyder in #598
+
+== 4.2.12
+=== Changes
+* fix: Provide empty fallback value for user_id local by @devoncrouse in #588
+
+== 4.2.11
+=== Changes
+* Update modules, support base64-encoded SSH key by @devoncrouse in #587
+* Update operator module version to 3.1.3 by @devoncrouse
+
+== 4.2.10
+=== Changes
+* fix: fixes condition when bastion/operator are set to false and no ip addresses for them are provided by @hyder in #585
+
+== 4.2.9
+=== Changes
+* fix icmp in cp_ingress_additional_cidrs nsg rule by @ooraini in #572
+* fix: Ignore lifecycle changes, support Resource Manager variables by @devoncrouse in #583
+
+== 4.2.8
+=== Changes
+* feat: Support existing VCN in other compartment by @chrisbulgaria in #564
+* fix: Add missing NSG rules for VCN-Native Pod Networking by @devoncrouse in #563
+* fix: error referencing pod nsgs by @hyder in #567
+* fix: added lifecycle meta-argument on default security list by @hyder in #565
+* fix: handle pod nsg id/ids issue by @hyder in #570
+* feat: Added option to specify ADs in node pools by @12345ieee in #520
+* feat: added tagging using defined tags #560 by @valireds in #562
+* fix: Check for existing element in freeform and defined tags by @hyder in #574
+* fix: handle placement_ads for 1 AD regions. by @hyder in #581
+
+== 4.2.7
+=== Changes
+* fix: bug fix in helm installation script by @hyder in #558
+* feat: added freeform tagging for pvc and nodepools by @hyder in #552
+* Updated docs for cloud-init by @33percent in #554
+
+== 4.2.6
+=== Changes
+* feat: added kubectx and kubens by @hyder in #548
+* Support for VCN Native Pod Networking by @hyder in #542
+* feat: added output for all nsg ids in a map. Previous nsg outputs are deprecated by @hyder in #550
+
+== 4.2.5
+=== Changes
+* docs: Reuse VCN by @karthicgit in #524
+* docs: updated instruction for when using the remote module from by @hyder in #531
+* docs: updated architecture diagrams by @hyder in #533
+* feat adopt new DRG module by @snafuz in #546
+
 == 4.2.4
 === Changes
 * feat: added support for OKE images for faster worker node provisioning by @hyder in #529

--- a/docs/instructions.adoc
+++ b/docs/instructions.adoc
@@ -231,19 +231,47 @@ N.B. In order for kubeconfig to be created on the operator host, you need to lin
 
 An alias "*k*" will be created for kubectl on the operator host. 
 
-If you would like to use kubectl locally, {uri-install-kubectl}[install kubectl]. Then, set the KUBECONFIG to the config file path. The kubeconfig file will be saved generated locally under the folder *generated*:
+If you would like to use kubectl locally, {uri-install-kubectl}[install kubectl]. Then, set the KUBECONFIG to the config file path.
 
 ----
-export KUBECONFIG=generated/kubeconfig
+export KUBECONFIG=path/to/kubeconfig
 ----
+
+To be able to get the kubeconfig file, you will need to get the credentials with terraform and store in the preferred storage format (e.g: file, vault, bucket...). Example:
+
+[source,hcl]
+----
+# OKE cluster creation.
+module "oke_my_cluster" {
+#...
+}
+
+# Obtain cluster Kubeconfig.
+data "oci_containerengine_cluster_kube_config" "kube_config" {
+  cluster_id = module.oke_my_cluster.cluster_id
+}
+
+# Store kubeconfig in vault.
+resource "vault_generic_secret" "kube_config" {
+  path = "my/cluster/path/kubeconfig"
+  data_json = jsonencode({
+    "data" : data.oci_containerengine_cluster_kube_config.kube_config.content
+  })
+}
+
+# Store kubeconfig in file.
+resource "local_file" "kube_config" {
+  content         = data.oci_containerengine_cluster_kube_config.kube_config.content
+  filename        = "/tmp/kubeconfig"
+  file_permission = "0600"
+}
+----
+
 
 ****
 *Ensure you install the same kubectl version as the OKE Kubernetes version for compatibility.*
 ****
 
-****
-*To refresh the generated kubeconfig, run `terraform apply` with `update_kubeconfig: true`.*
-****
 
 == Creating a Secret for OCIR
 

--- a/main.tf
+++ b/main.tf
@@ -402,8 +402,7 @@ module "extensions" {
   nodepool_upgrade_method = var.nodepool_upgrade_method
   node_pools_to_drain     = var.node_pools_to_drain
 
-  debug_mode        = var.debug_mode
-  update_kubeconfig = var.update_kubeconfig
+  debug_mode = var.debug_mode
 
   depends_on = [
     module.bastion,

--- a/modules/extensions/kubeconfig.tf
+++ b/modules/extensions/kubeconfig.tf
@@ -1,30 +1,6 @@
 # Copyright 2017, 2021 Oracle Corporation and/or affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl
 
-data "oci_containerengine_cluster_kube_config" "kube_config" {
-  cluster_id = var.cluster_id
-}
-
-# Terraform doesn't support conditional dynamic blocks for lifecycle, so resource
-# is repeated with and without it based on update_kubeconfig boolean variable
-# Not ideal, but mitigates reported change on every apply
-resource "local_file" "kube_config_file" {
-  count           = var.update_kubeconfig ? 0 : 1
-  content         = data.oci_containerengine_cluster_kube_config.kube_config.content
-  filename        = "${path.root}/generated/kubeconfig"
-  file_permission = "0600"
-  lifecycle {
-    ignore_changes = [content]
-  }
-}
-
-resource "local_file" "kube_config_file_refresh" {
-  count           = var.update_kubeconfig == true ? 1 : 0
-  content         = data.oci_containerengine_cluster_kube_config.kube_config.content
-  filename        = "${path.root}/generated/kubeconfig"
-  file_permission = "0600"
-}
-
 resource "null_resource" "write_kubeconfig_on_operator" {
   connection {
     host        = var.operator_private_ip

--- a/modules/extensions/variables.tf
+++ b/modules/extensions/variables.tf
@@ -70,7 +70,7 @@ variable "cluster_kms_key_id" {}
 variable "cluster_kms_dynamic_group_id" {}
 
 variable "create_policies" {
-  type        = bool
+  type = bool
 }
 
 # ocir
@@ -143,8 +143,4 @@ variable "node_pools_to_drain" {
 
 variable "debug_mode" {
   type = bool
-}
-
-variable "update_kubeconfig" {
-  type    = bool
 }

--- a/variables.tf
+++ b/variables.tf
@@ -174,10 +174,10 @@ variable "drg_display_name" {
   default     = "drg"
 }
 
-variable "drg_id"{
+variable "drg_id" {
   description = "ID of an external created Dynamic Routing Gateway to be attached to the VCN"
-  type = string
-  default = null
+  type        = string
+  default     = null
 }
 
 variable "internet_gateway_route_rules" {
@@ -547,7 +547,7 @@ variable "cni_type" {
   validation {
     condition     = contains(["flannel", "npn"], var.cni_type)
     error_message = "Accepted values are flannel or npn."
-  }  
+  }
 }
 
 variable "control_plane_type" {
@@ -700,7 +700,7 @@ variable "node_pool_image_type" {
   validation {
     condition     = contains(["custom", "oke", "platform"], var.node_pool_image_type)
     error_message = "Accepted values are custom, oke, platform."
-  }  
+  }
 }
 
 variable "node_pool_name_prefix" {
@@ -986,11 +986,11 @@ variable "freeform_tags" {
       role        = "operator"
     }
     oke = {
-      
+
       cluster = {
         environment = "dev"
       }
-      
+
       persistent_volume = {
         environment = "dev"
       }
@@ -1017,17 +1017,17 @@ variable "defined_tags" {
     # add more tags in each as desired
     vcn = {}
     oke = {
-      cluster = {}
+      cluster           = {}
       persistent_volume = {}
-      service_lb = {}
-      node_pool = {}
-      node = {}
+      service_lb        = {}
+      node_pool         = {}
+      node              = {}
     }
   }
   description = "Tags to apply to different resources."
   type = object({
-    vcn      = map(any),
-    oke      = map(any)
+    vcn = map(any),
+    oke = map(any)
   })
 }
 
@@ -1035,11 +1035,5 @@ variable "defined_tags" {
 variable "debug_mode" {
   default     = false
   description = "Whether to turn on debug mode."
-  type        = bool
-}
-
-variable "update_kubeconfig" {
-  default     = false
-  description = "Whether to refresh the generated kubeconfig file."
   type        = bool
 }


### PR DESCRIPTION
Fixes #601 

This PR removes the creation of a local kubeconfig file and adds instructions so, users select how it wants to manage the kubeconfig information data.

Also removes the `update_kubeconfig` flag as isn't required anymore.

Note: I don't know where to add the changelog changes for unreleased ones.