### PR TITLE
fix: Ignore tags for instance config VNIC details, CN instance pools

### DIFF
--- a/modules/workers/clusternetworks.tf
+++ b/modules/workers/clusternetworks.tf
@@ -33,7 +33,11 @@ resource "oci_core_cluster_network" "workers" {
   }
 
   lifecycle {
-    ignore_changes = [display_name, defined_tags, freeform_tags]
+    ignore_changes = [
+      display_name, defined_tags, freeform_tags,
+      instance_pools[0].defined_tags,
+      instance_pools[0].freeform_tags,
+    ]
 
     precondition {
       condition     = coalesce(each.value.image_id, "none") != "none"

--- a/modules/workers/instanceconfig.tf
+++ b/modules/workers/instanceconfig.tf
@@ -120,6 +120,8 @@ resource "oci_core_instance_configuration" "workers" {
       instance_details[0].launch_details[0].metadata,
       instance_details[0].launch_details[0].defined_tags,
       instance_details[0].launch_details[0].freeform_tags,
+      instance_details[0].launch_details[0].create_vnic_details[0].defined_tags,
+      instance_details[0].launch_details[0].create_vnic_details[0].freeform_tags,
       instance_details[0].secondary_vnics,
     ]
   }


### PR DESCRIPTION
Minor updates to lifecycle ignore rules for tags based on further testing.