### PR TITLE
fix: Bastion & FSS support for disabled VCN DNS, min TF version -> 1.1

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -7,7 +7,11 @@ All notable changes to this project are documented in this file.
 
 The format is based on {uri-changelog}[Keep a Changelog].
 
-== 4.2.17 (not released)
+== 4.2.18 (not released)
+=== Changes
+* fix: Bastion & FSS support for disabled VCN DNS, min TF version -> 1.1 by @devoncrouse
+
+== 4.2.17
 === Changes
 * fix: Operator support for disabled VCN DNS by @devoncrouse in #614
 

--- a/main.tf
+++ b/main.tf
@@ -59,7 +59,7 @@ module "drg" {
 
 module "bastion" {
   source  = "oracle-terraform-modules/bastion/oci"
-  version = "3.1.3"
+  version = "3.1.5"
 
   tenancy_id     = local.tenancy_id
   compartment_id = local.compartment_id
@@ -67,6 +67,7 @@ module "bastion" {
   label_prefix = var.label_prefix
 
   # networking
+  assign_dns          = var.assign_dns
   availability_domain = var.availability_domains["bastion"]
   bastion_access      = var.bastion_access
   ig_route_id         = local.ig_route_id

--- a/modules/storage/fss.tf
+++ b/modules/storage/fss.tf
@@ -17,7 +17,7 @@ resource "oci_file_storage_mount_target" "fss_mount_target" {
   compartment_id      = var.compartment_id
   subnet_id           = oci_core_subnet.fss.id
   display_name        = var.label_prefix == "none" ? "fss-mt" : "${var.label_prefix}-fss-mt"
-  hostname_label      = "fss-mt"
+  hostname_label      = var.assign_dns ? "fss-mt" : null
   nsg_ids             = [oci_core_network_security_group.fss_mt.id]
 
   lifecycle {

--- a/versions.tf
+++ b/versions.tf
@@ -1,4 +1,4 @@
-# Copyright 2017, 2021, Oracle Corporation and/or affiliates.
+# Copyright 2017, 2022 Oracle Corporation and/or affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl
 
 terraform {
@@ -9,5 +9,5 @@ terraform {
       version               = ">= 4.67.3"
     }
   }
-  required_version = ">= 1.0.0"
+  required_version = ">= 1.1.0"
 }


### PR DESCRIPTION
* Update terraform-oci-bastion module version to support passing existing `assign_dns` var, so that bastion subnet and instance are correctly provisioned when VCN DNS resolution is disabled.
* Perform the same assign_dns check for FSS hostname_label (subnet already covered)
* Update minimum Terraform version to 1.1 (Resolves #616)

![image](https://user-images.githubusercontent.com/1114734/205221086-e05e03b3-61e2-4fad-96ec-6db48a609f32.png)
