### PR TITLE
Secondary VNIC for IP/CN, compatible defaults for block volume/AD

### DIFF
--- a/docs/terraformoptions.adoc
+++ b/docs/terraformoptions.adoc
@@ -799,25 +799,25 @@ node_pools = {
 }
 |{}
 
-|node_pool_image_id
-|The OCID of custom image to use when provisioning worker nodes. When no OCID is specified, the worker nodes will use the node_pool_os and node_pool_os_version to identify an image to provision the worker nodes.
+|worker_image_id
+|The OCID of custom image to use when provisioning worker nodes. When no OCID is specified, the worker nodes will use the worker_image_os and worker_image_os_version to identify an image to provision the worker nodes.
 |
 |"none"
 
-|node_pool_image_type
-|Whether to use a Platform, OKE or custom image. When custom is set, the node_pool_image_id *must* be specified. Using an OKE image minimizes the time it takes to provision worker nodes at runtime when compared to platform images and custom images. OKE images are optimized for use as worker node base images, with all the necessary configurations and required software. The use of OKE images reduces worker node provisioning time by more than half when compared to platform images. OKE images are provided by Oracle and built on top of platform images.
+|worker_image_type
+|Whether to use a Platform, OKE or custom image. When custom is set, the worker_image_id *must* be specified. Using an OKE image minimizes the time it takes to provision worker nodes at runtime when compared to platform images and custom images. OKE images are optimized for use as worker node base images, with all the necessary configurations and required software. The use of OKE images reduces worker node provisioning time by more than half when compared to platform images. OKE images are provided by Oracle and built on top of platform images.
 | "custom","oke","platform"
 |"oke"
 
-|node_pool_os
+|worker_image_os
 |The name of the Operating System image to use to provision the worker nodes.
 |
 |Oracle Linux
 
-|node_pool_os_version
+|worker_image_os_version
 |The corresponding version of the Operating System image to use to provision the worker nodes.
 |
-|7.9
+|8
 
 |cloudinit_nodepool_common
 |cloud-init common for all nodepools when no specific script mentioned for nodepool in cloudinit_nodepool.

--- a/locals.tf
+++ b/locals.tf
@@ -12,6 +12,4 @@ locals {
   validate_drg_input = var.create_drg && (var.drg_id != null) ? tobool("[ERROR]: create_drg variable can not be true if drg_id is provided.]") : true
 
   worker_pool_subnet_id = coalesce(var.worker_pool_subnet_id, lookup(module.network.subnet_ids, "workers", ""))
-  worker_image_id       = length(var.worker_pool_image_id) > 0 ? var.worker_pool_image_id : var.node_pool_image_id != "none" ? var.node_pool_image_id : ""
-  worker_image_type     = length(var.worker_pool_image_type) > 0 ? var.worker_pool_image_type : var.node_pool_image_type != "none" ? var.node_pool_image_type : ""
 }

