### PR TITLE
Preemptible 5.x

### DIFF
--- a/module-workers.tf
+++ b/module-workers.tf
@@ -65,6 +65,7 @@ module "workers" {
   volume_kms_key_id     = var.worker_volume_kms_key_id
   worker_nsg_ids        = concat(var.worker_nsg_ids, [module.network.worker_nsg_id])
   worker_subnet_id      = lookup(module.network.subnet_ids, "workers")
+  preemptible_config    = var.worker_preemptible_config
 
   # FSS
   create_fss              = var.create_fss

--- a/modules/workers/nodepools.tf
+++ b/modules/workers/nodepools.tf
@@ -29,6 +29,15 @@ resource "oci_containerengine_node_pool" "workers" {
       content {
         availability_domain = ad.value
         subnet_id           = each.value.subnet_id
+        dynamic "preemptible_node_config" {
+          for_each = each.value.preemptible_config.enable ? [1] : []
+          content {
+            preemption_action {
+              type                    = "TERMINATE"
+              is_preserve_boot_volume = each.value.preemptible_config.is_preserve_boot_volume
+            }
+          }
+        }
       }
     }
 

--- a/modules/workers/variables.tf
+++ b/modules/workers/variables.tf
@@ -52,6 +52,7 @@ variable "shape" { type = map(any) }
 variable "ssh_public_key" { type = string }
 variable "timezone" { type = string }
 variable "volume_kms_key_id" { type = string }
+variable "preemptible_config" { type = map(any) }
 
 # FSS
 variable "create_fss" { type = bool }

--- a/variables-workers.tf
+++ b/variables-workers.tf
@@ -147,6 +147,15 @@ variable "worker_shape" {
   type        = map(any)
 }
 
+variable "worker_preemptible_config" {
+  default = {
+    enable                  = false,
+    is_preserve_boot_volume = false
+  }
+  description = "Default preemptible Compute configuration when unspecified on a pool. See <a href=https://docs.oracle.com/en-us/iaas/Content/ContEng/Tasks/contengusingpreemptiblecapacity.htm>Preemptible Worker Nodes</a> for more information."
+  type        = map(any)
+}
+
 variable "worker_cloud_init" {
   default     = []
   description = "List of maps containing cloud init MIME part configuration for worker nodes. Merged with pool-specific definitions. See https://registry.terraform.io/providers/hashicorp/template/latest/docs/data-sources/cloudinit_config.html#part for expected schema of each element."

--- a/versions.tf
+++ b/versions.tf
@@ -23,7 +23,7 @@ terraform {
     oci = {
       configuration_aliases = [oci.home]
       source                = "oracle/oci"
-      version               = "~> 4.114.0"
+      version               = "~> 4.115.0"
     }
 
     random = {


### PR DESCRIPTION
This enables preemptible worker nodes during nodepool creation.
Examples of some of the invocations:

Default worker_preemptible:
`worker_preemptible_config = {enable = "false", is_preserve_boot_volume = "false"}`
 
Enable Preemptible :
`preemptible_np = { mode = "node-pool", size = 1, create = true, allow_autoscaler = true, placement_ads = [1] , preemptible_config = {enable = true, is_preserve_boot_volume = true}},`
Enable Preemptible with out preserving boot volume:
`preemptible_np1 = { mode = "node-pool", size = 1, create = true, allow_autoscaler = true, placement_ads = [2], 
preemptible_config = {enable = true, is_preserve_boot_volume = false}},`
Do not use Preemptible np:
`ondemand_np = { mode = "node-pool", size = 1, create = true, allow_autoscaler = true, placement_ads = [2]},`  

Nodepools created from above configuration:
![Screen Shot 2023-04-07 at 7 21 14 PM](https://user-images.githubusercontent.com/9535510/230943822-8757f8a8-3449-4091-afb8-50ddd22d90ac.png)
