### PR TITLE
feat: Support custom worker instance metadata

### DIFF
--- a/module-workers.tf
+++ b/module-workers.tf
@@ -55,6 +55,7 @@ module "workers" {
   kubeproxy_mode        = var.kubeproxy_mode
   max_pods_per_node     = var.max_pods_per_node
   node_labels           = var.worker_node_labels
+  node_metadata         = var.worker_node_metadata
   pod_nsg_ids           = concat(var.pod_nsg_ids, var.cni_type == "npn" ? [module.network.pod_nsg_id] : [])
   pod_subnet_id         = lookup(module.network.subnet_ids, "pods", "")
   pv_transit_encryption = var.worker_pv_transit_encryption

--- a/modules/workers/instanceconfig.tf
+++ b/modules/workers/instanceconfig.tf
@@ -44,7 +44,9 @@ resource "oci_core_instance_configuration" "workers" {
         },
 
         # Only provide cluster DNS service address if set explicitly; determined automatically in practice.
-        coalesce(var.cluster_dns, "none") == "none" ? {} : { kubedns_svc_ip = var.cluster_dns }
+        coalesce(var.cluster_dns, "none") == "none" ? {} : { kubedns_svc_ip = var.cluster_dns },
+
+        var.node_metadata, # Extra user-defined fields merged last
       )
 
       shape = each.value.shape

--- a/modules/workers/instanceconfig.tf
+++ b/modules/workers/instanceconfig.tf
@@ -46,7 +46,9 @@ resource "oci_core_instance_configuration" "workers" {
         # Only provide cluster DNS service address if set explicitly; determined automatically in practice.
         coalesce(var.cluster_dns, "none") == "none" ? {} : { kubedns_svc_ip = var.cluster_dns },
 
-        var.node_metadata, # Extra user-defined fields merged last
+        # Extra user-defined fields merged last
+        var.node_metadata,                       # global
+        lookup(each.value, "node_metadata", {}), # pool-specific
       )
 
       shape = each.value.shape

--- a/modules/workers/nodepools.tf
+++ b/modules/workers/nodepools.tf
@@ -61,7 +61,9 @@ resource "oci_containerengine_node_pool" "workers" {
     # Only provide cluster DNS service address if set explicitly; determined automatically in practice.
     coalesce(var.cluster_dns, "none") == "none" ? {} : { kubedns_svc_ip = var.cluster_dns },
 
-    var.node_metadata, # Extra user-defined fields merged last
+    # Extra user-defined fields merged last
+    var.node_metadata,                       # global
+    lookup(each.value, "node_metadata", {}), # pool-specific
   )
 
   dynamic "node_shape_config" {

--- a/modules/workers/nodepools.tf
+++ b/modules/workers/nodepools.tf
@@ -59,7 +59,9 @@ resource "oci_containerengine_node_pool" "workers" {
     },
 
     # Only provide cluster DNS service address if set explicitly; determined automatically in practice.
-    coalesce(var.cluster_dns, "none") == "none" ? {} : { kubedns_svc_ip = var.cluster_dns }
+    coalesce(var.cluster_dns, "none") == "none" ? {} : { kubedns_svc_ip = var.cluster_dns },
+
+    var.node_metadata, # Extra user-defined fields merged last
   )
 
   dynamic "node_shape_config" {

--- a/modules/workers/variables.tf
+++ b/modules/workers/variables.tf
@@ -46,6 +46,7 @@ variable "image_type" { type = string }
 variable "kubeproxy_mode" { type = string }
 variable "max_pods_per_node" { type = number }
 variable "node_labels" { type = map(string) }
+variable "node_metadata" { type = map(string) }
 variable "pv_transit_encryption" { type = bool }
 variable "shape" { type = map(any) }
 variable "ssh_public_key" { type = string }

--- a/variables-workers.tf
+++ b/variables-workers.tf
@@ -102,6 +102,12 @@ variable "worker_node_labels" {
   type        = map(string)
 }
 
+variable "worker_node_metadata" {
+  default     = {}
+  description = "Map of additional worker node instance metadata. Merged with metadata defined on each pool."
+  type        = map(string)
+}
+
 variable "worker_image_id" {
   default     = null
   description = "Default image for worker pools  when unspecified on a pool."


### PR DESCRIPTION
Adds a `worker_node_metadata` map variable for extra user-defined entries, merged with existing.