### PR TITLE
feat: 5.x Add configured VNICs to instance metadata when available

### DIFF
--- a/modules/workers/instanceconfig.tf
+++ b/modules/workers/instanceconfig.tf
@@ -39,6 +39,7 @@ resource "oci_core_instance_configuration" "workers" {
           oke-kubeproxy-proxy-mode = var.kubeproxy_mode
           oke-tenancy-id           = var.tenancy_id
           oke-initial-node-labels  = join(",", [for k, v in each.value.node_labels : "${k}=${v}"])
+          secondary_vnics          = jsonencode(lookup(each.value, "secondary_vnics", {}))
           ssh_authorized_keys      = var.ssh_public_key
           user_data                = lookup(lookup(data.cloudinit_config.workers, each.key, {}), "rendered", "")
         },


### PR DESCRIPTION
Makes expected VNIC attachment information available to worker nodes through instance metadata when available.