--- a/main.tf
+++ b/main.tf
@@ -268,10 +268,10 @@ module "oke" {
   max_pods_per_node               = var.max_pods_per_node
   node_pools                      = var.node_pools
   node_pool_name_prefix           = var.node_pool_name_prefix
-  node_pool_image_id              = var.node_pool_image_id
-  node_pool_image_type            = var.node_pool_image_type
-  node_pool_os                    = var.node_pool_os
-  node_pool_os_version            = var.node_pool_os_version
+  node_pool_image_id              = var.worker_image_id
+  node_pool_image_type            = var.worker_image_type
+  node_pool_os                    = var.worker_image_os
+  node_pool_os_version            = var.worker_image_os_version
   node_pool_timezone              = var.node_pool_timezone
   enable_pv_encryption_in_transit = var.enable_pv_encryption_in_transit
   use_node_pool_volume_encryption = var.use_node_pool_volume_encryption

--- a/modules/workerpools/README.md
+++ b/modules/workerpools/README.md
@@ -41,7 +41,7 @@ Many parameters to a worker pool can be defined at multiple levels, taken in pri
 label_prefix                   = ""
 worker_pool_enabled           = true
 worker_pool_size              = 0
-worker_pool_image_id          = "ocid1.image..." # Required here and/or on group
+worker_image_id          = "ocid1.image..." # Required here and/or on group
 worker_pool_mode              = "node-pool"
 worker_pool_shape             = "VM.Standard.E4.Flex"
 worker_pool_ocpus             = 2

--- a/modules/workerpools/clusternetworks.tf
+++ b/modules/workerpools/clusternetworks.tf
@@ -6,27 +6,30 @@ resource "oci_core_cluster_network" "workers" {
   # Create an OCI Cluster Network resource for each enabled entry of the worker_pools map with that mode.
   for_each       = local.enabled_cluster_networks
   compartment_id = each.value.compartment_id
-  display_name   = "${each.value.label_prefix}-${each.key}"
+  display_name   = each.key
   defined_tags   = merge(local.defined_tags, contains(keys(each.value), "defined_tags") ? each.value.defined_tags : {})
   freeform_tags  = merge(local.freeform_tags, contains(keys(each.value), "freeform_tags") ? each.value.freeform_tags : { worker_pool = each.key })
 
   instance_pools {
     instance_configuration_id = oci_core_instance_configuration.workers[each.key].id
-    display_name              = join("-", compact([lookup(each.value, "label_prefix", var.label_prefix), each.key]))
+    display_name              = each.key
     size                      = each.value.size
     defined_tags              = merge(coalesce(local.defined_tags, {}), contains(keys(each.value), "defined_tags") ? each.value.defined_tags : {})
     freeform_tags             = merge(coalesce(local.freeform_tags, {}), contains(keys(each.value), "freeform_tags") ? each.value.freeform_tags : { worker_pool = each.key })
   }
 
   placement_configuration {
-    # Define the configured availability domain for placement, bounded to a single value
-    # The configured AD number e.g. 2 is converted into a tenancy/compartment-specific name
-    availability_domain = lookup(local.ad_number_to_name, (
-      contains(keys(each.value), "placement_ads")
-      ? element(tolist(setintersection(each.value.placement_ads, local.ad_numbers)), 1)
-      : element(local.ad_numbers, 1)
-    ), local.first_ad_name)
-    primary_subnet_id = each.value.subnet_id
+    availability_domain = element(each.value.availability_domains, 1)
+    primary_subnet_id   = each.value.subnet_id
+
+    dynamic "secondary_vnic_subnets" {
+      for_each = lookup(each.value, "secondary_vnics", {})
+      iterator = vnic
+      content {
+        display_name = vnic.key
+        subnet_id    = lookup(vnic.value, "subnet_id", each.value.subnet_id)
+      }
+    }
   }
 
   lifecycle {

--- a/modules/workerpools/clusternetworks.tf
+++ b/modules/workerpools/clusternetworks.tf
@@ -38,9 +38,15 @@ resource "oci_core_cluster_network" "workers" {
       instance_pools["display_name"], instance_pools["defined_tags"], instance_pools["freeform_tags"],
       placement_configuration["availability_domain"],
     ]
+
     precondition {
       condition     = var.cni_type == "flannel"
       error_message = "Cluster Networks require a cluster with `cni_type = flannel`."
+    }
+
+    precondition {
+      condition = coalesce(each.value.image_id, "none") != "none"
+      error_message = "Missing image_id for pool ${each.key}. Check provided value for image_id if image_type is 'custom', or image_os/image_os_version if image_type is 'oke' or 'platform'."
     }
   }
 

--- a/modules/workerpools/datasources.tf
+++ b/modules/workerpools/datasources.tf
@@ -15,8 +15,3 @@ data "oci_containerengine_node_pool_option" "np_options" {
 data "oci_containerengine_cluster_kube_config" "kube_config" {
   cluster_id = var.cluster_id
 }
-
-data "oci_core_image" "worker_images" {
-  count    = length(local.enabled_worker_pool_image_ids)
-  image_id = local.enabled_worker_pool_image_ids[count.index]
-}

--- a/modules/workerpools/instancepools.tf
+++ b/modules/workerpools/instancepools.tf
@@ -36,9 +36,15 @@ resource "oci_core_instance_pool" "workers" {
       display_name, defined_tags, freeform_tags,
       placement_configurations,
     ]
+
     precondition {
       condition     = var.cni_type == "flannel"
       error_message = "Instance Pools require a cluster with `cni_type = flannel`."
+    }
+
+    precondition {
+      condition = coalesce(each.value.image_id, "none") != "none"
+      error_message = "Missing image_id for pool ${each.key}. Check provided value for image_id if image_type is 'custom', or image_os/image_os_version if image_type is 'oke' or 'platform'."
     }
   }
 

--- a/modules/workerpools/locals.tf
+++ b/modules/workerpools/locals.tf
@@ -8,7 +8,6 @@ locals {
   ad_number_to_name = local.ads != null ? {
     for ad in local.ads : parseint(substr(ad.name, -1, -1), 10) => ad.name
   } : { -1 : "" } # Fallback handles failure when unavailable but not required
-  first_ad_name = local.ad_number_to_name[1]
 
   k8s_version_length = length(var.kubernetes_version)
   k8s_version_only   = substr(var.kubernetes_version, 1, local.k8s_version_length)
@@ -51,29 +50,40 @@ locals {
   }
 
   worker_pools_default = {
-    mode             = var.mode
-    size             = var.size
-    shape            = var.shape
-    image_id         = var.image_id
-    image_type       = var.image_type
-    os               = var.os
-    os_version       = var.os_version
-    boot_volume_size = var.boot_volume_size
-    memory           = var.memory
-    ocpus            = var.ocpus
-    compartment_id   = local.worker_compartment_id
-    subnet_id        = var.subnet_id
-    pod_subnet_id    = var.pod_subnet_id
-    pod_nsgs         = var.pod_nsg_ids
-    worker_nsgs      = var.worker_nsg_ids
-    assign_public_ip = var.assign_public_ip
-    label_prefix     = var.label_prefix # TODO Deprecate
-    node_labels      = {}
+    mode              = var.mode
+    size              = var.size
+    shape             = var.shape
+    image_id          = var.image_id
+    image_type        = var.image_type
+    os                = var.os
+    os_version        = var.os_version
+    boot_volume_size  = var.boot_volume_size
+    memory            = var.memory
+    ocpus             = var.ocpus
+    compartment_id    = local.worker_compartment_id
+    placement_ads     = local.ad_numbers
+    block_volume_type = var.block_volume_type
+    pv_encryption     = var.enable_pv_encryption_in_transit
+    subnet_id         = var.subnet_id
+    pod_subnet_id     = var.pod_subnet_id
+    pod_nsgs          = var.pod_nsg_ids
+    worker_nsgs       = var.worker_nsg_ids
+    assign_public_ip  = var.assign_public_ip
+    node_labels       = {}
   }
 
   # Filter worker_pools map variable for enabled entries
-  worker_pools_enabled = {
+  worker_pools_enabled = { for x, y in { # Final dynamic configuration for pool requirements
+    # Merge desired pool configuration onto defaults
     for k, v in var.worker_pools : k => merge(local.worker_pools_default, v) if lookup(v, "enabled", var.enabled)
+    } : x => merge(y, {
+      # Translate configured + available  AD numbers e.g. 2 into a tenancy/compartment-specific name
+      availability_domains = compact([for ad_number in tolist(setintersection(y.placement_ads, local.ad_numbers)) :
+        lookup(local.ad_number_to_name, ad_number, null)
+      ])
+      block_volume_type = y.mode == "cluster-network" ? "iscsi" : var.block_volume_type
+      pv_encryption     = var.enable_pv_encryption_in_transit && y.block_volume_type == "paravirtualized" && y.mode != "cluster-network"
+    })
   }
 
   worker_compartments = distinct(compact([for k, v in local.worker_pools_enabled : lookup(v, "compartment_id", "")]))

--- a/terraform.tfvars.example
+++ b/terraform.tfvars.example
@@ -1,4 +1,4 @@
-# Copyright 2017, 2022 Oracle Corporation and/or affiliates.
+# Copyright (c) 2022, 2023 Oracle Corporation and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl
 
 # Identity and access parameters
@@ -173,7 +173,7 @@ control_plane_type           = "private"
 control_plane_allowed_cidrs  = ["0.0.0.0/0"]
 control_plane_nsgs           = []
 dashboard_enabled            = false
-kubernetes_version           = "v1.23.4"
+kubernetes_version           = "v1.25.4"
 pods_cidr                    = "10.244.0.0/16"
 services_cidr                = "10.96.0.0/16"
 

--- a/terraform.tfvars.example
+++ b/terraform.tfvars.example
@@ -268,11 +268,11 @@ node_pools = {
   #   placement_ads    = [1]
   # }
 }
-node_pool_image_id    = "none"
-node_pool_image_type  = "oke"
+worker_image_id    = "none"
+worker_image_type  = "oke"
 node_pool_name_prefix = "np"
-node_pool_os          = "Oracle Linux"
-node_pool_os_version  = "7.9"
+worker_image_os          = "Oracle Linux"
+worker_image_os_version  = "7.9"
 worker_nsgs           = []
 worker_type           = "private"
 

--- a/variables-workerpools.tf
+++ b/variables-workerpools.tf
@@ -53,7 +53,7 @@ variable "worker_pool_size" {
   type        = number
 }
 
-variable "worker_pool_image_id" {
+variable "worker_image_id" {
   default     = ""
   description = "Default image for worker pools when unspecified"
   type        = string
@@ -77,14 +77,26 @@ variable "worker_pool_memory" {
   type        = number
 }
 
-variable "worker_pool_image_type" {
+variable "worker_image_type" {
   default     = "custom"
-  description = "Whether to use a Platform, OKE or custom image. When custom is set, the worker_pool_image_id must be specified."
+  description = "Whether to use a Platform, OKE or custom image. When custom is set, the worker_image_id must be specified."
   type        = string
   validation {
-    condition     = contains(["custom", "oke", "platform"], var.worker_pool_image_type)
+    condition     = contains(["custom", "oke", "platform"], var.worker_image_type)
     error_message = "Accepted values are custom, oke, platform"
   }
+}
+
+variable "worker_image_os" {
+  default     = "Oracle Linux"
+  description = "Default worker base image operating system name when worker_image_type = 'oke' or 'platform'."
+  type        = string
+}
+
+variable "worker_image_os_version" {
+  default     = "8"
+  description = "Default worker base image operating system version when worker_image_type = 'oke' or 'platform'."
+  type        = string
 }
 
 variable "worker_pool_subnet_id" {

--- a/variables-workerpools.tf
+++ b/variables-workerpools.tf
@@ -39,7 +39,7 @@ variable "worker_pools" {
 
 variable "worker_pool_mode" {
   default     = "node-pool"
-  description = "Default management mode for worker pools when unspecified"
+  description = "Default management mode for worker pools when unspecified. Only node-pool is currently supported."
   type        = string
   validation {
     condition     = contains(["node-pool", "instance-pool", "cluster-network"], var.worker_pool_mode)

--- a/variables.tf
+++ b/variables.tf
@@ -477,7 +477,7 @@ variable "dashboard_enabled" {
 }
 
 variable "kubernetes_version" {
-  default     = "v1.23.4"
+  default     = "v1.25.4"
   description = "The version of kubernetes to use when provisioning OKE or to upgrade an existing OKE cluster to."
   type        = string
 }

--- a/variables.tf
+++ b/variables.tf
@@ -573,37 +573,9 @@ variable "node_pools" {
   type        = any
 }
 
-variable "node_pool_image_id" {
-  default     = "none"
-  description = "The ocid of a custom image to use for worker node."
-  type        = string
-}
-
-variable "node_pool_image_type" {
-  default     = "oke"
-  description = "Whether to use a Platform, OKE or custom image. When custom is set, the node_pool_image_id must be specified."
-  type        = string
-  validation {
-    condition     = contains(["custom", "oke", "platform"], var.node_pool_image_type)
-    error_message = "Accepted values are custom, oke, platform."
-  }
-}
-
 variable "node_pool_name_prefix" {
   default     = "np"
   description = "The prefix of the node pool name."
-  type        = string
-}
-
-variable "node_pool_os" {
-  default     = "Oracle Linux"
-  description = "The name of image to use."
-  type        = string
-}
-
-variable "node_pool_os_version" {
-  default     = "7.9"
-  description = "The version of operating system to use for the worker nodes."
   type        = string
 }
 

--- a/vars-workerpool.auto.tfvars.example
+++ b/vars-workerpool.auto.tfvars.example
@@ -14,12 +14,6 @@ worker_pool_subnet_id = ""    # Defaults to Terraform-managed when empty
 
 worker_nsgs = [] # Defaults to VCN workers NSG when empty/missing
 
-# Ignored when image type != "custom"
-# worker_pool_image_id = "ocid1.image..." 
-
-# Ignored when image type != "custom"; defaults to node_pool_image_id when unspecified
-worker_pool_image_type = "oke" # Defaults to node_pool_image_type when unspecified
-
 # Definitions for worker pools, with any fields set overriding defaults above
 #   The "worker_pool_" prefix is omitted for parameters at the group level
 #   All value fields may be omitted to accept defaults for a sparse definition

--- a/vars-workerpool.auto.tfvars.example
+++ b/vars-workerpool.auto.tfvars.example
@@ -4,7 +4,7 @@
 # Default parameters when undefined for a group
 worker_compartment_id        = "" # Defaults to compartment_id when unspecified
 worker_pool_size             = 0
-worker_pool_mode             = "node-pool"
+worker_pool_mode             = "node-pool" # Must be "node-pool"
 worker_pool_shape            = "VM.Standard.E4.Flex"
 worker_pool_ocpus            = 2  # Ignored for non-Flex shapes
 worker_pool_memory           = 16 # Ignored for non-Flex shapes

--- a/workerpools.tf
+++ b/workerpools.tf
@@ -12,10 +12,10 @@ module "worker_pools" {
   cluster_id                      = coalesce(var.cluster_id, module.oke.cluster_id)
   apiserver_private_host          = try(split(":", module.oke.endpoints[0].private_endpoint)[0], "")
   apiserver_public_host           = try(split(":", module.oke.endpoints[0].public_endpoint)[0], "")
-  image_id                        = local.worker_image_id
-  image_type                      = local.worker_image_type
-  os                              = var.node_pool_os
-  os_version                      = var.node_pool_os_version
+  image_id                        = var.worker_image_id
+  image_type                      = var.worker_image_type
+  os                              = var.worker_image_os
+  os_version                      = var.worker_image_os_version
   enabled                         = var.worker_pool_enabled
   mode                            = var.worker_pool_mode
   boot_volume_size                = var.worker_pool_boot_volume_size


### PR DESCRIPTION
- Add experimental configuration for secondary VNICs
- Use correct defaults by mode for block volume config
- Use Kubernetes v1.25 by default
- Use consistent worker image lookup and variables
- Add precondition for better error message with missing image_id
- Fix worker pool resource display names with removed label_prefix