### PR TITLE
fix: Set CALICO_MANAGE_CNI for Calico w/ Flannel

### DIFF
--- a/modules/extensions/resources/calico/calico-node-env-flannel.yaml
+++ b/modules/extensions/resources/calico/calico-node-env-flannel.yaml
@@ -8,5 +8,7 @@ spec:
           value: "${POD_CIDR}"
         - name: "CALICO_IPV4POOL_VXLAN"
           value: "${IPV4POOL_VXLAN}"
+        - name: "CALICO_MANAGE_CNI"
+          value: "true"
         - name: "FELIX_IPTABLESBACKEND"
           value: "${IPTABLES_BACKEND}"


### PR DESCRIPTION
See https://github.com/projectcalico/calico/issues/6546#issuecomment-1313496096 - the "policy only" manifest overrides the default value for this environment variable to `false`.