### PR TITLE
Output Endpoints

### DIFF
--- a/modules/oke/outputs.tf
+++ b/modules/oke/outputs.tf
@@ -12,3 +12,7 @@ output "cluster_kms_dynamic_group_id" {
 output "nodepool_ids" {
   value = zipmap(values(oci_containerengine_node_pool.nodepools)[*].name, values(oci_containerengine_node_pool.nodepools)[*].id)
 }
+
+output "endpoints" {
+  value = oci_containerengine_cluster.k8s_cluster.endpoints
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -84,3 +84,8 @@ output "bastion_service_instance_id" {
 output "fss_id" {
   value = var.create_fss == true ? module.storage[0].fss_id : null
 }
+
+output "cluster_endpoints" {
+  description = "Endpoints for the Kubernetes cluster"
+  value       = module.oke.endpoints
+}


### PR DESCRIPTION
Small change to output endpoints... justification:

Deploying the stack via Oracle Resource Manager/Market Place.  Terraform calls an Ansible playbook as part of the deployment for config mgmt of the cluster and requires access to the control plane (no operator is deployed).  

Access to the CP can be made through Resource Manager Private Endpoints, but to do so, the private endpoint IP must be known, for example:

```
data "oci_resourcemanager_private_endpoint_reachable_ip" "orm_pe_reachable_ip" {
  count               = var.orm_install ? 1 : 0
  private_endpoint_id = oci_resourcemanager_private_endpoint.orm_pe[0].id
  private_ip          = split(":", module.oke.cluster_endpoints[0].private_endpoint)[0]
}
```

This will provide an IP (`data.oci_resourcemanager_private_endpoint_reachable_ip.orm_pe_reachable_ip[0].ip_address`) to access the private endpoint of the CP via the ORM/MP private endpoint.