### PR TITLE
feat: Support disabled DNS record assignment for OKE subnets

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -10,6 +10,8 @@ The format is based on {uri-changelog}[Keep a Changelog].
 == 4.2.14 (not released)
 === Changes
 * feat: Removed local kubeconfig file creation and `update_kubeconfig` input variable by @slok in #602
+* feat: Support disabled DNS record assignment for OKE subnets by @devoncrouse in #606
+* fix: Fix misspelling of "gatekeeper" from "gatekeeeper" by @devoncrouse in #606
 
 == 4.2.13
 === Changes

--- a/docs/configuration.adoc
+++ b/docs/configuration.adoc
@@ -137,8 +137,8 @@ The networking parameters concern the VCN and the subnets network configuration 
 You can leave most of the default options. However, you may want to change the following parameters:
 
 * assign_dns: disable DNS resolution of hostnames if `false`. Defaults to `true`.
-* vcn_dns_label: this is the internal dns domain for resources created
-* vcn_name: this is the name of the vcn that will be appended to the label prefix, or null to disable DNS resolution of hostnames in the VCN.
+* vcn_dns_label: this is the internal dns domain for resources created, or null to disable DNS resolution of hostnames in the VCN.
+* vcn_name: this is the name of the vcn that will be appended to the label prefix.
 
 ****
 If you need to change the default VCN's CIDR, note the following:

--- a/docs/configuration.adoc
+++ b/docs/configuration.adoc
@@ -134,10 +134,11 @@ The list of regions can be found {uri-oci-region}[here].
 
 The networking parameters concern the VCN and the subnets network configuration as well as whether to enable some specific features such as the NAT Gateway.
 
-You can leave most of the default options. However, you may want to change the following 2 parameters:
+You can leave most of the default options. However, you may want to change the following parameters:
 
+* assign_dns: disable DNS resolution of hostnames if `false`. Defaults to `true`.
 * vcn_dns_label: this is the internal dns domain for resources created
-* vcn_name: this is the name of the vcn that will be appended to the label prefix
+* vcn_name: this is the name of the vcn that will be appended to the label prefix, or null to disable DNS resolution of hostnames in the VCN.
 
 ****
 If you need to change the default VCN's CIDR, note the following:

--- a/docs/quickstart.adoc
+++ b/docs/quickstart.adoc
@@ -122,7 +122,7 @@ terraform {
 module "oke" {
   source  = "oracle-terraform-modules/oke/oci"
   version = "4.2.4"
-  # insert the 9 required variables here
+  # insert required variables here
 }
 ----
 
@@ -144,7 +144,6 @@ module "oke" {
   home_region                           =   var.home_region
   region                                =   var.region
 
-  vcn_dns_label                         =   var.vcn_dns_label
   vcn_name                              =   var.vcn_name
 
   create_bastion_host                   =   var.create_bastion_host

--- a/docs/terraformoptions.adoc
+++ b/docs/terraformoptions.adoc
@@ -786,8 +786,11 @@ node_pools = {
     memory           = 32,
     node_pool_size   = 1,
     boot_volume_size = 150,
-  } 
-} 
+  }
+  np2 = { shape = "VM.Standard.E4.Flex", ocpus = 1, memory = 16, node_pool_size = 1, boot_volume_size = 150, label = { app = "frontend", pool = "np1" } }
+  np3 = { shape = "VM.Standard.E2.2", node_pool_size = 2, boot_volume_size = 150 }
+  np4 = { shape = "VM.Standard.E2.2", node_pool_size = 1 }
+}
 |{}
 
 |node_pool_image_id

--- a/docs/terraformoptions.adoc
+++ b/docs/terraformoptions.adoc
@@ -1048,7 +1048,7 @@ Refer to {uri-topology}[topology] for more thorough examples.
 |true/false
 |false
 
-|gatekeeeper_version
+|gatekeeper_version
 |version of {uri-openpolicyagent-gatekeeper}[Gatekeeper].
 |
 |3.7

--- a/docs/terraformoptions.adoc
+++ b/docs/terraformoptions.adoc
@@ -251,7 +251,7 @@ EOT
 |`10.0.0.0/16`
 
 |vcn_dns_label
-|The internal DNS domain for resources created and prepended to "oraclevcn.com" which is the VCN-internal domain name. *Required*
+|The internal DNS domain for resources created and prepended to "oraclevcn.com" which is the VCN-internal domain name. DNS resolution of hostnames in the VCN is disabled when null.
 |
 |oke
 

