### PR TITLE
Wait for cloud-init completion before k8s extension install

### DIFF
--- a/modules/extensions/k8stools.tf
+++ b/modules/extensions/k8stools.tf
@@ -1,4 +1,4 @@
-# Copyright 2017, 2021 Oracle Corporation and/or affiliates.
+# Copyright 2017, 2022 Oracle Corporation and/or affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl
 
 resource "null_resource" "install_k8stools_on_operator" {
@@ -21,6 +21,7 @@ resource "null_resource" "install_k8stools_on_operator" {
 
   provisioner "remote-exec" {
     inline = [
+      "cloud-init status --wait",
       "if [ -f \"$HOME/install_kubectx.sh\" ]; then bash \"$HOME/install_kubectx.sh\"; rm -f \"$HOME/install_kubectx.sh\";fi",
     ]
   }


### PR DESCRIPTION
These utilities are now installed earlier in cloud-init, however a race still exists between setup that uses them in the `extensions` module. This change blocks the k8stools operator installation step until cloud-init has completed.

Resolves #610