### PR TITLE
fix: Resource name-safe state_id

### DIFF
--- a/data-common.tf
+++ b/data-common.tf
@@ -1,10 +1,18 @@
 # Copyright (c) 2022, 2023 Oracle Corporation and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl
 
-resource "random_id" "state_id" {
-  byte_length = 6
+locals {
+  state_id = random_string.state_id.id
+}
+
+resource "random_string" "state_id" {
+  length  = 6
+  lower   = true
+  numeric = false
+  special = false
+  upper   = false
 }
 
 output "state_id" {
-  value = random_id.state_id.id
+  value = local.state_id
 }

--- a/module-bastion.tf
+++ b/module-bastion.tf
@@ -26,7 +26,7 @@ locals {
 module "bastion" {
   count          = var.create_bastion ? 1 : 0
   source         = "./modules/bastion"
-  state_id       = random_id.state_id.id
+  state_id       = local.state_id
   compartment_id = local.compartment_id
 
   # Bastion

--- a/module-cluster.tf
+++ b/module-cluster.tf
@@ -30,7 +30,7 @@ module "cluster" {
   count          = var.create_cluster ? 1 : 0
   source         = "./modules/cluster"
   compartment_id = local.compartment_id
-  state_id       = random_id.state_id.id
+  state_id       = local.state_id
 
   # Network
   cni_type                = var.cni_type

--- a/module-extensions.tf
+++ b/module-extensions.tf
@@ -2,9 +2,10 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl
 
 module "extensions" {
-  source = "./modules/extensions"
-  count  = local.operator_enabled ? 1 : 0
-  region = var.region
+  source   = "./modules/extensions"
+  count    = local.operator_enabled ? 1 : 0
+  region   = var.region
+  state_id = local.state_id
 
   # Cluster
   kubernetes_version  = var.kubernetes_version

--- a/module-iam.tf
+++ b/module-iam.tf
@@ -54,7 +54,7 @@ locals {
 module "iam" {
   source                       = "./modules/iam"
   compartment_id               = local.compartment_id
-  state_id                     = random_id.state_id.id
+  state_id                     = local.state_id
   tenancy_id                   = local.tenancy_id
   cluster_id                   = local.cluster_id
   create_iam_resources         = var.create_iam_resources

--- a/module-network.tf
+++ b/module-network.tf
@@ -81,7 +81,7 @@ module "drg" {
 
 module "network" {
   source           = "./modules/network"
-  state_id         = random_id.state_id.id
+  state_id         = local.state_id
   compartment_id   = coalesce(var.network_compartment_id, local.compartment_id)
   defined_tags     = lookup(var.defined_tags, "network", {})
   freeform_tags    = lookup(var.freeform_tags, "network", {})

--- a/module-operator.tf
+++ b/module-operator.tf
@@ -35,7 +35,7 @@ locals {
 module "operator" {
   count          = var.create_operator ? 1 : 0
   source         = "./modules/operator"
-  state_id       = random_id.state_id.id
+  state_id       = local.state_id
   compartment_id = local.compartment_id
 
   # Bastion (to await cloud-init completion)

--- a/module-workers.tf
+++ b/module-workers.tf
@@ -25,7 +25,7 @@ module "workers" {
   # Common
   compartment_id      = local.worker_compartment_id
   tenancy_id          = local.tenancy_id
-  state_id            = random_id.state_id.id
+  state_id            = local.state_id
   ad_numbers          = local.ad_numbers
   ad_numbers_to_names = local.ad_numbers_to_names
 


### PR DESCRIPTION
Use only lowercase alpha characters for generated `state_id` variable, to keep it compatible with some resource name constraints.