### PR TITLE
feat: [4.x] Add support for preemptible worker nodes

### DIFF
--- a/modules/oke/nodepools.tf
+++ b/modules/oke/nodepools.tf
@@ -32,6 +32,15 @@ resource "oci_containerengine_node_pool" "nodepools" {
       content {
         availability_domain = ad_iterator.value
         subnet_id           = var.cluster_subnets["workers"]
+        dynamic "preemptible_node_config" {
+          for_each = lookup(lookup(each.value, "preemptible_config", {}), "enable", false)? [1]: []
+          content {
+            preemption_action {
+              type                    = "TERMINATE"
+              is_preserve_boot_volume = lookup(lookup(each.value, "preemptible_config", {}), "is_preserve_boot_volume", false)
+            }
+          }
+        }
       }
     }
 

--- a/terraform.tfvars.example
+++ b/terraform.tfvars.example
@@ -193,6 +193,16 @@ enable_pv_encryption_in_transit = false
 kubeproxy_mode = "iptables"
 node_pools = {
   # Basic node pool
+  #preemptible = {
+  #  shape            = "VM.Standard.1.1",
+  #  ocpus            = 1,
+  #  memory           = 1,
+  #  node_pool_size   = 1,
+  #  boot_volume_size = 150,
+  #  eviction_grace_duration = 0,  //Grade duration in minutes. Service default is 60.
+  #  force_node_delete       = true
+  #  preemptible_config = {"enable": true, "is_preserve_boot_volume": true}
+  #}
   #np1 = {
   #  shape            = "VM.Standard.E4.Flex",
   #  ocpus            = 2,

--- a/versions.tf
+++ b/versions.tf
@@ -6,7 +6,7 @@ terraform {
     oci = {
       source                = "oracle/oci"
       configuration_aliases = [oci.home]
-      version               = "~> 4.114.0"
+      version               = "~> 4.115.0"
     }
   }
   required_version = ">= 1.2.0"


### PR DESCRIPTION
Add support for preemptible worker nodes

Terraform plan differences from following configuration:

```hcl
node_pools = {
  np1 = {
    shape            = "VM.Standard.1.1",
    ocpus            = 1,
    memory           = 1,
    node_pool_size   = 1,
    boot_volume_size = 150,
    eviction_grace_duration = 0,  //Grade duration in minutes. Service default is 60.
    force_node_delete       = true
  }
  preemptible = {
    shape            = "VM.Standard.1.1",
    ocpus            = 1,
    memory           = 1,
    node_pool_size   = 1,
    boot_volume_size = 150,
    eviction_grace_duration = 0,  //Grade duration in minutes. Service default is 60.
    force_node_delete       = true
    preemptible_config = {"enable": true, "is_preserve_boot_volume": true}
  }
  preemptible1 = {
    shape            = "VM.Standard.1.1",
    ocpus            = 1,
    memory           = 1,
    node_pool_size   = 1,
    boot_volume_size = 150,
    eviction_grace_duration = 0,  //Grade duration in minutes. Service default is 60.
    force_node_delete       = true
    preemptible_config = {"enable": true, "is_preserve_boot_volume": false}
  }
  nonpreemptible = {
    shape            = "VM.Standard.1.1",
    ocpus            = 1,
    memory           = 1,
    node_pool_size   = 1,
    boot_volume_size = 150,
    eviction_grace_duration = 0,  //Grade duration in minutes. Service default is 60.
    force_node_delete       = true
    preemptible_config = {"enable": false, "is_preserve_boot_volume": false}
  }
```

terraform plan:

```hcl
# module.oke.oci_containerengine_node_pool.nodepools["nonpreemptible"] will be created
  + resource "oci_containerengine_node_pool" "nodepools" {
      + cluster_id          = "ocid1.cluster.oc1.iad.aaaaaaaavfgcv4bb3q634j4n2kjmanzajexc2lrg72ur62zl4csmiprrvcla"
      + compartment_id      = "ocid1.compartment.oc1..aaaaaaaaxksxxqwvbpim33mlyu6l7hgzu75e44qfl6dljm5nn4k3vquitehq"
      + defined_tags        = (known after apply)
      + freeform_tags       = (known after apply)
      + id                  = (known after apply)
      + kubernetes_version  = "v1.24.1"
      + lifecycle_details   = (known after apply)
      + name                = "dev-nonpreemptible"
      + node_image_id       = (known after apply)
      + node_image_name     = (known after apply)
      + node_metadata       = {
          + "oke-kubeproxy-proxy-mode" = "iptables"
          + "user_data"                = "Q29udGVudC1UeXBlOiBtdWx0aXBhcnQvbWl4ZWQ7IGJvdW5kYXJ5PSJNSU1FQk9VTkRBUlkiCk1JTUUtVmVyc2lvbjogMS4wDQoNCi0tTUlNRUJPVU5EQVJZDQpDb250ZW50LURpc3Bvc2l0aW9uOiBhdHRhY2htZW50OyBmaWxlbmFtZT0id29ya2VyLnNoIg0KQ29udGVudC1UcmFuc2Zlci1FbmNvZGluZzogN2JpdA0KQ29udGVudC1UeXBlOiB0ZXh0L3gtc2hlbGxzY3JpcHQNCk1pbWUtVmVyc2lvbjogMS4wDQoNCiMhL2Jpbi9iYXNoCgojIERPIE5PVCBNT0RJRlkKY3VybCAtLWZhaWwgLUggIkF1dGhvcml6YXRpb246IEJlYXJlciBPcmFjbGUiIC1MMCBodHRwOi8vMTY5LjI1NC4xNjkuMjU0L29wYy92Mi9pbnN0YW5jZS9tZXRhZGF0YS9va2VfaW5pdF9zY3JpcHQgfCBiYXNlNjQgLS1kZWNvZGUgPi92YXIvcnVuL29rZS1pbml0LnNoCgojIyBydW4gb2tlIHByb3Zpc2lvbmluZyBzY3JpcHQKYmFzaCAteCAvdmFyL3J1bi9va2UtaW5pdC5zaAoKIyMjIGFkanVzdCBibG9jayB2b2x1bWUgc2l6ZQovdXNyL2xpYmV4ZWMvb2NpLWdyb3dmcyAteQoKdGltZWRhdGVjdGwgc2V0LXRpbWV6b25lIEV0Yy9VVEMKCnRvdWNoIC92YXIvbG9nL29rZS5kb25lDQotLU1JTUVCT1VOREFSWS0tDQo="
        }
      + node_shape          = "VM.Standard.1.1"
      + node_source         = (known after apply)
      + nodes               = (known after apply)
      + quantity_per_subnet = (known after apply)
      + ssh_public_key      = (known after apply)
      + state               = (known after apply)
      + subnet_ids          = (known after apply)

      + node_config_details {
          + defined_tags                        = (known after apply)
          + freeform_tags                       = (known after apply)
          + is_pv_encryption_in_transit_enabled = false
          + kms_key_id                          = (known after apply)
          + nsg_ids                             = [
              + "ocid1.networksecuritygroup.oc1.iad.aaaaaaaaf2oqbwy7qurc44d7bmzt4efvesv5floeadbgo26oesgueuk6zbiq",
            ]
          + size                                = 1

          + node_pool_pod_network_option_details {
              + cni_type          = "FLANNEL_OVERLAY"
              + max_pods_per_node = (known after apply)
              + pod_nsg_ids       = (known after apply)
              + pod_subnet_ids    = (known after apply)
            }

          + placement_configs {
              + availability_domain     = "zkJl:US-ASHBURN-AD-1"
              + capacity_reservation_id = (known after apply)
              + fault_domains           = (known after apply)
              + subnet_id               = "ocid1.subnet.oc1.iad.aaaaaaaagsfdwaaqvcgtgk3d75gxl7rzennw2yrkrxrmcujmdaab6phlgh7q"
            }
          + placement_configs {
              + availability_domain     = "zkJl:US-ASHBURN-AD-2"
              + capacity_reservation_id = (known after apply)
              + fault_domains           = (known after apply)
              + subnet_id               = "ocid1.subnet.oc1.iad.aaaaaaaagsfdwaaqvcgtgk3d75gxl7rzennw2yrkrxrmcujmdaab6phlgh7q"
            }
          + placement_configs {
              + availability_domain     = "zkJl:US-ASHBURN-AD-3"
              + capacity_reservation_id = (known after apply)
              + fault_domains           = (known after apply)
              + subnet_id               = "ocid1.subnet.oc1.iad.aaaaaaaagsfdwaaqvcgtgk3d75gxl7rzennw2yrkrxrmcujmdaab6phlgh7q"
            }
        }

      + node_eviction_node_pool_settings {
          + eviction_grace_duration              = "PT0M"
          + is_force_delete_after_grace_duration = true
        }

      + node_source_details {
          + boot_volume_size_in_gbs = "150"
          + image_id                = "ocid1.image.oc1.iad.aaaaaaaa3fvrav2d4b6l7qgxnirporwjffau2pj7gj3onovigwp6sfq6kz7q"
          + source_type             = "IMAGE"
        }
    }

  # module.oke.oci_containerengine_node_pool.nodepools["np1"] will be created
  + resource "oci_containerengine_node_pool" "nodepools" {
      + cluster_id          = "ocid1.cluster.oc1.iad.aaaaaaaavfgcv4bb3q634j4n2kjmanzajexc2lrg72ur62zl4csmiprrvcla"
      + compartment_id      = "ocid1.compartment.oc1..aaaaaaaaxksxxqwvbpim33mlyu6l7hgzu75e44qfl6dljm5nn4k3vquitehq"
      + defined_tags        = (known after apply)
      + freeform_tags       = (known after apply)
      + id                  = (known after apply)
      + kubernetes_version  = "v1.24.1"
      + lifecycle_details   = (known after apply)
      + name                = "dev-np1"
      + node_image_id       = (known after apply)
      + node_image_name     = (known after apply)
      + node_metadata       = {
          + "oke-kubeproxy-proxy-mode" = "iptables"
          + "user_data"                = "Q29udGVudC1UeXBlOiBtdWx0aXBhcnQvbWl4ZWQ7IGJvdW5kYXJ5PSJNSU1FQk9VTkRBUlkiCk1JTUUtVmVyc2lvbjogMS4wDQoNCi0tTUlNRUJPVU5EQVJZDQpDb250ZW50LURpc3Bvc2l0aW9uOiBhdHRhY2htZW50OyBmaWxlbmFtZT0id29ya2VyLnNoIg0KQ29udGVudC1UcmFuc2Zlci1FbmNvZGluZzogN2JpdA0KQ29udGVudC1UeXBlOiB0ZXh0L3gtc2hlbGxzY3JpcHQNCk1pbWUtVmVyc2lvbjogMS4wDQoNCiMhL2Jpbi9iYXNoCgojIERPIE5PVCBNT0RJRlkKY3VybCAtLWZhaWwgLUggIkF1dGhvcml6YXRpb246IEJlYXJlciBPcmFjbGUiIC1MMCBodHRwOi8vMTY5LjI1NC4xNjkuMjU0L29wYy92Mi9pbnN0YW5jZS9tZXRhZGF0YS9va2VfaW5pdF9zY3JpcHQgfCBiYXNlNjQgLS1kZWNvZGUgPi92YXIvcnVuL29rZS1pbml0LnNoCgojIyBydW4gb2tlIHByb3Zpc2lvbmluZyBzY3JpcHQKYmFzaCAteCAvdmFyL3J1bi9va2UtaW5pdC5zaAoKIyMjIGFkanVzdCBibG9jayB2b2x1bWUgc2l6ZQovdXNyL2xpYmV4ZWMvb2NpLWdyb3dmcyAteQoKdGltZWRhdGVjdGwgc2V0LXRpbWV6b25lIEV0Yy9VVEMKCnRvdWNoIC92YXIvbG9nL29rZS5kb25lDQotLU1JTUVCT1VOREFSWS0tDQo="
        }
      + node_shape          = "VM.Standard.1.1"
      + node_source         = (known after apply)
      + nodes               = (known after apply)
      + quantity_per_subnet = (known after apply)
      + ssh_public_key      = (known after apply)
      + state               = (known after apply)
      + subnet_ids          = (known after apply)

      + node_config_details {
          + defined_tags                        = (known after apply)
          + freeform_tags                       = (known after apply)
          + is_pv_encryption_in_transit_enabled = false
          + kms_key_id                          = (known after apply)
          + nsg_ids                             = [
              + "ocid1.networksecuritygroup.oc1.iad.aaaaaaaaf2oqbwy7qurc44d7bmzt4efvesv5floeadbgo26oesgueuk6zbiq",
            ]
          + size                                = 1

          + node_pool_pod_network_option_details {
              + cni_type          = "FLANNEL_OVERLAY"
              + max_pods_per_node = (known after apply)
              + pod_nsg_ids       = (known after apply)
              + pod_subnet_ids    = (known after apply)
            }

          + placement_configs {
              + availability_domain     = "zkJl:US-ASHBURN-AD-1"
              + capacity_reservation_id = (known after apply)
              + fault_domains           = (known after apply)
              + subnet_id               = "ocid1.subnet.oc1.iad.aaaaaaaagsfdwaaqvcgtgk3d75gxl7rzennw2yrkrxrmcujmdaab6phlgh7q"
            }
          + placement_configs {
              + availability_domain     = "zkJl:US-ASHBURN-AD-2"
              + capacity_reservation_id = (known after apply)
              + fault_domains           = (known after apply)
              + subnet_id               = "ocid1.subnet.oc1.iad.aaaaaaaagsfdwaaqvcgtgk3d75gxl7rzennw2yrkrxrmcujmdaab6phlgh7q"
            }
          + placement_configs {
              + availability_domain     = "zkJl:US-ASHBURN-AD-3"
              + capacity_reservation_id = (known after apply)
              + fault_domains           = (known after apply)
              + subnet_id               = "ocid1.subnet.oc1.iad.aaaaaaaagsfdwaaqvcgtgk3d75gxl7rzennw2yrkrxrmcujmdaab6phlgh7q"
            }
        }

      + node_eviction_node_pool_settings {
          + eviction_grace_duration              = "PT0M"
          + is_force_delete_after_grace_duration = true
        }

      + node_source_details {
          + boot_volume_size_in_gbs = "150"
          + image_id                = "ocid1.image.oc1.iad.aaaaaaaa3fvrav2d4b6l7qgxnirporwjffau2pj7gj3onovigwp6sfq6kz7q"
          + source_type             = "IMAGE"
        }
    }

  # module.oke.oci_containerengine_node_pool.nodepools["preemptible"] will be created
  + resource "oci_containerengine_node_pool" "nodepools" {
      + cluster_id          = "ocid1.cluster.oc1.iad.aaaaaaaavfgcv4bb3q634j4n2kjmanzajexc2lrg72ur62zl4csmiprrvcla"
      + compartment_id      = "ocid1.compartment.oc1..aaaaaaaaxksxxqwvbpim33mlyu6l7hgzu75e44qfl6dljm5nn4k3vquitehq"
      + defined_tags        = (known after apply)
      + freeform_tags       = (known after apply)
      + id                  = (known after apply)
      + kubernetes_version  = "v1.24.1"
      + lifecycle_details   = (known after apply)
      + name                = "dev-preemptible"
      + node_image_id       = (known after apply)
      + node_image_name     = (known after apply)
      + node_metadata       = {
          + "oke-kubeproxy-proxy-mode" = "iptables"
          + "user_data"                = "Q29udGVudC1UeXBlOiBtdWx0aXBhcnQvbWl4ZWQ7IGJvdW5kYXJ5PSJNSU1FQk9VTkRBUlkiCk1JTUUtVmVyc2lvbjogMS4wDQoNCi0tTUlNRUJPVU5EQVJZDQpDb250ZW50LURpc3Bvc2l0aW9uOiBhdHRhY2htZW50OyBmaWxlbmFtZT0id29ya2VyLnNoIg0KQ29udGVudC1UcmFuc2Zlci1FbmNvZGluZzogN2JpdA0KQ29udGVudC1UeXBlOiB0ZXh0L3gtc2hlbGxzY3JpcHQNCk1pbWUtVmVyc2lvbjogMS4wDQoNCiMhL2Jpbi9iYXNoCgojIERPIE5PVCBNT0RJRlkKY3VybCAtLWZhaWwgLUggIkF1dGhvcml6YXRpb246IEJlYXJlciBPcmFjbGUiIC1MMCBodHRwOi8vMTY5LjI1NC4xNjkuMjU0L29wYy92Mi9pbnN0YW5jZS9tZXRhZGF0YS9va2VfaW5pdF9zY3JpcHQgfCBiYXNlNjQgLS1kZWNvZGUgPi92YXIvcnVuL29rZS1pbml0LnNoCgojIyBydW4gb2tlIHByb3Zpc2lvbmluZyBzY3JpcHQKYmFzaCAteCAvdmFyL3J1bi9va2UtaW5pdC5zaAoKIyMjIGFkanVzdCBibG9jayB2b2x1bWUgc2l6ZQovdXNyL2xpYmV4ZWMvb2NpLWdyb3dmcyAteQoKdGltZWRhdGVjdGwgc2V0LXRpbWV6b25lIEV0Yy9VVEMKCnRvdWNoIC92YXIvbG9nL29rZS5kb25lDQotLU1JTUVCT1VOREFSWS0tDQo="
        }
      + node_shape          = "VM.Standard.1.1"
      + node_source         = (known after apply)
      + nodes               = (known after apply)
      + quantity_per_subnet = (known after apply)
      + ssh_public_key      = (known after apply)
      + state               = (known after apply)
      + subnet_ids          = (known after apply)

      + node_config_details {
          + defined_tags                        = (known after apply)
          + freeform_tags                       = (known after apply)
          + is_pv_encryption_in_transit_enabled = false
          + kms_key_id                          = (known after apply)
          + nsg_ids                             = [
              + "ocid1.networksecuritygroup.oc1.iad.aaaaaaaaf2oqbwy7qurc44d7bmzt4efvesv5floeadbgo26oesgueuk6zbiq",
            ]
          + size                                = 1

          + node_pool_pod_network_option_details {
              + cni_type          = "FLANNEL_OVERLAY"
              + max_pods_per_node = (known after apply)
              + pod_nsg_ids       = (known after apply)
              + pod_subnet_ids    = (known after apply)
            }

          + placement_configs {
              + availability_domain     = "zkJl:US-ASHBURN-AD-1"
              + capacity_reservation_id = (known after apply)
              + fault_domains           = (known after apply)
              + subnet_id               = "ocid1.subnet.oc1.iad.aaaaaaaagsfdwaaqvcgtgk3d75gxl7rzennw2yrkrxrmcujmdaab6phlgh7q"

              + preemptible_node_config {
                  + preemption_action {
                      + is_preserve_boot_volume = true
                      + type                    = "TERMINATE"
                    }
                }
            }
          + placement_configs {
              + availability_domain     = "zkJl:US-ASHBURN-AD-2"
              + capacity_reservation_id = (known after apply)
              + fault_domains           = (known after apply)
              + subnet_id               = "ocid1.subnet.oc1.iad.aaaaaaaagsfdwaaqvcgtgk3d75gxl7rzennw2yrkrxrmcujmdaab6phlgh7q"

              + preemptible_node_config {
                  + preemption_action {
                      + is_preserve_boot_volume = true
                      + type                    = "TERMINATE"
                    }
                }
            }
          + placement_configs {
              + availability_domain     = "zkJl:US-ASHBURN-AD-3"
              + capacity_reservation_id = (known after apply)
              + fault_domains           = (known after apply)
              + subnet_id               = "ocid1.subnet.oc1.iad.aaaaaaaagsfdwaaqvcgtgk3d75gxl7rzennw2yrkrxrmcujmdaab6phlgh7q"

              + preemptible_node_config {
                  + preemption_action {
                      + is_preserve_boot_volume = true
                      + type                    = "TERMINATE"
                    }
                }
            }
        }

      + node_eviction_node_pool_settings {
          + eviction_grace_duration              = "PT0M"
          + is_force_delete_after_grace_duration = true
        }

      + node_source_details {
          + boot_volume_size_in_gbs = "150"
          + image_id                = "ocid1.image.oc1.iad.aaaaaaaa3fvrav2d4b6l7qgxnirporwjffau2pj7gj3onovigwp6sfq6kz7q"
          + source_type             = "IMAGE"
        }
    }

  # module.oke.oci_containerengine_node_pool.nodepools["preemptible1"] will be created
  + resource "oci_containerengine_node_pool" "nodepools" {
      + cluster_id          = "ocid1.cluster.oc1.iad.aaaaaaaavfgcv4bb3q634j4n2kjmanzajexc2lrg72ur62zl4csmiprrvcla"
      + compartment_id      = "ocid1.compartment.oc1..aaaaaaaaxksxxqwvbpim33mlyu6l7hgzu75e44qfl6dljm5nn4k3vquitehq"
      + defined_tags        = (known after apply)
      + freeform_tags       = (known after apply)
      + id                  = (known after apply)
      + kubernetes_version  = "v1.24.1"
      + lifecycle_details   = (known after apply)
      + name                = "dev-preemptible1"
      + node_image_id       = (known after apply)
      + node_image_name     = (known after apply)
      + node_metadata       = {
          + "oke-kubeproxy-proxy-mode" = "iptables"
          + "user_data"                = "Q29udGVudC1UeXBlOiBtdWx0aXBhcnQvbWl4ZWQ7IGJvdW5kYXJ5PSJNSU1FQk9VTkRBUlkiCk1JTUUtVmVyc2lvbjogMS4wDQoNCi0tTUlNRUJPVU5EQVJZDQpDb250ZW50LURpc3Bvc2l0aW9uOiBhdHRhY2htZW50OyBmaWxlbmFtZT0id29ya2VyLnNoIg0KQ29udGVudC1UcmFuc2Zlci1FbmNvZGluZzogN2JpdA0KQ29udGVudC1UeXBlOiB0ZXh0L3gtc2hlbGxzY3JpcHQNCk1pbWUtVmVyc2lvbjogMS4wDQoNCiMhL2Jpbi9iYXNoCgojIERPIE5PVCBNT0RJRlkKY3VybCAtLWZhaWwgLUggIkF1dGhvcml6YXRpb246IEJlYXJlciBPcmFjbGUiIC1MMCBodHRwOi8vMTY5LjI1NC4xNjkuMjU0L29wYy92Mi9pbnN0YW5jZS9tZXRhZGF0YS9va2VfaW5pdF9zY3JpcHQgfCBiYXNlNjQgLS1kZWNvZGUgPi92YXIvcnVuL29rZS1pbml0LnNoCgojIyBydW4gb2tlIHByb3Zpc2lvbmluZyBzY3JpcHQKYmFzaCAteCAvdmFyL3J1bi9va2UtaW5pdC5zaAoKIyMjIGFkanVzdCBibG9jayB2b2x1bWUgc2l6ZQovdXNyL2xpYmV4ZWMvb2NpLWdyb3dmcyAteQoKdGltZWRhdGVjdGwgc2V0LXRpbWV6b25lIEV0Yy9VVEMKCnRvdWNoIC92YXIvbG9nL29rZS5kb25lDQotLU1JTUVCT1VOREFSWS0tDQo="
        }
      + node_shape          = "VM.Standard.1.1"
      + node_source         = (known after apply)
      + nodes               = (known after apply)
      + quantity_per_subnet = (known after apply)
      + ssh_public_key      = (known after apply)
      + state               = (known after apply)
      + subnet_ids          = (known after apply)

      + node_config_details {
          + defined_tags                        = (known after apply)
          + freeform_tags                       = (known after apply)
          + is_pv_encryption_in_transit_enabled = false
          + kms_key_id                          = (known after apply)
          + nsg_ids                             = [
              + "ocid1.networksecuritygroup.oc1.iad.aaaaaaaaf2oqbwy7qurc44d7bmzt4efvesv5floeadbgo26oesgueuk6zbiq",
            ]
          + size                                = 1

          + node_pool_pod_network_option_details {
              + cni_type          = "FLANNEL_OVERLAY"
              + max_pods_per_node = (known after apply)
              + pod_nsg_ids       = (known after apply)
              + pod_subnet_ids    = (known after apply)
            }

          + placement_configs {
              + availability_domain     = "zkJl:US-ASHBURN-AD-1"
              + capacity_reservation_id = (known after apply)
              + fault_domains           = (known after apply)
              + subnet_id               = "ocid1.subnet.oc1.iad.aaaaaaaagsfdwaaqvcgtgk3d75gxl7rzennw2yrkrxrmcujmdaab6phlgh7q"

              + preemptible_node_config {
                  + preemption_action {
                      + is_preserve_boot_volume = false
                      + type                    = "TERMINATE"
                    }
                }
            }
          + placement_configs {
              + availability_domain     = "zkJl:US-ASHBURN-AD-2"
              + capacity_reservation_id = (known after apply)
              + fault_domains           = (known after apply)
              + subnet_id               = "ocid1.subnet.oc1.iad.aaaaaaaagsfdwaaqvcgtgk3d75gxl7rzennw2yrkrxrmcujmdaab6phlgh7q"

              + preemptible_node_config {
                  + preemption_action {
                      + is_preserve_boot_volume = false
                      + type                    = "TERMINATE"
                    }
                }
            }
          + placement_configs {
              + availability_domain     = "zkJl:US-ASHBURN-AD-3"
              + capacity_reservation_id = (known after apply)
              + fault_domains           = (known after apply)
              + subnet_id               = "ocid1.subnet.oc1.iad.aaaaaaaagsfdwaaqvcgtgk3d75gxl7rzennw2yrkrxrmcujmdaab6phlgh7q"

              + preemptible_node_config {
                  + preemption_action {
                      + is_preserve_boot_volume = false
                      + type                    = "TERMINATE"
                    }
                }
            }
        }

      + node_eviction_node_pool_settings {
          + eviction_grace_duration              = "PT0M"
          + is_force_delete_after_grace_duration = true
        }

      + node_source_details {
          + boot_volume_size_in_gbs = "150"
          + image_id                = "ocid1.image.oc1.iad.aaaaaaaa3fvrav2d4b6l7qgxnirporwjffau2pj7gj3onovigwp6sfq6kz7q"
          + source_type             = "IMAGE"
        }
    }

Plan: 4 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  ~ autoscaling_nodepools       = [
      + {
          + max_node_pool_size = 1
          + name               = "nonpreemptible"
          + node_pool_size     = 1
        },
      + {
          + max_node_pool_size = 1
          + name               = "np1"
          + node_pool_size     = 1
        },
      + {
          + max_node_pool_size = 1
          + name               = "preemptible"
          + node_pool_size     = 1
        },
      + {
          + max_node_pool_size = 1
          + name               = "preemptible1"
          + node_pool_size     = 1
        },
    ]
```