### PR TITLE
fix: added kubernetes api control plane network access for pods

### DIFF
--- a/modules/network/locals.tf
+++ b/modules/network/locals.tf
@@ -120,7 +120,7 @@ locals {
   ]
 
   # Network Security Group ingress rules for control plane subnet (Flannel & VCN-Native Pod networking)
-  cp_ingress = [
+  cp_ingress = concat(var.cni_type == "npn" ? local.cp_ingress_npn : [], [
     {
       description = "Allow worker nodes to control plane API endpoint communication"
       protocol    = local.tcp_protocol,
@@ -150,6 +150,26 @@ locals {
       protocol    = local.tcp_protocol,
       port        = 6443,
       source      = local.operator_subnet,
+      source_type = "CIDR_BLOCK",
+      stateless   = false
+    },
+  ])
+
+  # Network Security Group ingress rules for control plane subnet (Only VCN-Native Pod networking)
+  cp_ingress_npn = [
+    {
+      description = "Allow pods to control plane API endpoint communication"
+      protocol    = local.tcp_protocol,
+      port        = 6443,
+      source      = local.pods_subnet,
+      source_type = "CIDR_BLOCK",
+      stateless   = false
+    },
+    {
+      description = "Allow pods to control plane communication"
+      protocol    = local.tcp_protocol,
+      port        = 12250,
+      source      = local.pods_subnet,
       source_type = "CIDR_BLOCK",
       stateless   = false
     },


### PR DESCRIPTION
Resolves https://github.com/oracle-terraform-modules/terraform-oci-oke/issues/608

As per the Oracle Kubernetes Engine [documentation](https://docs.oracle.com/en-us/iaas/Content/ContEng/Concepts/contengnetworkconfig.htm) the Kubernetes API endpoint on ports `TCP/6443` and `TCP/12250` allows ingress traffic to the Control Plane subnet.

Signed-off-by: James Marino <james@marino.io>