### PR TITLE
fix: Correct Internet Gateway creation rule

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -10,7 +10,7 @@ module "vcn" {
   label_prefix   = var.label_prefix
 
   # gateways
-  create_internet_gateway  = var.load_balancers == "internal" && var.create_bastion_host == false ? false : true
+  create_internet_gateway  = var.load_balancers == "internal" && var.create_bastion_host == false && var.control_plane_type == "private" ? false : true
   create_nat_gateway       = var.worker_type == "private" || var.create_operator == true || (var.load_balancers == "internal" || var.load_balancers == "both") ? true : false
   create_service_gateway   = true
   nat_gateway_public_ip_id = var.nat_gateway_public_ip_id


### PR DESCRIPTION
The Internet Gateway is not created if the Load Balancer subnet is PRIVATE and Control Plane is PUBLIC. This PR is fixing this issue