### PR TITLE
Correct eviction grace duration in case of 0 (or default) timeout

### DIFF
--- a/modules/oke/nodepools.tf
+++ b/modules/oke/nodepools.tf
@@ -66,7 +66,7 @@ resource "oci_containerengine_node_pool" "nodepools" {
 
   node_eviction_node_pool_settings {
     #Optional
-    eviction_grace_duration              = format("PT%sM", lookup(each.value, "eviction_grace_duration", 0))
+    eviction_grace_duration              = lookup(each.value, "eviction_grace_duration", 0) == 0 ? "PT0S" : format("PT%sM", each.value.eviction_grace_duration)
     is_force_delete_after_grace_duration = tobool(lookup(each.value, "force_node_delete", true))
   }
 


### PR DESCRIPTION
The OCI prvider (4.114.0) wants a value of 0 timeout to be formatted as PT0S instead of PT0M, and would give plan residuals against PT0M, even though they are clearly equivalent.

So special case 0 minutes to be formatted as PT0S. No functional change.

Fixes: #688