### PR TITLE
cloudinit: Run oke provisioning script after modifications

### DIFF
--- a/modules/oke/cloudinit/worker.template.sh
+++ b/modules/oke/cloudinit/worker.template.sh
@@ -3,12 +3,12 @@
 # DO NOT MODIFY
 curl --fail -H "Authorization: Bearer Oracle" -L0 http://169.254.169.254/opc/v2/instance/metadata/oke_init_script | base64 --decode >/var/run/oke-init.sh
 
-## run oke provisioning script
-bash -x /var/run/oke-init.sh
-
 ### adjust block volume size
 /usr/libexec/oci-growfs -y
 
 timedatectl set-timezone ${worker_timezone}
 
 touch /var/log/oke.done
+
+## run oke provisioning script
+bash -x /var/run/oke-init.sh


### PR DESCRIPTION
Otherwise, growfs for example has no impact as the kubernetes node has only the default size, and not the right size after expanding.