### PR TITLE
feat: Optionally ignore the label prefix in node pool names

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -264,20 +264,21 @@ module "oke" {
   admission_controller_options                            = var.admission_controller_options
 
   # oke node pool parameters
-  kubeproxy_mode                  = var.kubeproxy_mode
-  max_pods_per_node               = var.max_pods_per_node
-  node_pools                      = var.node_pools
-  node_pool_name_prefix           = var.node_pool_name_prefix
-  node_pool_image_id              = var.node_pool_image_id
-  node_pool_image_type            = var.node_pool_image_type
-  node_pool_os                    = var.node_pool_os
-  node_pool_os_version            = var.node_pool_os_version
-  node_pool_timezone              = var.node_pool_timezone
-  enable_pv_encryption_in_transit = var.enable_pv_encryption_in_transit
-  use_node_pool_volume_encryption = var.use_node_pool_volume_encryption
-  node_pool_volume_kms_key_id     = var.node_pool_volume_kms_key_id
-  cloudinit_nodepool              = var.cloudinit_nodepool
-  cloudinit_nodepool_common       = var.cloudinit_nodepool_common
+  kubeproxy_mode                         = var.kubeproxy_mode
+  max_pods_per_node                      = var.max_pods_per_node
+  node_pools                             = var.node_pools
+  node_pool_name_prefix                  = var.node_pool_name_prefix
+  node_pool_image_id                     = var.node_pool_image_id
+  node_pool_image_type                   = var.node_pool_image_type
+  node_pool_os                           = var.node_pool_os
+  node_pool_os_version                   = var.node_pool_os_version
+  node_pool_timezone                     = var.node_pool_timezone
+  ignore_label_prefix_in_node_pool_names = var.ignore_label_prefix_in_node_pool_names
+  enable_pv_encryption_in_transit        = var.enable_pv_encryption_in_transit
+  use_node_pool_volume_encryption        = var.use_node_pool_volume_encryption
+  node_pool_volume_kms_key_id            = var.node_pool_volume_kms_key_id
+  cloudinit_nodepool                     = var.cloudinit_nodepool
+  cloudinit_nodepool_common              = var.cloudinit_nodepool_common
 
   # oke load balancer parameters
   preferred_load_balancer = var.preferred_load_balancer

--- a/modules/oke/nodepools.tf
+++ b/modules/oke/nodepools.tf
@@ -8,7 +8,7 @@ resource "oci_containerengine_node_pool" "nodepools" {
   depends_on     = [oci_containerengine_cluster.k8s_cluster]
 
   kubernetes_version = var.cluster_kubernetes_version
-  name               = var.label_prefix == "none" ? each.key : "${var.label_prefix}-${each.key}"
+  name               = var.label_prefix == "none" || var.ignore_label_prefix_in_node_pool_names ? each.key : "${var.label_prefix}-${each.key}"
 
   freeform_tags = merge(lookup(var.freeform_tags, "node_pool", {}), lookup(each.value, "nodepool_freeform_tags", {}))
   defined_tags  = merge(lookup(var.defined_tags, "node_pool", {}), lookup(each.value, "nodepool_defined_tags", {}))

--- a/modules/oke/variables.tf
+++ b/modules/oke/variables.tf
@@ -97,7 +97,7 @@ variable "node_pools" {
 
 variable "ignore_label_prefix_in_node_pool_names" {
   default     = false
-  description = "Do not use the label_prefix when naming each node pool. This frees up more characters for the nodepool name. Current limit to node pool name is 32 characters."
+  description = "While using label_prefix to add a prefix to many OCI resource names, do not use the label_prefix when naming each node pool. This frees up more characters for the nodepool name. Current limit to node pool name is 32 characters."
   type        = bool
 }
 

--- a/modules/oke/variables.tf
+++ b/modules/oke/variables.tf
@@ -95,6 +95,12 @@ variable "node_pools" {
   type = any
 }
 
+variable "ignore_label_prefix_in_node_pool_names" {
+  default     = false
+  description = "Do not use the label_prefix when naming each node pool. This frees up more characters for the nodepool name. Current limit to node pool name is 32 characters."
+  type        = bool
+}
+
 variable "node_pool_name_prefix" {}
 
 variable "node_pool_image_id" {}

--- a/variables.tf
+++ b/variables.tf
@@ -739,6 +739,12 @@ variable "node_pool_timezone" {
   type        = string
 }
 
+variable "ignore_label_prefix_in_node_pool_names" {
+  default     = false
+  description = "Do not use the label_prefix when naming each node pool. This frees up more characters for the nodepool name. Current limit to node pool name is 32 characters."
+  type        = bool
+}
+
 variable "worker_nsgs" {
   default     = []
   description = "An additional list of network security groups (NSG) ids for the worker nodes that can be created subsequently."

--- a/variables.tf
+++ b/variables.tf
@@ -741,7 +741,7 @@ variable "node_pool_timezone" {
 
 variable "ignore_label_prefix_in_node_pool_names" {
   default     = false
-  description = "Do not use the label_prefix when naming each node pool. This frees up more characters for the nodepool name. Current limit to node pool name is 32 characters."
+  description = "While using label_prefix to add a prefix to many OCI resource names, do not use the label_prefix when naming each node pool. This frees up more characters for the nodepool name. Current limit to node pool name is 32 characters."
   type        = bool
 }
 


### PR DESCRIPTION
https://github.com/oracle-terraform-modules/terraform-oci-oke/issues/628

An OKE nodepool is limited to 32 chars.

var.label_prefix can sometimes consume most of those chars, leaving little room for the remainder of the node pool name as defined in each key name of var.node_pools.

for a more descriptive nodepool name we should have the ability to drop the var.label_prefix name specifically for the oci_containerengine_node_pool resource. this way, we can maintain the functionality of var.label_prefix that is used across this terraform module.

to validate this change:
```
module "oke" {
  source = "oracle-terraform-modules/oke/oci"
  ignore_label_prefix_in_node_pool_names = true  
  ....
}
```