### PR TITLE
fix: Re-trigger await cloud-init on bastion/operator replacement

### DIFF
--- a/modules/bastion/cloudinit.tf
+++ b/modules/bastion/cloudinit.tf
@@ -37,6 +37,10 @@ resource "null_resource" "await_cloudinit" {
     type        = "ssh"
   }
 
+  lifecycle {
+    replace_triggered_by = [oci_core_instance.bastion]
+  }
+
   provisioner "remote-exec" {
     inline = ["cloud-init status --wait &> /dev/null"]
   }

--- a/modules/operator/cloudinit.tf
+++ b/modules/operator/cloudinit.tf
@@ -258,6 +258,10 @@ resource "null_resource" "await_cloudinit" {
     type                = "ssh"
   }
 
+  lifecycle {
+    replace_triggered_by = [oci_core_instance.operator]
+  }
+
   provisioner "remote-exec" {
     inline = ["cloud-init status --wait &> /dev/null"]
   }


### PR DESCRIPTION
- Re-trigger null resource to await completion of cloud-init when operator/bastion hosts are replaced.