### PR TITLE
feat: Add TF node labels

### DIFF
--- a/modules/workers/locals.tf
+++ b/modules/workers/locals.tf
@@ -103,6 +103,13 @@ locals {
 
       # Add a node label for cluster autoscaler where scheduling is supported
       node_labels = merge(
+        {
+          "oke.oraclecloud.com/tf.module"    = "terraform-oci-oke"
+          "oke.oraclecloud.com/tf.state_id"  = var.state_id
+          "oke.oraclecloud.com/tf.workspace" = terraform.workspace
+          "oke.oraclecloud.com/pool.name"    = pool_name
+          "oke.oraclecloud.com/pool.mode"    = pool.mode
+        },
         pool.allow_autoscaler ? {
           "oke.oraclecloud.com/cluster_autoscaler" = "allowed"
         } : {},


### PR DESCRIPTION
- Add k8s node labels with Terraform state information:
```json
        {
          "oke.oraclecloud.com/tf.module": "terraform-oci-oke"
          "oke.oraclecloud.com/tf.state_id": "<state ID>"
          "oke.oraclecloud.com/tf.workspace": "<TF workspace>"
          "oke.oraclecloud.com/pool.name": "<pool name>"
          "oke.oraclecloud.com/pool.mode": "<pool mode>"
        },
```