### PR TITLE
feat: 5.x Add oci_containerengine_cluster type variable

### DIFF
--- a/examples/vars-cluster.auto.tfvars
+++ b/examples/vars-cluster.auto.tfvars
@@ -7,6 +7,7 @@ create_cluster     = true # *true/false
 cluster_dns        = "10.96.5.5"
 cluster_kms_key_id = null
 cluster_name       = "oke"
+cluster_type       = "basic" # *basic/enhanced
 cni_type           = "flannel"
 control_plane_type = "public"
 image_signing_keys = []

--- a/module-cluster.tf
+++ b/module-cluster.tf
@@ -45,6 +45,10 @@ module "cluster" {
   # Cluster
   cluster_kms_key_id = var.cluster_kms_key_id
   cluster_name       = var.cluster_name
+  cluster_type = lookup({
+    "basic"    = "BASIC_CLUSTER",
+    "enhanced" = "ENHANCED_CLUSTER"
+  }, lower(var.cluster_type), "BASIC_CLUSTER")
   kubernetes_version = var.kubernetes_version
 
   # KMS

--- a/modules/cluster/variables.tf
+++ b/modules/cluster/variables.tf
@@ -8,6 +8,7 @@ variable "state_id" { type = string }
 # Cluster
 variable "cluster_kms_key_id" { type = string }
 variable "cluster_name" { type = string }
+variable "cluster_type" { type = string }
 variable "cni_type" { type = string }
 variable "control_plane_is_public" { type = bool }
 variable "control_plane_nsg_ids" { type = set(string) }

--- a/variables-cluster.tf
+++ b/variables-cluster.tf
@@ -13,6 +13,16 @@ variable "cluster_name" {
   type        = string
 }
 
+variable "cluster_type" {
+  default     = "basic"
+  description = "The cluster type. See <a href=https://docs.oracle.com/en-us/iaas/Content/ContEng/Tasks/contengworkingwithenhancedclusters.htm>Working with Enhanced Clusters and Basic Clusters</a> for more information."
+  type        = string
+  validation {
+    condition     = contains(["basic", "enhanced"], lower(var.cluster_type))
+    error_message = "Accepted values are 'basic' or 'enhanced'."
+  }
+}
+
 variable "control_plane_is_public" {
   default     = true
   description = "Whether the Kubernetes control plane endpoint should be allocated a public IP address."

--- a/versions.tf
+++ b/versions.tf
@@ -23,7 +23,7 @@ terraform {
     oci = {
       configuration_aliases = [oci.home]
       source                = "oracle/oci"
-      version               = "~> 4.108.0"
+      version               = "~> 4.114.0"
     }
 
     random = {


### PR DESCRIPTION
- Add [oci_containerengine_cluster#type](https://registry.terraform.io/providers/oracle/oci/latest/docs/resources/containerengine_cluster#type) for [Enhanced clusters](https://docs.oracle.com/en-us/iaas/Content/ContEng/Tasks/contengworkingwithenhancedclusters.htm)
- Update `oci` provider version to `~> 4.114.0`