--- a/main.tf
+++ b/main.tf
@@ -3,7 +3,7 @@
 
 module "vcn" {
   source  = "oracle-terraform-modules/vcn/oci"
-  version = "3.5.2"
+  version = "3.5.3"
 
   # general oci parameters
   compartment_id = local.compartment_id

--- a/main.tf
+++ b/main.tf
@@ -1,4 +1,4 @@
-# Copyright 2017, 2021 Oracle Corporation and/or affiliates.
+# Copyright 2017, 2022 Oracle Corporation and/or affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl
 
 module "vcn" {
@@ -388,7 +388,7 @@ module "extensions" {
 
   #Gatekeeper
   enable_gatekeeper   = var.enable_gatekeeper
-  gatekeeeper_version = var.gatekeeeper_version
+  gatekeeper_version = var.gatekeeper_version
 
   # service account
   create_service_account               = var.create_service_account

--- a/main.tf
+++ b/main.tf
@@ -25,7 +25,7 @@ module "vcn" {
 
   # vcn
   vcn_cidrs                    = var.vcn_cidrs
-  vcn_dns_label                = var.vcn_dns_label
+  vcn_dns_label                = var.assign_dns ? var.vcn_dns_label : null
   vcn_name                     = var.vcn_name
   lockdown_default_seclist     = var.lockdown_default_seclist
   internet_gateway_route_rules = var.internet_gateway_route_rules
@@ -187,6 +187,7 @@ module "network" {
   label_prefix   = var.label_prefix
 
   # oke networking parameters
+  assign_dns   = var.assign_dns
   ig_route_id  = local.ig_route_id
   nat_route_id = local.nat_route_id
   subnets      = var.subnets
@@ -307,6 +308,7 @@ module "storage" {
 
   # FSS network information
   subnets      = var.subnets
+  assign_dns   = var.assign_dns
   vcn_id       = local.vcn_id
   nat_route_id = local.nat_route_id
 

--- a/modules/extensions/scripts/install_gatekeeper.template.sh
+++ b/modules/extensions/scripts/install_gatekeeper.template.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
-# Copyright 2021 Oracle Corporation and/or affiliates.
+# Copyright 2021, 2022 Oracle Corporation and/or affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl
 
 if [ ! -f .gatekeeper_completed ]; then
 
   echo "Installing Open Policy Agent Gatekeeper"
-  kubectl apply -f https://raw.githubusercontent.com/open-policy-agent/gatekeeper/release-${gatekeeeper_version}/deploy/gatekeeper.yaml > /dev/null 2>&1
+  kubectl apply -f https://raw.githubusercontent.com/open-policy-agent/gatekeeper/release-${gatekeeper_version}/deploy/gatekeeper.yaml > /dev/null 2>&1
 
   touch .gatekeeper_completed
 fi

--- a/modules/extensions/templates.tf
+++ b/modules/extensions/templates.tf
@@ -1,4 +1,4 @@
-# Copyright 2017, 2021 Oracle Corporation and/or affiliates.
+# Copyright 2017, 2022 Oracle Corporation and/or affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl
 
 locals {
@@ -60,7 +60,7 @@ locals {
   gatekeeper_template = templatefile("${path.module}/scripts/install_gatekeeper.template.sh",
     {
       enable_gatekeeper   = var.enable_gatekeeper
-      gatekeeeper_version = var.gatekeeeper_version
+      gatekeeper_version = var.gatekeeper_version
     }
   )
 

--- a/modules/extensions/variables.tf
+++ b/modules/extensions/variables.tf
@@ -103,7 +103,7 @@ variable "enable_gatekeeper" {
   default = false
 }
 
-variable "gatekeeeper_version" {
+variable "gatekeeper_version" {
   type = string
 
 }

--- a/modules/network/subnets.tf
+++ b/modules/network/subnets.tf
@@ -5,7 +5,7 @@ resource "oci_core_subnet" "cp" {
   cidr_block                 = local.cp_subnet
   compartment_id             = var.compartment_id
   display_name               = var.label_prefix == "none" ? "control-plane" : "${var.label_prefix}-control-plane"
-  dns_label                  = var.label_prefix == "none" ? "cp" : "${var.label_prefix}cp"
+  dns_label                  = var.assign_dns ? var.label_prefix == "none" ? "cp" : "${var.label_prefix}cp" : null
   prohibit_public_ip_on_vnic = var.control_plane_type == "private" ? true : false
   route_table_id             = var.control_plane_type == "private" ? var.nat_route_id : var.ig_route_id
   security_list_ids          = [oci_core_security_list.control_plane_seclist.id]
@@ -20,7 +20,7 @@ resource "oci_core_subnet" "workers" {
   cidr_block                 = local.workers_subnet
   compartment_id             = var.compartment_id
   display_name               = var.label_prefix == "none" ? "workers" : "${var.label_prefix}-workers"
-  dns_label                  = var.label_prefix == "none" ? "workers" : "${var.label_prefix}wo"
+  dns_label                  = var.assign_dns ? var.label_prefix == "none" ? "workers" : "${var.label_prefix}wo" : null
   prohibit_public_ip_on_vnic = var.worker_type == "private" ? true : false
   route_table_id             = var.worker_type == "private" ? var.nat_route_id : var.ig_route_id
   vcn_id                     = var.vcn_id
@@ -34,7 +34,7 @@ resource "oci_core_subnet" "pods" {
   cidr_block                 = local.pods_subnet
   compartment_id             = var.compartment_id
   display_name               = var.label_prefix == "none" ? "pods" : "${var.label_prefix}-pods"
-  dns_label                  = var.label_prefix == "none" ? "pods" : "${var.label_prefix}po"
+  dns_label                  = var.assign_dns ? var.label_prefix == "none" ? "pods" : "${var.label_prefix}po" : null
   prohibit_public_ip_on_vnic = true
   route_table_id             = var.nat_route_id
   vcn_id                     = var.vcn_id
@@ -50,7 +50,7 @@ resource "oci_core_subnet" "int_lb" {
   cidr_block                 = local.int_lb_subnet
   compartment_id             = var.compartment_id
   display_name               = var.label_prefix == "none" ? "int-lb" : "${var.label_prefix}-int-lb"
-  dns_label                  = var.label_prefix == "none" ? "intlb" : "${var.label_prefix}ilb"
+  dns_label                  = var.assign_dns ? var.label_prefix == "none" ? "intlb" : "${var.label_prefix}ilb" : null
   prohibit_public_ip_on_vnic = true
   route_table_id             = var.nat_route_id
   vcn_id                     = var.vcn_id
@@ -66,11 +66,10 @@ resource "oci_core_subnet" "pub_lb" {
   cidr_block                 = local.pub_lb_subnet
   compartment_id             = var.compartment_id
   display_name               = var.label_prefix == "none" ? "pub-lb" : "${var.label_prefix}-pub-lb"
-  dns_label                  = var.label_prefix == "none" ? "publb" : "${var.label_prefix}plb"
+  dns_label                  = var.assign_dns ? var.label_prefix == "none" ? "publb" : "${var.label_prefix}plb" : null
   prohibit_public_ip_on_vnic = false
   route_table_id             = var.ig_route_id
-  # security_list_ids          = [oci_core_security_list.pub_lb_seclist[0].id]
-  vcn_id = var.vcn_id
+  vcn_id                     = var.vcn_id
 
   lifecycle {
     ignore_changes = [dns_label]

--- a/modules/network/variables.tf
+++ b/modules/network/variables.tf
@@ -1,4 +1,4 @@
-# Copyright 2017, 2021 Oracle Corporation and/or affiliates.
+# Copyright 2017, 2022 Oracle Corporation and/or affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl
 
 # general oci parameters

--- a/modules/network/variables.tf
+++ b/modules/network/variables.tf
@@ -47,6 +47,10 @@ variable "allow_worker_ssh_access" {
   type = bool
 }
 
+variable "assign_dns" {
+  type = bool
+}
+
 variable "worker_type" {}
 
 # load balancers

--- a/modules/storage/subnet.tf
+++ b/modules/storage/subnet.tf
@@ -3,7 +3,7 @@ resource "oci_core_subnet" "fss" {
   cidr_block                 = local.fss_subnet
   compartment_id             = var.compartment_id
   display_name               = var.label_prefix == "none" ? "fss" : "${var.label_prefix}-fss"
-  dns_label                  = "fss"
+  dns_label                  = var.assign_dns ? "fss" : null
   prohibit_public_ip_on_vnic = true
   route_table_id             = var.nat_route_id
   vcn_id                     = var.vcn_id

--- a/modules/storage/variables.tf
+++ b/modules/storage/variables.tf
@@ -16,6 +16,10 @@ variable "subnets" {
   type = map(any)
 }
 
+variable "assign_dns" {
+  type = bool
+}
+
 variable "vcn_id" {
   type        = string
   description = "(optional) describe your variable"

--- a/terraform.tfvars.example
+++ b/terraform.tfvars.example
@@ -2,7 +2,7 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl
 
 # Identity and access parameters
-api_fingerprint      = ""
+api_fingerprint = ""
 # api_private_key      = <<EOT
 #-----BEGIN RSA PRIVATE KEY-----
 #content+of+api+key
@@ -12,17 +12,17 @@ api_fingerprint      = ""
 api_private_key_path = ""
 
 home_region = "us-ashburn-1"
-region = "us-phoenix-1"
+region      = "us-phoenix-1"
 
-tenancy_id           = ""
-user_id              = ""
+tenancy_id = ""
+user_id    = ""
 
 # general oci parameters
 compartment_id = ""
 label_prefix   = "dev"
 
 # ssh keys
-ssh_private_key      = ""
+ssh_private_key = ""
 # ssh_private_key    = <<EOT
 #-----BEGIN RSA PRIVATE KEY-----
 #content+of+api+key
@@ -34,20 +34,17 @@ ssh_private_key_path = "~/.ssh/id_rsa"
 # ssh_public_key_path = "~/.ssh/id_rsa.pub"
 
 # networking
-
-assign_dns = true
-
 create_drg       = false
 drg_display_name = "drg"
 drg_id           = null
 
 internet_gateway_route_rules = [
-#   {
-#     destination       = "192.168.0.0/16" # Route Rule Destination CIDR
-#     destination_type  = "CIDR_BLOCK"     # only CIDR_BLOCK is supported at the moment
-#     network_entity_id = "drg"            # for internet_gateway_route_rules input variable, you can use special strings "drg", "internet_gateway" or pass a valid OCID using string or any Named Values
-#     description       = "Terraformed - User added Routing Rule: To drg provided to this module. drg_id, if available, is automatically retrieved with keyword drg"
-#   },
+  #   {
+  #     destination       = "192.168.0.0/16" # Route Rule Destination CIDR
+  #     destination_type  = "CIDR_BLOCK"     # only CIDR_BLOCK is supported at the moment
+  #     network_entity_id = "drg"            # for internet_gateway_route_rules input variable, you can use special strings "drg", "internet_gateway" or pass a valid OCID using string or any Named Values
+  #     description       = "Terraformed - User added Routing Rule: To drg provided to this module. drg_id, if available, is automatically retrieved with keyword drg"
+  #   },
 ]
 
 local_peering_gateways = {}
@@ -55,12 +52,12 @@ local_peering_gateways = {}
 lockdown_default_seclist = true
 
 nat_gateway_route_rules = [
-#   {
-#     destination       = "192.168.0.0/16" # Route Rule Destination CIDR
-#     destination_type  = "CIDR_BLOCK"     # only CIDR_BLOCK is supported at the moment
-#     network_entity_id = "drg"            # for nat_gateway_route_rules input variable, you can use special strings "drg", "nat_gateway" or pass a valid OCID using string or any Named Values
-#     description       = "Terraformed - User added Routing Rule: To drg provided to this module. drg_id, if available, is automatically retrieved with keyword drg"
-#   },
+  #   {
+  #     destination       = "192.168.0.0/16" # Route Rule Destination CIDR
+  #     destination_type  = "CIDR_BLOCK"     # only CIDR_BLOCK is supported at the moment
+  #     network_entity_id = "drg"            # for nat_gateway_route_rules input variable, you can use special strings "drg", "nat_gateway" or pass a valid OCID using string or any Named Values
+  #     description       = "Terraformed - User added Routing Rule: To drg provided to this module. drg_id, if available, is automatically retrieved with keyword drg"
+  #   },
 ]
 
 nat_gateway_public_ip_id = "none"
@@ -76,6 +73,7 @@ subnets = {
   fss      = { netnum = 18, newbits = 11 }
 }
 
+assign_dns                   = true
 create_vcn                   = true
 vcn_cidrs                    = ["10.0.0.0/16"]
 vcn_dns_label                = "oke"
@@ -180,26 +178,26 @@ pods_cidr                    = "10.244.0.0/16"
 services_cidr                = "10.96.0.0/16"
 
 ## oke cluster kms integration
-use_cluster_encryption  = false
-cluster_kms_key_id      = ""
-create_policies = true
+use_cluster_encryption = false
+cluster_kms_key_id     = ""
+create_policies        = true
 
 ## oke cluster container image policy and keys
-use_signed_images = false
+use_signed_images  = false
 image_signing_keys = []
 
 # node pools
-check_node_active = "all"
+check_node_active               = "all"
 enable_pv_encryption_in_transit = false
 node_pools = {
   # Basic node pool
-  np1 = {
-    shape            = "VM.Standard.E4.Flex",
-    ocpus            = 2,
-    memory           = 32,
-    node_pool_size   = 1,
-    boot_volume_size = 150,
-  }
+  #np1 = {
+  #  shape            = "VM.Standard.E4.Flex",
+  #  ocpus            = 2,
+  #  memory           = 32,
+  #  node_pool_size   = 1,
+  #  boot_volume_size = 150,
+  #}
   # # node pool with initial node labels
   # np2 = {
   #   shape            = "VM.Standard.E4.Flex",
@@ -228,15 +226,6 @@ node_pools = {
   #   boot_volume_size      = 150,
   #   nodepool_defined_tags = { "cn.environment" = "prod" },
   #   node_defined_tags     = { "cn.environment" = "prod" },
-  # }
-  # # node pool with placement ads
-  # np5 = {
-  #   shape            = "VM.Standard.E4.Flex",
-  #   ocpus            = 2,
-  #   memory           = 32,
-  #   node_pool_size   = 1,
-  #   boot_volume_size = 150,
-  #   placement_ads    = [1]
   # }
   # # node pool using ARM Flex shape
   # np6 = {
@@ -270,17 +259,12 @@ node_pools = {
   #   node_pool_size   = 1,
   #   boot_volume_size = 150,
   # }
-  # # node pool using BM.GPU3.8
-  # np10 = {
-  #   shape            = "BM.GPU3.8",
-  #   node_pool_size   = 1,
-  #   boot_volume_size = 150,
-  # }
-  # # node pool using BM.GPU4.8
+  # # node pool using BM.GPU4.8 and availability domain placement
   # np11 = {
   #   shape            = "BM.GPU4.8",
   #   node_pool_size   = 1,
   #   boot_volume_size = 150,
+  #   placement_ads    = [1]
   # }
 }
 node_pool_image_id    = "none"
@@ -296,7 +280,7 @@ worker_type           = "private"
   #np1 = "/tmp/np1cloudinit.sh"
   #np3 = "/tmp/np3cloudinit.sh"
 #}
-node_pool_timezone        = "Etc/UTC"
+node_pool_timezone = "Etc/UTC"
 
 # upgrade of existing node pools
 upgrade_nodepool        = false
@@ -304,17 +288,17 @@ node_pools_to_drain     = ["np1", "np2"]
 nodepool_upgrade_method = "out_of_place"
 
 # oke load balancers
-enable_waf                   = false
-load_balancers               = "both"
-preferred_load_balancer      = "public"
+enable_waf              = false
+load_balancers          = "both"
+preferred_load_balancer = "public"
 # internal_lb_allowed_cidrs  = ["172.16.1.0/24", "172.16.2.0/24"] # By default, anywhere i.e. 0.0.0.0/0 is allowed
 # internal_lb_allowed_ports  = [80, 443, "7001-7005"] # By default, only 80 and 443 are allowed
 # public_lb_allowed_cidrs    = ["0.0.0.0/0"] # By default, anywhere i.e. 0.0.0.0/0 is allowed
 # public_lb_allowed_ports    = [443,"9001-9002"] # By default, only 443 is allowed
 
-#fss
-create_fss = false
-fss_mount_path = "/oke_fss"
+# fss
+create_fss        = false
+fss_mount_path    = "/oke_fss"
 max_fs_stat_bytes = 23843202333
 max_fs_stat_files = 223442
 
@@ -335,8 +319,8 @@ enable_metric_server = false
 enable_vpa           = false
 vpa_version          = 0.8
 
-#OPA Gatekeeper
-enable_gatekeeper = false
+# OPA Gatekeeper
+enable_gatekeeper  = false
 gatekeeper_version = "3.7"
 
 # service account
@@ -347,74 +331,74 @@ service_account_cluster_role_binding = ""
 
 # freeform_tags
 freeform_tags = {
-  # vcn, bastion and operator freeform_tags are required
-  # add more freeform_tags in each as desired
-  vcn = {
-    environment = "dev"
-  }
-  bastion = {
-    access      = "public",
-    environment = "dev",
-    role        = "bastion",
-    security    = "high"
-  }
-  operator = {
-    access      = "restricted",
-    environment = "dev",
-    role        = "operator",
-    security    = "high"
-  }
-  oke = {
-    cluster = {
-      environment = "dev"
-      role        = "cluster"
-    }
-    persistent_volume = {
-      environment = "dev"
-    }    
-    service_lb = {
-      environment = "dev"
-      role        = "load balancer"
-    }
-    node_pool = {
-      environment = "dev"
-      role        = "node-pool"
-    }
-    node = {
-      environment = "dev"
-      role        = "worker"
-    }
-  }
+  # # vcn, bastion and operator freeform_tags are required
+  # # add more freeform_tags in each as desired
+  # vcn = {
+  #   environment = "dev"
+  # }
+  # bastion = {
+  #   access      = "public",
+  #   environment = "dev",
+  #   role        = "bastion",
+  #   security    = "high"
+  # }
+  # operator = {
+  #   access      = "restricted",
+  #   environment = "dev",
+  #   role        = "operator",
+  #   security    = "high"
+  # }
+  # oke = {
+  #   cluster = {
+  #     environment = "dev"
+  #     role        = "cluster"
+  #   }
+  #   persistent_volume = {
+  #     environment = "dev"
+  #   }    
+  #   service_lb = {
+  #     environment = "dev"
+  #     role        = "load balancer"
+  #   }
+  #   node_pool = {
+  #     environment = "dev"
+  #     role        = "node-pool"
+  #   }
+  #   node = {
+  #     environment = "dev"
+  #     role        = "worker"
+  #   }
+  # }
 }
 
 # defined_tags
 defined_tags = {
-  # vcn, bastion and operator freeform_tags are required
-  # add more freeform_tags in each as desired
-  vcn = {
-    "cn.environment" = "dev"
-  }
-  oke = {
-    cluster = {
-      "cn.environment" = "dev"
-      "cn.role"        = "cluster"
-    }
-    persistent_volume = {
-      "cn.environment" = "dev"
-    }    
-    service_lb = {
-      "cn.environment" = "dev"
-      "cn.role"        = "load balancer"
-    }
-    node_pool = {
-      "cn.environment" = "dev"
-      "cn.role"        = "node-pool"
-    }
-    node = {
-      "cn.environment" = "dev"
-      "cn.role"        = "worker"
-    }
-  }
+  # # vcn, bastion and operator freeform_tags are required
+  # # add more freeform_tags in each as desired
+  # vcn = {
+  #   "cn.environment" = "dev"
+  # }
+  # oke = {
+  #   cluster = {
+  #     "cn.environment" = "dev"
+  #     "cn.role"        = "cluster"
+  #   }
+  #   persistent_volume = {
+  #     "cn.environment" = "dev"
+  #   }    
+  #   service_lb = {
+  #     "cn.environment" = "dev"
+  #     "cn.role"        = "load balancer"
+  #   }
+  #   node_pool = {
+  #     "cn.environment" = "dev"
+  #     "cn.role"        = "node-pool"
+  #   }
+  #   node = {
+  #     "cn.environment" = "dev"
+  #     "cn.role"        = "worker"
+  #   }
+  # }
 }
 
 # placeholder variable for debugging scripts. To be implemented in future

--- a/terraform.tfvars.example
+++ b/terraform.tfvars.example
@@ -337,7 +337,7 @@ vpa_version          = 0.8
 
 #OPA Gatekeeper
 enable_gatekeeper = false
-gatekeeeper_version = "3.7"
+gatekeeper_version = "3.7"
 
 # service account
 create_service_account               = false

--- a/terraform.tfvars.example
+++ b/terraform.tfvars.example
@@ -1,4 +1,4 @@
-# Copyright 2017, 2021 Oracle Corporation and/or affiliates.
+# Copyright 2017, 2022 Oracle Corporation and/or affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl
 
 # Identity and access parameters
@@ -34,6 +34,9 @@ ssh_private_key_path = "~/.ssh/id_rsa"
 # ssh_public_key_path = "~/.ssh/id_rsa.pub"
 
 # networking
+
+assign_dns = true
+
 create_drg       = false
 drg_display_name = "drg"
 drg_id           = null

--- a/variables.tf
+++ b/variables.tf
@@ -233,8 +233,14 @@ variable "vcn_cidrs" {
 
 variable "vcn_dns_label" {
   default     = "oke"
-  description = "A DNS label for the VCN, used in conjunction with the VNIC's hostname and subnet's DNS label to form a fully qualified domain name (FQDN) for each VNIC within this subnet."
+  description = "A DNS label for the VCN, used in conjunction with the VNIC's hostname and subnet's DNS label to form a fully qualified domain name (FQDN) for each VNIC within this subnet. DNS resolution of hostnames in the VCN is disabled when null."
   type        = string
+}
+
+variable "assign_dns" {
+  default     = true
+  description = "Whether to assign DNS records to created instances"
+  type        = bool
 }
 
 variable "vcn_name" {

--- a/variables.tf
+++ b/variables.tf
@@ -1,4 +1,4 @@
-# Copyright 2017, 2021 Oracle Corporation and/or affiliates.
+# Copyright 2017, 2022 Oracle Corporation and/or affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl
 
 # OCI Provider parameters
@@ -944,6 +944,16 @@ variable "enable_gatekeeper" {
 }
 
 variable "gatekeeeper_version" {
+  type        = string
+  default     = null
+  description = "DEPRECATED - Fix spelling to `gatekeeper_version`"
+  validation {
+    condition     = var.gatekeeeper_version == null
+    error_message = "Deprecated - please fix variable spelling to `gatekeeper_version`."
+  }
+}
+
+variable "gatekeeper_version" {
   type        = string
   default     = "3.7"
   description = "The version of Gatekeeper to install"

--- a/variables.tf
+++ b/variables.tf
@@ -684,11 +684,7 @@ variable "cloudinit_nodepool_common" {
 }
 
 variable "node_pools" {
-  default = {
-    np1 = { shape = "VM.Standard.E4.Flex", ocpus = 1, memory = 16, node_pool_size = 1, boot_volume_size = 150, label = { app = "frontend", pool = "np1" } }
-    np2 = { shape = "VM.Standard.E2.2", node_pool_size = 2, boot_volume_size = 150 }
-    np3 = { shape = "VM.Standard.E2.2", node_pool_size = 1 }
-  }
+  default = {}
   description = "Tuple of node pools. Each key maps to a node pool. Each value is a tuple of shape (string),ocpus(number) , node_pool_size(number) and boot_volume_size(number)"
   type        = any
 }
@@ -941,16 +937,6 @@ variable "enable_gatekeeper" {
   type        = bool
   default     = false
   description = "Whether to install Gatekeeper"
-}
-
-variable "gatekeeeper_version" {
-  type        = string
-  default     = null
-  description = "DEPRECATED - Fix spelling to `gatekeeper_version`"
-  validation {
-    condition     = var.gatekeeeper_version == null
-    error_message = "Deprecated - please fix variable spelling to `gatekeeper_version`."
-  }
 }
 
 variable "gatekeeper_version" {


### PR DESCRIPTION
# Proposed changes

1. Add a new `assign_dns` boolean variable with default of `true` to match current behavior. When `false`, the optional `dns_label` values for OKE subnets will be unset, resulting in disabled DNS resolution of hostnames within the subnet. This also provides one option to avoid issues with `label_prefix` when the DNS names are unused; other changes for added flexibility will be considered separately.

References:
* [core_vcn#dns_label](https://registry.terraform.io/providers/oracle/oci/latest/docs/resources/core_vcn#dns_label)
* [oci_core_subnet#dns_label](https://registry.terraform.io/providers/oracle/oci/latest/docs/data-sources/core_subnet#dns_label)

```
assign_dns = false
```

> DNS Domain Name: DNS isn’t enabled for this VCN
> DNS Domain Name: DNS isn’t enabled for this Subnet

2. Don't create nodepools when variable is unspecified
3. Use defaults in tfvars example

## How has these changes been tested?

Manually, on new and existing tfstate with null and default values.
