### PR TITLE
Fix: ssh_to_operator output use long form

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -76,7 +76,7 @@ output "operator_private_ip" {
 
 output "ssh_to_operator" {
   description = "convenient command to ssh to the operator host"
-  value       = "ssh${local.ssh_key_arg} -J ${var.bastion_user}@${local.bastion_public_ip} ${var.operator_user}@${local.operator_private_ip}"
+  value       = "ssh${local.ssh_key_arg} -o ProxyCommand='ssh ${local.ssh_key_arg} -W %h:%p ${var.bastion_user}@${local.bastion_public_ip}' ${var.operator_user}@${local.operator_private_ip}"
 }
 
 output "ssh_to_bastion" {


### PR DESCRIPTION
This commit Updates the terraform output for `ssh_to_operator` so that you can use a private key that is anywhere on the filesystem.  Currently the short form (`-J`) does not allow you to pass any arguments like `-i`, therefore if your ssh key is not in a default location that openssh knows about it will fail to connect.

More info in this issue: https://github.com/oracle-terraform-modules/terraform-oci-oke/issues/246