### PR TITLE
fix: add preferred_loadbalancer validation

### DIFF
--- a/modules/oke/cluster.tf
+++ b/modules/oke/cluster.tf
@@ -71,11 +71,16 @@ resource "oci_containerengine_cluster" "k8s_cluster" {
       defined_tags  = lookup(var.defined_tags,"service_lb",{})
     }
 
-    service_lb_subnet_ids = var.preferred_load_balancer == "public" ? [var.cluster_subnets["pub_lb"]] : [var.cluster_subnets["int_lb"]]
+    service_lb_subnet_ids = [var.cluster_subnets[local.lb_subnet]]
   }
 
   lifecycle {
     ignore_changes = [defined_tags, freeform_tags, cluster_pod_network_options]
+
+    precondition {
+      condition     = var.cluster_subnets[local.lb_subnet] != ""
+      error_message = "Preferred load balancer references unexisting load balancer. Please check variables preferred_load_balancer and load_balancers."
+    }
   }
 
   vcn_id = var.vcn_id


### PR DESCRIPTION
In case if user provision OKE with internal LB and doesn't set perferred_load_balancer variable the terraform will fail during provision with unintuitive message:

> Error: 400-InvalidParameter, Invalid subnetId: subnetId must not be blank
> │ Suggestion: Please update the parameter(s) in the Terraform config as per error message Invalid subnetId: subnetId must not be blank
> │ Documentation: https://registry.terraform.io/providers/oracle/oci/latest/docs/resources/containerengine_cluster 
> │ API Reference: https://docs.oracle.com/iaas/api/#/en/containerengine/20180222/Cluster/CreateCluster 
> │ Request Target: POST https://containerengine.us-ashburn-1.oci.oraclecloud.com/20180222/clusters 
> │ Provider version: 4.102.0, released on 2022-12-14. This provider is 2 Update(s) behind to current. 
> │ Service: Containerengine Cluster 
> │ Operation Name: CreateCluster 
> │ OPC request ID: ....
> │ 
> │ 
> │   with module.oke.module.oke.oci_containerengine_cluster.k8s_cluster,
> │   on .terraform/modules/oke/modules/oke/cluster.tf line 11, in resource "oci_containerengine_cluster" "k8s_cluster":
> │   11: resource "oci_containerengine_cluster" "k8s_cluster" {
> │ 

With the fix terraform would fail on a plan phase:
> ╷
> │ Error: Resource precondition failed
> │ 
> │   on ../../modules/oke/cluster.tf line 81, in resource "oci_containerengine_cluster" "k8s_cluster":
> │   81:       condition     = var.cluster_subnets[local.lb_subnet] != ""
> │     ├────────────────
> │     │ local.lb_subnet is "pub_lb"
> │     │ var.cluster_subnets is map of string with 5 elements
> │ 
> │ preferred_load_balancer references unexisting load balancer.

Also found that modules/oke/locals.tf contains unused variable `lb_subnet`, so I simplified `service_lb_subnet_ids` expression by using `local.lb_subnet`