### PR TITLE
fix: 5.x Lifecycle ignore fixes, individual worker mode

### DIFF
--- a/docs/codingconventions.adoc
+++ b/docs/codingconventions.adoc
@@ -11,6 +11,7 @@ endif::[]
 
 :uri-terraform-standard-module-structure: https://www.terraform.io/docs/language/modules/develop/structure.html
 :uri-oci-security-guide: https://docs.oracle.com/en-us/iaas/Content/Security/Concepts/security_guide.htm
+:uri-tflint: https://github.com/terraform-linters/tflint
 
 This project adheres to the following conventions:
 
@@ -86,6 +87,12 @@ Links that are used multiple times must be defined in the header using the `:uri
 - Use `snake_case` when naming Terraform files, variables and resources
 - If you need a new .tf file for better clarity, use this naming scheme: `<resources_group>`: e.g. `subnets.tf`, `nsgs.tf`
 - If your variable is controlling a behaviour, use imperative style to name it: e.g. `create_internet_gateway`, `use_cluster_encryption`
+
+=== Formatting/
+
+The following should be performed as needed before committing changes:
+- Run `terraform fmt -recursive` from the project root directory.
+- Run `tflint --recursive` from the project root directory (see {uri-tflint}[documentation here]) and address new warnings.
 
 === Variable blocks
 

--- a/module-cluster.tf
+++ b/module-cluster.tf
@@ -17,6 +17,7 @@ data "oci_containerengine_cluster_kube_config" "private" {
 locals {
   cluster_enabled        = var.create_cluster || coalesce(var.cluster_id, "none") != "none"
   cluster_id             = var.create_cluster ? one(module.cluster[*].cluster_id) : var.cluster_id
+  cluster_name           = coalesce(var.cluster_name, "oke-${local.state_id}")
   apiserver_private_host = local.cluster_enabled ? try(split(":", one(module.cluster[*].endpoints.private_endpoint))[0], "") : null
 
   kubeconfig_public  = var.control_plane_is_public ? try(yamldecode(lookup(one(data.oci_containerengine_cluster_kube_config.public), "content", "")), tomap({})) : null
@@ -34,18 +35,21 @@ module "cluster" {
   state_id       = local.state_id
 
   # Network
+  vcn_id                  = local.vcn_id
   cni_type                = var.cni_type
   control_plane_is_public = var.control_plane_is_public
   control_plane_nsg_ids   = setunion(var.control_plane_nsg_ids, var.create_nsgs ? [module.network.control_plane_nsg_id] : [])
   control_plane_subnet_id = lookup(module.network.subnet_ids, "cp")
   pods_cidr               = var.pods_cidr
-  service_lb_subnet_id    = lookup(module.network.subnet_ids, var.preferred_load_balancer == "public" ? "pub_lb" : "int_lb")
   services_cidr           = var.services_cidr
-  vcn_id                  = local.vcn_id
+  service_lb_subnet_id = (var.preferred_load_balancer == "public"
+    ? lookup(module.network.subnet_ids, "pub_lb")
+    : lookup(module.network.subnet_ids, "int_lb")
+  )
 
   # Cluster
   cluster_kms_key_id = var.cluster_kms_key_id
-  cluster_name       = var.cluster_name
+  cluster_name       = local.cluster_name
   cluster_type = lookup({
     "basic"    = "BASIC_CLUSTER",
     "enhanced" = "ENHANCED_CLUSTER"
@@ -68,12 +72,12 @@ module "cluster" {
 }
 
 output "cluster_id" {
-  description = "ID of the Kubernetes cluster"
+  description = "ID of the OKE cluster"
   value       = one(module.cluster[*].cluster_id)
 }
 
 output "cluster_endpoints" {
-  description = "Endpoints for the Kubernetes cluster"
+  description = "Endpoints for the OKE cluster"
   value       = var.create_cluster ? one(module.cluster[*].endpoints) : null
 }
 

--- a/module-network.tf
+++ b/module-network.tf
@@ -58,8 +58,8 @@ module "vcn" {
   nat_gateway_public_ip_id     = var.nat_gateway_public_ip_id
   nat_gateway_route_rules      = var.nat_gateway_route_rules
   vcn_cidrs                    = local.vcn_cidrs
-  vcn_dns_label                = var.assign_dns ? var.vcn_dns_label : null
-  vcn_name                     = var.vcn_name
+  vcn_dns_label                = var.assign_dns ? coalesce(var.vcn_dns_label, local.state_id) : null
+  vcn_name                     = coalesce(var.vcn_name, "oke-${local.state_id}")
 }
 
 module "drg" {
@@ -69,7 +69,7 @@ module "drg" {
   compartment_id = coalesce(var.network_compartment_id, local.compartment_id)
 
   drg_id              = var.drg_id # existing DRG ID or null
-  drg_display_name    = var.drg_display_name
+  drg_display_name    = coalesce(var.drg_display_name, "oke-${local.state_id}")
   drg_vcn_attachments = var.drg_attachments
 }
 

--- a/module-workers.tf
+++ b/module-workers.tf
@@ -19,7 +19,7 @@ locals {
 
 # Default workers sub-module implementation for OKE cluster
 module "workers" {
-  count  = var.create_cluster ? 1 : 0
+  count  = local.cluster_enabled ? 1 : 0
   source = "./modules/workers"
 
   # Common
@@ -99,6 +99,11 @@ output "worker_pools" {
 output "worker_pool_ids" {
   description = "Enabled worker pool IDs"
   value       = local.worker_count_expected > 0 ? one(module.workers[*].worker_pool_ids) : null
+}
+
+output "worker_instance_ids" {
+  description = "Created worker instance IDs (mode == 'instance'). Excludes pool-managed instances."
+  value       = one(module.workers[*].worker_instance_ids)
 }
 
 output "fss_id" {

--- a/modules/cluster/cluster.tf
+++ b/modules/cluster/cluster.tf
@@ -77,11 +77,16 @@ resource "oci_containerengine_cluster" "k8s_cluster" {
       freeform_tags = lookup(local.freeform_tags, "service_lb", {})
     }
 
-    service_lb_subnet_ids = [var.service_lb_subnet_id]
+    service_lb_subnet_ids = compact([var.service_lb_subnet_id])
   }
 
   lifecycle {
     ignore_changes = [defined_tags, freeform_tags, cluster_pod_network_options]
+
+    precondition {
+      condition     = var.service_lb_subnet_id != null
+      error_message = "Missing service load balancer subnet."
+    }
 
     precondition {
       condition     = !var.use_signed_images || length(var.image_signing_keys) > 0

--- a/modules/workers/instance.tf
+++ b/modules/workers/instance.tf
@@ -1,0 +1,76 @@
+resource "oci_core_instance" "workers" {
+  for_each             = local.enabled_instances
+  availability_domain  = element(each.value.availability_domains, 1)
+  compartment_id       = each.value.compartment_id
+  display_name         = each.key
+  preserve_boot_volume = false
+  shape                = each.value.shape
+
+  defined_tags  = each.value.defined_tags
+  freeform_tags = each.value.freeform_tags
+
+  dynamic "shape_config" {
+    for_each = length(regexall("Flex", each.value.shape)) > 0 ? [1] : []
+    content {
+      ocpus = each.value.ocpus
+      memory_in_gbs = ( # If > 64GB memory/core, correct input to exactly 64GB memory/core
+        (each.value.memory / each.value.ocpus) > 64 ? each.value.ocpus * 64 : each.value.memory
+      )
+    }
+  }
+
+  agent_config {
+    are_all_plugins_disabled = false
+    is_management_disabled   = false
+    is_monitoring_disabled   = false
+  }
+
+  create_vnic_details {
+    assign_private_dns_record = var.assign_dns
+    assign_public_ip          = each.value.assign_public_ip
+    nsg_ids                   = each.value.nsg_ids
+    subnet_id                 = each.value.subnet_id
+    defined_tags              = each.value.defined_tags
+    freeform_tags             = each.value.freeform_tags
+  }
+
+  instance_options {
+    are_legacy_imds_endpoints_disabled = false
+  }
+
+  metadata = merge(
+    {
+      apiserver_host           = var.apiserver_private_host
+      cluster_ca_cert          = var.cluster_ca_cert
+      oke-k8version            = var.kubernetes_version
+      oke-kubeproxy-proxy-mode = var.kubeproxy_mode
+      oke-tenancy-id           = var.tenancy_id
+      oke-initial-node-labels  = join(",", [for k, v in each.value.node_labels : "${k}=${v}"])
+      secondary_vnics          = jsonencode(lookup(each.value, "secondary_vnics", {}))
+      ssh_authorized_keys      = var.ssh_public_key
+      user_data                = lookup(lookup(data.cloudinit_config.workers, lookup(each.value, "key", ""), {}), "rendered", "")
+    },
+
+    # Only provide cluster DNS service address if set explicitly; determined automatically in practice.
+    coalesce(var.cluster_dns, "none") == "none" ? {} : { kubedns_svc_ip = var.cluster_dns },
+
+    # Extra user-defined fields merged last
+    var.node_metadata,                       # global
+    lookup(each.value, "node_metadata", {}), # pool-specific
+  )
+
+  source_details {
+    boot_volume_size_in_gbs = each.value.boot_volume_size
+    source_id               = each.value.image_id
+    source_type             = "image"
+  }
+
+  lifecycle {
+    ignore_changes = [
+      defined_tags, freeform_tags, display_name,
+      metadata["cluster_ca_cert"], metadata["user_data"],
+      create_vnic_details[0].defined_tags,
+      create_vnic_details[0].freeform_tags,
+    ]
+  }
+}

--- a/modules/workers/locals.tf
+++ b/modules/workers/locals.tf
@@ -84,24 +84,34 @@ locals {
 
       # Standard tags as defined if enabled for use
       # User-provided freeform tags are merged and take precedence
-      defined_tags = merge(var.use_defined_tags ? {
-        "${var.tag_namespace}.state_id"           = var.state_id,
-        "${var.tag_namespace}.role"               = "worker",
-        "${var.tag_namespace}.pool"               = pool_name,
-        "${var.tag_namespace}.cluster_autoscaler" = pool.allow_autoscaler ? "allowed" : "disabled",
-        } : {},
-        var.defined_tags, lookup(pool, "defined_tags", {}),
+      defined_tags = merge(
+        var.use_defined_tags ? merge(
+          {
+            "${var.tag_namespace}.state_id"           = var.state_id,
+            "${var.tag_namespace}.role"               = "worker",
+            "${var.tag_namespace}.pool"               = pool_name,
+            "${var.tag_namespace}.cluster_autoscaler" = pool.allow_autoscaler ? "allowed" : "disabled",
+          },
+          pool.autoscale ? { "${var.tag_namespace}.oraclecloud.com/cluster_autoscaler" = "managed" } : {},
+        ) : {},
+        var.defined_tags,
+        lookup(pool, "defined_tags", {})
       )
 
       # Standard tags as freeform if defined tags are disabled
       # User-provided freeform tags are merged and take precedence
-      freeform_tags = merge(!var.use_defined_tags ? {
-        "state_id"           = var.state_id,
-        "role"               = "worker",
-        "pool"               = pool_name,
-        "cluster_autoscaler" = pool.allow_autoscaler ? "allowed" : "disabled",
-        } : {},
-        var.freeform_tags, lookup(pool, "freeform_tags", {}),
+      freeform_tags = merge(
+        !var.use_defined_tags ? merge(
+          {
+            "state_id"           = var.state_id,
+            "role"               = "worker",
+            "pool"               = pool_name,
+            "cluster_autoscaler" = pool.allow_autoscaler ? "allowed" : "disabled",
+          },
+          pool.autoscale ? { "cluster_autoscaler" = "managed" } : {},
+        ) : {},
+        var.freeform_tags,
+        lookup(pool, "freeform_tags", {})
       )
 
       # Combine global and pool-specific NSGs
@@ -110,15 +120,14 @@ locals {
       # Add a node label for cluster autoscaler where scheduling is supported
       node_labels = merge(
         {
-          "oke.oraclecloud.com/tf.module"    = "terraform-oci-oke"
-          "oke.oraclecloud.com/tf.state_id"  = var.state_id
-          "oke.oraclecloud.com/tf.workspace" = terraform.workspace
-          "oke.oraclecloud.com/pool.name"    = pool_name
-          "oke.oraclecloud.com/pool.mode"    = pool.mode
+          "oke.oraclecloud.com/tf.module"          = "terraform-oci-oke"
+          "oke.oraclecloud.com/tf.state_id"        = var.state_id
+          "oke.oraclecloud.com/tf.workspace"       = terraform.workspace
+          "oke.oraclecloud.com/pool.name"          = pool_name
+          "oke.oraclecloud.com/pool.mode"          = pool.mode
+          "oke.oraclecloud.com/cluster_autoscaler" = pool.allow_autoscaler ? "allowed" : "disabled"
         },
-        pool.allow_autoscaler ? {
-          "oke.oraclecloud.com/cluster_autoscaler" = "allowed"
-        } : {},
+        pool.autoscale ? { "oke.oraclecloud.com/cluster_autoscaler" = "managed" } : {},
         var.node_labels,
       )
     }) if tobool(pool.create)
@@ -145,6 +154,13 @@ locals {
     for k, v in local.enabled_worker_pools : k => v if lookup(v, "mode", "") == "instance-pool"
   }
 
+  # Enabled worker_pool map entries for individual instances
+  enabled_instances = { for k, v in concat([], [
+    for k, v in local.enabled_worker_pools : [
+      for i in range(0, lookup(v, "size", 0)) : merge(v, { "key" = k, "index" = i })
+    ] if lookup(v, "mode", "") == "instance"
+  ]...) : "${lookup(v, "key")}-${k}" => v }
+
   # Enabled worker_pool map entries for cluster networks
   enabled_cluster_networks = {
     for k, v in local.enabled_worker_pools : k => v if lookup(v, "mode", "") == "cluster-network"
@@ -167,4 +183,5 @@ locals {
   worker_cluster_networks = { for k, v in oci_core_cluster_network.workers : k => merge(v, lookup(local.worker_pools_final, k, {})) }
   worker_pools_output     = merge(local.worker_node_pools, local.worker_instance_pools, local.worker_cluster_networks)
   worker_pool_ids         = { for k, v in local.worker_pools_output : k => v.id }
+  worker_instance_ids     = { for k, v in local.enabled_instances : k => lookup(lookup(oci_core_instance.workers, k, {}), "id", "") }
 }

--- a/modules/workers/nodepools.tf
+++ b/modules/workers/nodepools.tf
@@ -96,8 +96,8 @@ resource "oci_containerengine_node_pool" "workers" {
       kubernetes_version, # e.g. if changed as part of an upgrade
       name, defined_tags, freeform_tags,
       node_metadata["user_data"],               # templated cloud-init
-      node_config_details["placement_configs"], # dynamic placement configs
-      node_source_details,                      # dynamic image lookup
+      node_config_details[0].placement_configs, # dynamic placement configs
+      node_source_details[0],                   # dynamic image lookup
     ]
 
     precondition {
@@ -110,7 +110,7 @@ resource "oci_containerengine_node_pool" "workers" {
         contains(["instance-pool", "cluster-network"], each.value.mode), # supported modes
         length(lookup(each.value, "secondary_vnics", {})) == 0,          # unrestricted when empty/unset
       ])
-      error_message = "Unsupported option for mode: '${each.value.mode}'; var: 'secondary_vnics'"
+      error_message = "Unsupported option for mode=${each.value.mode}: secondary_vnics"
     }
   }
 

--- a/modules/workers/outputs.tf
+++ b/modules/workers/outputs.tf
@@ -11,6 +11,11 @@ output "worker_pool_ids" {
   value       = local.worker_pool_ids
 }
 
+output "worker_instance_ids" {
+  description = "Created worker instance IDs (mode == 'instance'). Excludes pool-managed instances."
+  value       = local.worker_instance_ids
+}
+
 output "worker_count_expected" {
   description = "# of nodes expected from created worker pools"
   value       = local.expected_node_count

--- a/variables-network.tf
+++ b/variables-network.tf
@@ -20,8 +20,8 @@ variable "create_nsgs_always" { // TODO Align with subnets declaration, never/au
 }
 
 variable "vcn_name" {
-  default     = "oke"
-  description = "Name of created VCN when `create_vcn = true`, or optional filter when `create_vcn = false`."
+  default     = null
+  description = "Display name for the created VCN. Defaults to 'oke' suffixed with the generated Terraform 'state_id' value."
   type        = string
 }
 
@@ -75,13 +75,13 @@ variable "nat_route_table_id" {
 
 variable "create_drg" {
   default     = false
-  description = "whether to create Dynamic Routing Gateway. If set to true, creates a Dynamic Routing Gateway and attach it to the VCN."
+  description = "Whether to create a Dynamic Routing Gateway and attach it to the VCN."
   type        = bool
 }
 
 variable "drg_display_name" {
-  default     = "drg"
-  description = "(Updatable) Name of Dynamic Routing Gateway. Does not have to be unique."
+  default     = null
+  description = "(Updatable) Name of the created Dynamic Routing Gateway. Does not have to be unique. Defaults to 'oke' suffixed with the generated Terraform 'state_id' value."
   type        = string
 }
 
@@ -143,14 +143,14 @@ variable "vcn_cidrs" {
 }
 
 variable "vcn_dns_label" {
-  default     = "oke"
-  description = "A DNS label for the VCN, used in conjunction with the VNIC's hostname and subnet's DNS label to form a fully qualified domain name (FQDN) for each VNIC within this subnet. DNS resolution of hostnames in the VCN is disabled when null."
+  default     = null
+  description = "A DNS label for the VCN, used in conjunction with the VNIC's hostname and subnet's DNS label to form a fully qualified domain name (FQDN) for each VNIC within this subnet. Defaults to the generated Terraform 'state_id' value."
   type        = string
 }
 
 variable "assign_dns" {
   default     = true
-  description = "Whether to assign DNS records to created instances."
+  description = "Whether to assign DNS records to created instances or disable DNS resolution of hostnames in the VCN."
   type        = bool
 }
 

--- a/variables-workers.tf
+++ b/variables-workers.tf
@@ -38,7 +38,7 @@ variable "worker_pool_mode" {
   description = "Default management mode for workers when unspecified on a pool. Only 'node-pool' is currently supported."
   type        = string
   validation {
-    condition     = contains(["node-pool", "instance-pool", "cluster-network"], var.worker_pool_mode)
+    condition     = contains(["node-pool", "instance", "instance-pool", "cluster-network"], var.worker_pool_mode)
     error_message = "Accepted values are node-pool, instance-pool, or cluster-network"
   }
 }


### PR DESCRIPTION
- Fix for over-matching with node pool lifecycle ignore.
- Add `mode = "instance"` for individual self-managed nodes outside of a pool. Extended fields pending implementation aren't required with standard usage and left for context later. Provides a simple reference implementation for the `oci_core_instance` resource and can be helpful with certain testing.
