### PR TITLE
Node pool correctly ignore sub-sub-object

### DIFF
--- a/modules/oke/nodepools.tf
+++ b/modules/oke/nodepools.tf
@@ -121,8 +121,8 @@ resource "oci_containerengine_node_pool" "nodepools" {
     ignore_changes = [
       kubernetes_version,
       defined_tags, # automatic tagging after apply
-      node_metadata["user_data"], # templated cloud-init
-      node_config_details["placement_configs"], # dynamic placement configs
+      node_metadata, # templated cloud-init
+      node_config_details[0].placement_configs, # dynamic placement configs
       node_source_details # dynamic image lookup
     ]
   }


### PR DESCRIPTION
Correct terraform syntax to ignore just the needed parts of `node_metadata` and `node_config_details`

Before the change the whole sub-objects were ignored, leading to inability to change a nodepool size via terraform.

Fixes: 269d3fdd89