### PR TITLE
fix: Operator support for disabled VCN DNS

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -7,7 +7,19 @@ All notable changes to this project are documented in this file.
 
 The format is based on {uri-changelog}[Keep a Changelog].
 
-== 4.2.14 (not released)
+== 4.2.17 (not released)
+=== Changes
+* fix: Operator support for disabled VCN DNS by @devoncrouse in #614
+
+== 4.2.16
+=== Changes
+* fix: Wait for cloud-init completion before k8s extension install by @devoncrouse in #611
+
+== 4.2.15
+=== Changes
+* fix: added kubernetes api control plane network access for pods by @JamesMarino in #609
+
+== 4.2.14
 === Changes
 * feat: Removed local kubeconfig file creation and `update_kubeconfig` input variable by @slok in #602
 * feat: Support disabled DNS record assignment for OKE subnets by @devoncrouse in #606

--- a/main.tf
+++ b/main.tf
@@ -108,7 +108,7 @@ module "bastion" {
 
 module "operator" {
   source  = "oracle-terraform-modules/operator/oci"
-  version = "3.1.4"
+  version = "3.1.5"
 
 
   # general oci parameters
@@ -117,6 +117,7 @@ module "operator" {
   label_prefix   = var.label_prefix
 
   # networking
+  assign_dns          = var.assign_dns
   availability_domain = var.availability_domains["operator"]
   nat_route_id        = local.nat_route_id
   netnum              = lookup(var.subnets["operator"], "netnum")


### PR DESCRIPTION
Update `terraform-oci-operator` module  version to support passing existing `assign_dns` var, so that operator subnet and instance are correctly provisioned when VCN DNS resolution is disabled.