### PR TITLE
fix: 5.x Misc fixes, worker/deploy examples

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -31,6 +31,12 @@
 
 This {uri-repo}[Terraform OKE Installer] for {uri-oci}[Oracle Cloud Infrastructure] provides a reusable Terraform module that provisions a {uri-oke}[Oracle Container Engine] cluster.
 
+++++
+<a href="https://cloud.oracle.com/resourcemanager/stacks/create?zipUrl=https://objectstorage.ap-osaka-1.oraclecloud.com/p/_Wt0-8C_kJrl9oiT9WQyF6a1m0W1YI2N_1NCBSsv3iWbrycoE-UOV1Shqi0N-3VL/n/hpc_limited_availability/b/temporary/o/rms-oke-full.20230330-2.zip" target="_blank">
+  <img src="https://oci-resourcemanager-plugin.plugins.oci.oraclecloud.com/latest/deploy-to-oracle-cloud.svg" alt="Deploy to Oracle Cloud"/>
+</a>
+++++
+
 == {uri-docs}[Documentation]
 * {uri-prereqs}[Prerequisites]
 * {uri-quickstart}[Quick Start]

--- a/data-common.tf
+++ b/data-common.tf
@@ -2,7 +2,7 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl
 
 locals {
-  state_id = random_string.state_id.id
+  state_id = coalesce(var.state_id, random_string.state_id.id)
 }
 
 resource "random_string" "state_id" {

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -1,0 +1,102 @@
+# Deploy the OKE Terraform Module
+
+## Prerequisites
+* [Required Keys and OCIDs](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/apisigningkey.htm)
+* [Required IAM policies](https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengpolicyconfig.htm#PolicyPrerequisitesService)
+* `git`, `ssh` client to run locally
+* Terraform `>= 1.2.0` to run locally
+
+## Provisioning from an OCI Resource Manager Stack
+<table>
+  <tr>
+    <th>Name</th>
+    <th>Resources</th>
+    <th>Deploy</th>
+  </tr>
+  <tr>
+    <td>OKE Network Only</td>
+    <td>
+      <li><a href=https://registry.terraform.io/providers/oracle/oci/latest/docs/resources/core_vcn>core_vcn</a></li>
+      <li><a href=https://registry.terraform.io/providers/oracle/oci/latest/docs/resources/core_nat_gateway>core_nat_gateway</a></li>
+      <li><a href=https://registry.terraform.io/providers/oracle/oci/latest/docs/resources/core_internet_gateway>core_internet_gateway</a></li>
+      <li><a href=https://registry.terraform.io/providers/oracle/oci/latest/docs/resources/core_subnet>core_subnet</a> (all)</li>
+      <li><a href=https://registry.terraform.io/providers/oracle/oci/latest/docs/resources/core_instance>core_instance</a> (bastion)</li>
+    </td>
+    <td><a href=https://cloud.oracle.com/resourcemanager/stacks/create?zipUrl=https://objectstorage.ap-osaka-1.oraclecloud.com/p/vFo1AKj2b5_ptWQzTW8PorFW2is7zjlSlnIU9pKF9pWG6gMoBDVVwfO-tGOu_mK6/n/hpc_limited_availability/b/temporary/o/oke-network-only.20230404-2.zip target="_blank">
+        <img src="https://oci-resourcemanager-plugin.plugins.oci.oraclecloud.com/latest/deploy-to-oracle-cloud.svg" alt="Deploy to Oracle Cloud"/></a>
+    </td>
+  </tr>
+  <tr>
+    <td>OKE Cluster <i>(new network)</i></td>
+    <td>
+      <li><a href=https://registry.terraform.io/providers/oracle/oci/latest/docs/resources/core_vcn>core_vcn</a></li>
+      <li><a href=https://registry.terraform.io/providers/oracle/oci/latest/docs/resources/core_nat_gateway>core_nat_gateway</a></li>
+      <li><a href=https://registry.terraform.io/providers/oracle/oci/latest/docs/resources/core_internet_gateway>core_internet_gateway</a></li>
+      <li><a href=https://registry.terraform.io/providers/oracle/oci/latest/docs/resources/core_subnet>core_subnet</a> (configured)</li>
+      <li><a href=https://registry.terraform.io/providers/oracle/oci/latest/docs/resources/core_network_security_group>core_network_security_group</a></li>
+      <li><a href=https://registry.terraform.io/providers/oracle/oci/latest/docs/resources/core_network_security_group_security_rule>core_network_security_group_security_rule</a></li>
+      <li><a href=https://registry.terraform.io/providers/oracle/oci/latest/docs/resources/core_instance>core_instance</a> (bastion, operator)</li>
+      <li><a href=https://registry.terraform.io/providers/oracle/oci/latest/docs/resources/containerengine_cluster>containerengine_cluster</a></li>
+    </td>
+    <td><a href=https://cloud.oracle.com/resourcemanager/stacks/create?zipUrl=https://objectstorage.ap-osaka-1.oraclecloud.com/p/tHj8r2oK37qUCyZ-bC7lPnjG3ZMhqiK0zVZDcd58aaBUr62jUm95kSzJExEKT-9A/n/hpc_limited_availability/b/temporary/o/oke-cluster-with-network.20230404-2.zip&zipUrlVariables={"cluster_name":"oke-cluster-with-network"} target="_blank">
+        <img src="https://oci-resourcemanager-plugin.plugins.oci.oraclecloud.com/latest/deploy-to-oracle-cloud.svg" alt="Deploy to Oracle Cloud"/></a>
+    </td>
+  </tr>
+  <tr>
+    <td>OKE Cluster <i>(existing network)</a></td>
+    <td>
+      <li><a href=https://registry.terraform.io/providers/oracle/oci/latest/docs/resources/core_network_security_group>core_network_security_group</a></li>
+      <li><a href=https://registry.terraform.io/providers/oracle/oci/latest/docs/resources/core_network_security_group_security_rule>core_network_security_group_security_rule</a></li>
+      <li><a href=https://registry.terraform.io/providers/oracle/oci/latest/docs/resources/core_instance>core_instance</a> (operator)</li>
+      <li><a href=https://registry.terraform.io/providers/oracle/oci/latest/docs/resources/containerengine_cluster>containerengine_cluster</a></li>
+    </td>
+    <td><a href=https://cloud.oracle.com/resourcemanager/stacks/create?zipUrl=https://objectstorage.ap-osaka-1.oraclecloud.com/p/tHj8r2oK37qUCyZ-bC7lPnjG3ZMhqiK0zVZDcd58aaBUr62jUm95kSzJExEKT-9A/n/hpc_limited_availability/b/temporary/o/oke-cluster-with-network.20230404-2.zip&zipUrlVariables={"cluster_name":"oke-cluster-existing-network","create_vcn":false,"create_nsgs":false,"create_bastion":false,"worker_subnet_create":"Never","control_plane_subnet_create":"Never","operator_subnet_create":"Never","bastion_subnet_create":"Never","pod_subnet_create":"Never","int_lb_subnet_create":"Never","pub_lb_subnet_create":"Never","fss_subnet_create":"Never"} target="_blank">
+        <img src="https://oci-resourcemanager-plugin.plugins.oci.oraclecloud.com/latest/deploy-to-oracle-cloud.svg" alt="Deploy to Oracle Cloud"/></a>
+    </td>
+  </tr>
+  <tr>
+    <td>OKE-Managed Node Pool</td>
+    <td>
+      <li><a href=https://registry.terraform.io/providers/oracle/oci/latest/docs/resources/containerengine_node_pool>containerengine_node_pool</a></li>
+    </td>
+    <td><a href=https://cloud.oracle.com/resourcemanager/stacks/create?zipUrl=https://objectstorage.ap-osaka-1.oraclecloud.com/p/XidL_HsLx4P-BPg7lAhydhSNYjTeZlF7tGg7Ras0eAMs_k52pvxdXi8enfsFFbtN/n/hpc_limited_availability/b/temporary/o/oke-workers.20230404.zip&zipUrlVariables={"worker_pool_mode":"Node%20Pool","worker_pool_name":"oke-node-pool"} target="_blank">
+        <img src="https://oci-resourcemanager-plugin.plugins.oci.oraclecloud.com/latest/deploy-to-oracle-cloud.svg" alt="Deploy to Oracle Cloud"/></a>
+    </td>
+  </tr>
+  <tr>
+    <td>Self-Managed Instances</td>
+    <td>
+      <li><a href=https://registry.terraform.io/providers/oracle/oci/latest/docs/resources/identity_dynamic_group>identity_dynamic_group</a> (workers)</li>
+      <li><a href=https://registry.terraform.io/providers/oracle/oci/latest/docs/resources/identity_policy>identity_policy</a> (JoinCluster)</li>
+      <li><a href=https://registry.terraform.io/providers/oracle/oci/latest/docs/resources/core_instance>core_instance</a></li>
+    </td>
+    <td><a href=https://cloud.oracle.com/resourcemanager/stacks/create?zipUrl=https://objectstorage.ap-osaka-1.oraclecloud.com/p/XidL_HsLx4P-BPg7lAhydhSNYjTeZlF7tGg7Ras0eAMs_k52pvxdXi8enfsFFbtN/n/hpc_limited_availability/b/temporary/o/oke-workers.20230404.zip&zipUrlVariables={"worker_pool_mode":"Instances","worker_pool_name":"oke-instances"} target="_blank">
+        <img src="https://oci-resourcemanager-plugin.plugins.oci.oraclecloud.com/latest/deploy-to-oracle-cloud.svg" alt="Deploy to Oracle Cloud"/></a>
+    </td>
+  </tr>
+  <tr>
+    <td>Self-Managed Instance Pool</td>
+    <td>
+      <li><a href=https://registry.terraform.io/providers/oracle/oci/latest/docs/resources/identity_dynamic_group>identity_dynamic_group</a> (workers)</li>
+      <li><a href=https://registry.terraform.io/providers/oracle/oci/latest/docs/resources/identity_policy>identity_policy</a> (JoinCluster)</li>
+      <li><a href=https://registry.terraform.io/providers/oracle/oci/latest/docs/resources/core_instance_configuration>core_instance_configuration</a></li>
+      <li><a href=https://registry.terraform.io/providers/oracle/oci/latest/docs/resources/core_instance_pool>core_instance_pool</a></li>
+    </td>
+    <td><a href=https://cloud.oracle.com/resourcemanager/stacks/create?zipUrl=https://objectstorage.ap-osaka-1.oraclecloud.com/p/XidL_HsLx4P-BPg7lAhydhSNYjTeZlF7tGg7Ras0eAMs_k52pvxdXi8enfsFFbtN/n/hpc_limited_availability/b/temporary/o/oke-workers.20230404.zip&zipUrlVariables={"worker_pool_mode":"Instance%20Pool","worker_pool_name":"oke-instance-pool"} target="_blank">
+        <img src="https://oci-resourcemanager-plugin.plugins.oci.oraclecloud.com/latest/deploy-to-oracle-cloud.svg" alt="Deploy to Oracle Cloud"/></a>
+    </td>
+  </tr>
+  <tr>
+    <td>Self-Managed Cluster Network</td>
+    <td>
+      <li><a href=https://registry.terraform.io/providers/oracle/oci/latest/docs/resources/identity_dynamic_group>identity_dynamic_group</a> (workers)</li>
+      <li><a href=https://registry.terraform.io/providers/oracle/oci/latest/docs/resources/identity_policy>identity_policy</a> (JoinCluster)</li>
+      <li><a href=https://registry.terraform.io/providers/oracle/oci/latest/docs/resources/core_instance_configuration>core_instance_configuration</a></li>
+      <li><a href=https://registry.terraform.io/providers/oracle/oci/latest/docs/resources/core_cluster_network>core_cluster_network</a></li>
+    </td>
+    <td><a href=https://cloud.oracle.com/resourcemanager/stacks/create?zipUrl=https://objectstorage.ap-osaka-1.oraclecloud.com/p/XidL_HsLx4P-BPg7lAhydhSNYjTeZlF7tGg7Ras0eAMs_k52pvxdXi8enfsFFbtN/n/hpc_limited_availability/b/temporary/o/oke-workers.20230404.zip&zipUrlVariables={"worker_pool_mode":"Cluster%20Network","worker_pool_name":"oke-cluster-network","worker_shape":"BM.GPU.B4.8"} target="_blank">
+        <img src="https://oci-resourcemanager-plugin.plugins.oci.oraclecloud.com/latest/deploy-to-oracle-cloud.svg" alt="Deploy to Oracle Cloud"/></a>
+    </td>
+  </tr>
+</table>
+

--- a/docs/quickstart.adoc
+++ b/docs/quickstart.adoc
@@ -21,85 +21,187 @@
 :uri-terraform-options: {uri-docs}/terraformoptions.adoc
 :uri-terraform-precedence: https://www.terraform.io/docs/language/values/variables.html#variable-definition-precedence
 :uri-variables: {uri-rel-file-base}/variables.tf
+:uri-rms-zip: 
 
-== Assumptions
+.Prerequisites
+- {uri-oci-keys}[Required Keys and OCIDs]
+- {uri-oci-okepolicy}[Required IAM policies]
+- `git`, `ssh` client to run locally
+- Terraform `>= 1.2.0` to run locally
 
-1. You have setup the {uri-oci-keys}[required keys]
-2. You know the {uri-oci-ocids}[required OCIDs]
-3. You have set the {uri-oci-okepolicy}[necessary OKE policy]
+== Provisioning from an OCI Resource Manager Stack
+++++
+<table>
+  <tr>
+    <th>Name</th>
+    <th>Resources</th>
+    <th>Deploy</th>
+  </tr>
+  <tr>
+    <td>OKE Network Only</td>
+    <td>
+      <li><a href=https://registry.terraform.io/providers/oracle/oci/latest/docs/resources/core_vcn>core_vcn</a></li>
+      <li><a href=https://registry.terraform.io/providers/oracle/oci/latest/docs/resources/core_nat_gateway>core_nat_gateway</a></li>
+      <li><a href=https://registry.terraform.io/providers/oracle/oci/latest/docs/resources/core_internet_gateway>core_internet_gateway</a></li>
+      <li><a href=https://registry.terraform.io/providers/oracle/oci/latest/docs/resources/core_subnet>core_subnet</a> (all)</li>
+      <li><a href=https://registry.terraform.io/providers/oracle/oci/latest/docs/resources/core_instance>core_instance</a> (bastion)</li>
+    </td>
+    <td><a href=https://cloud.oracle.com/resourcemanager/stacks/create?zipUrl=https://objectstorage.ap-osaka-1.oraclecloud.com/p/LwHOyvlB0vrV7li0K03CDTGz5b12YLzqnBHVB4ud418o6ybBtHBVGzjehp5gK4Hw/n/hpc_limited_availability/b/temporary/o/oke-network-only.20230410.zip target="_blank">
+        <img src="https://oci-resourcemanager-plugin.plugins.oci.oraclecloud.com/latest/deploy-to-oracle-cloud.svg" alt="Deploy to Oracle Cloud"/></a>
+    </td>
+  </tr>
+  <tr>
+    <td>OKE Cluster <i>(new network)</i></td>
+    <td>
+      <li><a href=https://registry.terraform.io/providers/oracle/oci/latest/docs/resources/core_vcn>core_vcn</a></li>
+      <li><a href=https://registry.terraform.io/providers/oracle/oci/latest/docs/resources/core_nat_gateway>core_nat_gateway</a></li>
+      <li><a href=https://registry.terraform.io/providers/oracle/oci/latest/docs/resources/core_internet_gateway>core_internet_gateway</a></li>
+      <li><a href=https://registry.terraform.io/providers/oracle/oci/latest/docs/resources/core_subnet>core_subnet</a> (configured)</li>
+      <li><a href=https://registry.terraform.io/providers/oracle/oci/latest/docs/resources/core_network_security_group>core_network_security_group</a></li>
+      <li><a href=https://registry.terraform.io/providers/oracle/oci/latest/docs/resources/core_network_security_group_security_rule>core_network_security_group_security_rule</a></li>
+      <li><a href=https://registry.terraform.io/providers/oracle/oci/latest/docs/resources/core_instance>core_instance</a> (bastion, operator)</li>
+      <li><a href=https://registry.terraform.io/providers/oracle/oci/latest/docs/resources/containerengine_cluster>containerengine_cluster</a></li>
+    </td>
+    <td><a href=https://cloud.oracle.com/resourcemanager/stacks/create?zipUrl=https://objectstorage.ap-osaka-1.oraclecloud.com/p/LwHOyvlB0vrV7li0K03CDTGz5b12YLzqnBHVB4ud418o6ybBtHBVGzjehp5gK4Hw/n/hpc_limited_availability/b/temporary/o/oke-cluster-with-network.20230410.zip&zipUrlVariables={"cluster_name":"oke-cluster-with-network"} target="_blank">
+        <img src="https://oci-resourcemanager-plugin.plugins.oci.oraclecloud.com/latest/deploy-to-oracle-cloud.svg" alt="Deploy to Oracle Cloud"/></a>
+    </td>
+  </tr>
+  <tr>
+    <td>OKE Cluster <i>(existing network)</a></td>
+    <td>
+      <li><a href=https://registry.terraform.io/providers/oracle/oci/latest/docs/resources/core_network_security_group>core_network_security_group</a></li>
+      <li><a href=https://registry.terraform.io/providers/oracle/oci/latest/docs/resources/core_network_security_group_security_rule>core_network_security_group_security_rule</a></li>
+      <li><a href=https://registry.terraform.io/providers/oracle/oci/latest/docs/resources/core_instance>core_instance</a> (operator)</li>
+      <li><a href=https://registry.terraform.io/providers/oracle/oci/latest/docs/resources/containerengine_cluster>containerengine_cluster</a></li>
+    </td>
+    <td><a href=https://cloud.oracle.com/resourcemanager/stacks/create?zipUrl=https://objectstorage.ap-osaka-1.oraclecloud.com/p/LwHOyvlB0vrV7li0K03CDTGz5b12YLzqnBHVB4ud418o6ybBtHBVGzjehp5gK4Hw/n/hpc_limited_availability/b/temporary/o/oke-cluster-with-network.20230410.zip&zipUrlVariables={"cluster_name":"oke-cluster-existing-network","create_vcn":false,"create_nsgs":false,"create_bastion":false,"worker_subnet_create":"Never","control_plane_subnet_create":"Never","operator_subnet_create":"Never","bastion_subnet_create":"Never","pod_subnet_create":"Never","int_lb_subnet_create":"Never","pub_lb_subnet_create":"Never","fss_subnet_create":"Never"} target="_blank">
+        <img src="https://oci-resourcemanager-plugin.plugins.oci.oraclecloud.com/latest/deploy-to-oracle-cloud.svg" alt="Deploy to Oracle Cloud"/></a>
+    </td>
+  </tr>
+  <tr>
+    <td>OKE-Managed Node Pool</td>
+    <td>
+      <li><a href=https://registry.terraform.io/providers/oracle/oci/latest/docs/resources/containerengine_node_pool>containerengine_node_pool</a></li>
+    </td>
+    <td><a href=https://cloud.oracle.com/resourcemanager/stacks/create?zipUrl=https://objectstorage.ap-osaka-1.oraclecloud.com/p/LwHOyvlB0vrV7li0K03CDTGz5b12YLzqnBHVB4ud418o6ybBtHBVGzjehp5gK4Hw/n/hpc_limited_availability/b/temporary/o/oke-workers.20230410.zip&zipUrlVariables={"worker_pool_mode":"Node%20Pool","worker_pool_name":"oke-node-pool"} target="_blank">
+        <img src="https://oci-resourcemanager-plugin.plugins.oci.oraclecloud.com/latest/deploy-to-oracle-cloud.svg" alt="Deploy to Oracle Cloud"/></a>
+    </td>
+  </tr>
+  <tr>
+    <td>Self-Managed Instances</td>
+    <td>
+      <li><a href=https://registry.terraform.io/providers/oracle/oci/latest/docs/resources/identity_dynamic_group>identity_dynamic_group</a> (workers)</li>
+      <li><a href=https://registry.terraform.io/providers/oracle/oci/latest/docs/resources/identity_policy>identity_policy</a> (JoinCluster)</li>
+      <li><a href=https://registry.terraform.io/providers/oracle/oci/latest/docs/resources/core_instance>core_instance</a></li>
+    </td>
+    <td><a href=https://cloud.oracle.com/resourcemanager/stacks/create?zipUrl=https://objectstorage.ap-osaka-1.oraclecloud.com/p/LwHOyvlB0vrV7li0K03CDTGz5b12YLzqnBHVB4ud418o6ybBtHBVGzjehp5gK4Hw/n/hpc_limited_availability/b/temporary/o/oke-workers.20230410.zip&zipUrlVariables={"worker_pool_mode":"Instances","worker_pool_name":"oke-instances"} target="_blank">
+        <img src="https://oci-resourcemanager-plugin.plugins.oci.oraclecloud.com/latest/deploy-to-oracle-cloud.svg" alt="Deploy to Oracle Cloud"/></a>
+    </td>
+  </tr>
+  <tr>
+    <td>Self-Managed Instance Pool</td>
+    <td>
+      <li><a href=https://registry.terraform.io/providers/oracle/oci/latest/docs/resources/identity_dynamic_group>identity_dynamic_group</a> (workers)</li>
+      <li><a href=https://registry.terraform.io/providers/oracle/oci/latest/docs/resources/identity_policy>identity_policy</a> (JoinCluster)</li>
+      <li><a href=https://registry.terraform.io/providers/oracle/oci/latest/docs/resources/core_instance_configuration>core_instance_configuration</a></li>
+      <li><a href=https://registry.terraform.io/providers/oracle/oci/latest/docs/resources/core_instance_pool>core_instance_pool</a></li>
+    </td>
+    <td><a href=https://cloud.oracle.com/resourcemanager/stacks/create?zipUrl=https://objectstorage.ap-osaka-1.oraclecloud.com/p/LwHOyvlB0vrV7li0K03CDTGz5b12YLzqnBHVB4ud418o6ybBtHBVGzjehp5gK4Hw/n/hpc_limited_availability/b/temporary/o/oke-workers.20230410.zip&zipUrlVariables={"worker_pool_mode":"Instance%20Pool","worker_pool_name":"oke-instance-pool"} target="_blank">
+        <img src="https://oci-resourcemanager-plugin.plugins.oci.oraclecloud.com/latest/deploy-to-oracle-cloud.svg" alt="Deploy to Oracle Cloud"/></a>
+    </td>
+  </tr>
+  <tr>
+    <td>Self-Managed Cluster Network</td>
+    <td>
+      <li><a href=https://registry.terraform.io/providers/oracle/oci/latest/docs/resources/identity_dynamic_group>identity_dynamic_group</a> (workers)</li>
+      <li><a href=https://registry.terraform.io/providers/oracle/oci/latest/docs/resources/identity_policy>identity_policy</a> (JoinCluster)</li>
+      <li><a href=https://registry.terraform.io/providers/oracle/oci/latest/docs/resources/core_instance_configuration>core_instance_configuration</a></li>
+      <li><a href=https://registry.terraform.io/providers/oracle/oci/latest/docs/resources/core_cluster_network>core_cluster_network</a></li>
+    </td>
+    <td><a href=https://cloud.oracle.com/resourcemanager/stacks/create?zipUrl=https://objectstorage.ap-osaka-1.oraclecloud.com/p/LwHOyvlB0vrV7li0K03CDTGz5b12YLzqnBHVB4ud418o6ybBtHBVGzjehp5gK4Hw/n/hpc_limited_availability/b/temporary/o/oke-workers.20230410.zip&zipUrlVariables={"worker_pool_mode":"Cluster%20Network","worker_pool_name":"oke-cluster-network","worker_shape":"BM.GPU4.8"} target="_blank">
+        <img src="https://oci-resourcemanager-plugin.plugins.oci.oraclecloud.com/latest/deploy-to-oracle-cloud.svg" alt="Deploy to Oracle Cloud"/></a>
+    </td>
+  </tr>
+</table>
+++++
 
-== Prerequisites
+== Configure OCI Terraform providers locally
+Review {uri-oci-provider}[Configuring the OCI Terraform Provider] for additional detail.
 
-1. git is installed
-2. ssh client is installed
-3. Terraform 1.0.0+ is installed
+.The module will need at least 2 instances of the `oci` provider in most cases for access to regional endpoints:
+- 1 provider for the region where your OKE cluster and other resources will be created
+- 1 provider for the home region. This is required for conducting identity operations. *Note that your home region may not necessarily be the same as your current region.*
 
-== Provision using this git repo
-
-. Clone the repo:
-
-+
-[source,bash]
-----
-git clone https://github.com/oracle-terraform-modules/terraform-oci-oke.git tfoke
-
-cd tfoke
-cp terraform.tfvars.example terraform.tfvars
-----
-
-=== Creating Providers
-
-You need to create 2 providers:
-.. 1 provider for the region where your OKE cluster and other resources will be created
-.. 1 provider for the home region. This is required for conducting identity operations. *Note that your home region may not necessarily be the same as your current region.*
-
-. Create a provider.tf file in root with 2 providers. An {uri-provider-example}[example] is provided for convenience:
-+
-[source,bash]
+.Create a provider.tf file in root with 2 providers. An {uri-provider-example}[example] is provided for convenience:
+[source, shell]
 ----
 cp provider.tf.example provider.tf
 ----
 
-. You can also create use providers ({uri-oci-provider}[using differerent methods]) such as:
-
-.. config file profile
-.. auth token
-.. instance principal
-
-
-. Set mandatory parameters in the provider depending on your {uri-oci-provider}[method of initializing your provider]:
-
-* api_fingerprint
-* api_private_key_path
-* compartment_id
-* tenancy_id
-* user_id
-* regions
-
-You can set those parameters using: 
-
-1. environment variables (e.g. TF_api_fingerprint)
-2. the terraform.tfvars
-
-Please ensure you understand the {uri-terraform-precedence}[Terraform variable definition order of precedence] and {uri-oci-provider-precedence}[that of OCI].
-
-. Run Terraform:
-
-+
-[source,bash]
+.Define the appropriate provider configuration for your {uri-oci-provider}[authentication method]. A full configuration may include the following:
 ----
-terraform init
-terraform plan
-terraform apply
+provider "oci" {
+  config_file_profile  = var.config_file_profile
+  fingerprint          = var.api_fingerprint
+  api_private_key_path = var.api_private_key_path
+  private_key          = var.api_private_key
+  private_key_password = var.api_private_key_password
+  region               = var.region
+  tenancy_ocid         = var.tenancy_ocid
+  user_ocid            = var.current_user_ocid
+}
+
+provider "oci" {
+  alias                = "home"
+  config_file_profile  = var.config_file_profile
+  fingerprint          = var.api_fingerprint
+  api_private_key_path = var.api_private_key_path
+  private_key          = var.api_private_key
+  private_key_password = var.api_private_key_password
+  region               = var.home_region
+  tenancy_ocid         = var.tenancy_ocid
+  user_ocid            = var.current_user_ocid
+}
 ----
+
+.The following may suffice in a Resource Manager Stack, with the home region determined using a Terraform datasource:
+----
+provider "oci" {
+  alias        = "home"
+  region       = one(data.oci_identity_region_subscriptions.home.region_subscriptions[*].region_name)
+  tenancy_ocid = var.tenancy_ocid
+  user_ocid    = var.current_user_ocid
+}
+
+provider "oci" {
+  region                 = var.region
+  tenancy_ocid           = var.tenancy_ocid
+  user_ocid              = var.current_user_ocid
+  retry_duration_seconds = 1800
+}
+
+data "oci_identity_region_subscriptions" "home" {
+  tenancy_id = var.tenancy_ocid
+  filter {
+    name   = "is_home_region"
+    values = [true]
+  }
+}
+----
+
+.Parameters may be defined using:
+1. Environment variables (e.g. `TF_api_fingerprint`)
+2. `terraform.tfvars/*.auto.tfvars` files
+
+NOTE: Review {uri-terraform-precedence}[Terraform] and {uri-oci-provider-precedence}[OCI] variable definition order of precedence.
 
 == Provision using the HashiCorp registry module
+. {uri-oci-provider}[Configuring the OCI Terraform Provider]
+. In your project root, create a `provider.tf` file and repeat the steps for creating providers as above.
 
-. In your project root, create a provider.tf file and repeat the steps for creating providers as above.
+. In your project root, create a `variables.tf` file and add variables for your project. You can copy the existing {uri-variables}[variables.tf] in the OKE module root.
 
-. In your project root, create a variables.tf file and add variables for your project. You can copy the existing {uri-variables}[variables.tf] in the OKE module root.
-
-. In your project root, create a versions.tf file and add the following:
+. In your project root, create a `versions.tf` file and add the following:
 
 +
 ----
@@ -115,9 +217,7 @@ terraform {
 }
 ----
 
-. In your project root, create a main.tf file and add the following:
-
-+
+.In your project root, create a main.tf file and add the following:
 ----
 module "oke" {
   source  = "oracle-terraform-modules/oke/oci"
@@ -126,13 +226,11 @@ module "oke" {
 }
 ----
 
-. Edit your OKE module definition and pass the required variables:
-
-+
+.Edit your OKE module definition and pass the required variables:
 ----
 module "oke" {
   source                                =   "oracle-terraform-modules/oke/oci"
-  version                               =   "4.0.0"
+  version                               =   "5.0.0"
 
   compartment_id                        =   var.compartment_id
   tenancy_id                            =   var.tenancy_id
@@ -158,18 +256,35 @@ module "oke" {
 }
 ----
 
-. Run Terraform:
-
-+
-[source,bash]
+.Run Terraform:
+[source, shell]
 ----
 terraform init
 terraform plan
 terraform apply
 ----
 
+== Provision using this Git repo
+
+.Clone the repo:
+[source, shell]
+----
+git clone https://github.com/oracle-terraform-modules/terraform-oci-oke.git tfoke && cd tfoke
+cp terraform.tfvars.example terraform.tfvars
+----
+
+Review the steps above to Configure OCI Terraform providers.
+
+NOTE: Review {uri-terraform-precedence}[Terraform] and {uri-oci-provider-precedence}[OCI] variable definition order of precedence.
+
+== Run Terraform
+[source, shell]
+----
+terraform init     # With -upgrade for the latest module versions
+terraform plan
+terraform apply
+----
+
 == Related documentation
-
 * {uri-instructions}[Detailed Instructions]
-
 * {uri-terraform-options}[All Terraform configuration options] for {uri-repo}[this project]

--- a/examples/oke-cluster-with-network/main.tf
+++ b/examples/oke-cluster-with-network/main.tf
@@ -1,0 +1,205 @@
+# Copyright (c) 2023 Oracle Corporation and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl
+
+data "oci_identity_region_subscriptions" "home" {
+  tenancy_id = var.tenancy_ocid
+  filter {
+    name   = "is_home_region"
+    values = [true]
+  }
+}
+
+data "oci_secrets_secretbundle" "ssh_key" {
+  secret_id = var.ssh_kms_secret_id
+
+}
+
+data "oci_secrets_secretbundle" "ocir" {
+  count     = var.ocir_kms_vault_id == null ? 0 : 1
+  secret_id = var.ocir_kms_secret_id
+}
+
+locals {
+  bastion_allowed_cidrs       = compact(split(",", var.bastion_allowed_cidrs))
+  bastion_nsg_ids             = compact(split(",", var.bastion_nsg_id))
+  control_plane_allowed_cidrs = compact(split(",", var.control_plane_allowed_cidrs))
+  control_plane_nsg_ids       = compact(split(",", var.control_plane_nsg_id))
+  fss_nsg_ids                 = compact(split(",", var.fss_nsg_id))
+  operator_nsg_ids            = compact(split(",", var.operator_nsg_id))
+  pod_nsg_ids                 = compact(split(",", var.pod_nsg_id))
+  worker_nsg_ids              = compact(split(",", var.worker_nsg_id))
+  ssh_key_bundle_content      = sensitive(lookup(one(data.oci_secrets_secretbundle.ssh_key.secret_bundle_content), "content", null))
+}
+
+module "oke" {
+  source         = "github.com/devoncrouse/terraform-oci-oke.git?ref=5.x-stack&depth=1"
+  providers      = { oci.home = oci.home }
+  tenancy_id     = var.tenancy_ocid
+  compartment_id = var.compartment_ocid
+
+  # General
+  timezone      = var.timezone
+  output_detail = var.output_detail
+
+  # Identity
+  create_iam_resources = true
+
+  # Network
+  create_vcn                  = var.create_vcn
+  vcn_id                      = var.vcn_id
+  vcn_cidrs                   = split(",", var.vcn_cidrs)
+  vcn_create_internet_gateway = lower(var.vcn_create_internet_gateway)
+  vcn_create_nat_gateway      = lower(var.vcn_create_nat_gateway)
+  vcn_create_service_gateway  = lower(var.vcn_create_service_gateway)
+  vcn_name                    = var.vcn_name
+  vcn_dns_label               = var.vcn_dns_label
+  assign_dns                  = var.assign_dns
+  ig_route_table_id           = var.ig_route_table_id
+  local_peering_gateways      = var.local_peering_gateways
+  lockdown_default_seclist    = var.lockdown_default_seclist
+  nat_gateway_public_ip_id    = var.nat_gateway_public_ip_id
+  nat_route_table_id          = var.nat_route_table_id
+  create_drg                  = var.create_drg
+  drg_id                      = var.drg_id
+  enable_waf                  = var.enable_waf
+  subnets = {
+    bastion  = { create = lower(var.bastion_subnet_create), newbits = var.bastion_subnet_newbits, id = var.bastion_subnet_id }
+    operator = { create = lower(var.operator_subnet_create), newbits = var.operator_subnet_newbits, id = var.operator_subnet_id }
+    cp       = { create = lower(var.control_plane_subnet_create), newbits = var.control_plane_subnet_newbits, id = var.control_plane_subnet_id }
+    int_lb   = { create = lower(var.int_lb_subnet_create), newbits = var.int_lb_subnet_newbits, id = var.int_lb_subnet_id }
+    pub_lb   = { create = lower(var.pub_lb_subnet_create), newbits = var.pub_lb_subnet_newbits, id = var.pub_lb_subnet_id }
+    workers  = { create = lower(var.worker_subnet_create), newbits = var.worker_subnet_newbits, id = var.worker_subnet_id }
+    pods     = { create = lower(var.pod_subnet_create), newbits = var.pod_subnet_newbits, id = var.pod_subnet_id }
+    fss      = { create = lower(var.fss_subnet_create), newbits = var.fss_subnet_newbits, id = var.fss_subnet_id }
+  }
+
+  # Network Security
+  create_nsgs                  = var.create_nsgs
+  allow_node_port_access       = var.allow_node_port_access
+  allow_pod_internet_access    = var.allow_pod_internet_access
+  allow_rules_internal_lb      = var.allow_rules_internal_lb
+  allow_rules_public_lb        = var.allow_rules_public_lb
+  allow_worker_internet_access = var.allow_worker_internet_access
+  allow_worker_ssh_access      = var.allow_worker_ssh_access
+  bastion_allowed_cidrs        = local.bastion_allowed_cidrs
+  bastion_nsg_ids              = local.bastion_nsg_ids
+  control_plane_allowed_cidrs  = local.control_plane_allowed_cidrs
+  control_plane_is_public      = var.control_plane_is_public
+  control_plane_nsg_ids        = local.control_plane_nsg_ids
+  fss_nsg_ids                  = local.fss_nsg_ids
+  load_balancers               = lower(var.load_balancers)
+  operator_nsg_ids             = local.operator_nsg_ids
+  pod_nsg_ids                  = local.pod_nsg_ids
+  worker_is_public             = var.worker_is_public
+  worker_nsg_ids               = local.worker_nsg_ids
+
+  # Bastion
+  bastion_availability_domain = var.bastion_availability_domain
+  bastion_image_id            = var.bastion_image_id
+  bastion_image_os            = var.bastion_image_os
+  bastion_image_os_version    = var.bastion_image_os_version
+  bastion_image_type          = lower(var.bastion_image_type)
+  bastion_is_public           = var.bastion_is_public
+  bastion_public_ip           = var.bastion_public_ip
+  bastion_shape               = var.bastion_shape
+  bastion_upgrade             = var.bastion_upgrade
+  bastion_user                = var.bastion_user
+  create_bastion              = var.create_bastion
+
+  # Operator
+  create_operator                = var.create_operator
+  operator_availability_domain   = var.operator_availability_domain
+  operator_cloud_init            = var.operator_cloud_init
+  operator_image_id              = var.operator_image_id
+  operator_image_os              = var.operator_image_os
+  operator_image_os_version      = var.operator_image_os_version
+  operator_install_helm          = var.operator_install_helm
+  operator_install_k9s           = var.operator_install_k9s
+  operator_install_kubectx       = var.operator_install_kubectx
+  operator_private_ip            = var.operator_private_ip
+  operator_pv_transit_encryption = var.operator_pv_transit_encryption
+  operator_shape                 = var.operator_shape
+  operator_upgrade               = var.operator_upgrade
+  operator_user                  = var.operator_user
+  operator_volume_kms_key_id     = var.operator_volume_kms_key_id
+
+  # SSH
+  ssh_public_key  = local.ssh_public_key
+  ssh_private_key = sensitive(local.ssh_key_bundle_content)
+
+  # Cluster
+  cluster_kms_key_id      = var.cluster_kms_key_id
+  cluster_name            = var.cluster_name
+  cni_type                = lower(var.cni_type)
+  create_cluster          = var.create_cluster
+  cluster_type            = lower(var.cluster_type)
+  kubernetes_version      = var.kubernetes_version
+  pods_cidr               = var.pods_cidr
+  preferred_load_balancer = lower(var.preferred_load_balancer)
+  services_cidr           = var.services_cidr
+  use_signed_images       = var.use_signed_images
+  image_signing_keys      = var.image_signing_keys
+
+  # CNI: Calico
+  calico_install           = var.calico_install
+  calico_apiserver_install = var.calico_apiserver_install
+  calico_mode              = var.calico_mode
+  calico_mtu               = var.calico_mtu
+  calico_staging_dir       = var.calico_staging_dir
+  calico_typha_install     = var.calico_typha_install
+  calico_typha_replicas    = var.calico_typha_replicas
+  calico_url               = var.calico_url
+  calico_version           = var.calico_version
+
+  # Metrics server
+  metrics_server_install      = var.metrics_server_install
+  metrics_server_namespace    = var.metrics_server_namespace
+  metrics_server_helm_version = var.metrics_server_helm_version
+  # metrics_server_helm_values       = var.metrics_server_helm_values
+  # metrics_server_helm_values_files = var.metrics_server_helm_values_files
+
+  # Cluster autoscaler
+  cluster_autoscaler_install      = var.cluster_autoscaler_install
+  cluster_autoscaler_namespace    = var.cluster_autoscaler_namespace
+  cluster_autoscaler_helm_version = var.cluster_autoscaler_helm_version
+  # cluster_autoscaler_helm_values       = var.cluster_autoscaler_helm_values
+  # cluster_autoscaler_helm_values_files = var.cluster_autoscaler_helm_values_files
+
+  # Gatekeeper
+  gatekeeper_install      = var.gatekeeper_install
+  gatekeeper_namespace    = var.gatekeeper_namespace
+  gatekeeper_helm_version = var.gatekeeper_helm_version
+  # gatekeeper_helm_values       = var.gatekeeper_helm_values
+  # gatekeeper_helm_values_files = var.gatekeeper_helm_values_files
+
+  # Prometheus
+  prometheus_install      = var.prometheus_install
+  prometheus_namespace    = var.prometheus_namespace
+  prometheus_helm_version = var.prometheus_helm_version
+  # prometheus_helm_values       = var.prometheus_helm_values
+  # prometheus_helm_values_files = var.prometheus_helm_values_files
+
+  # Tags
+  use_defined_tags = var.use_defined_tags
+  tag_namespace    = var.tag_namespace
+
+  freeform_tags = { # TODO Remaining tags in schema
+    cluster           = lookup(var.cluster_tags, "freeformTags", {})
+    persistent_volume = {}
+    service_lb        = {}
+    workers           = {}
+    bastion           = lookup(var.bastion_tags, "freeformTags", {})
+    operator          = lookup(var.operator_tags, "freeformTags", {})
+    vcn               = {}
+  }
+
+  defined_tags = { # TODO Remaining tags in schema
+    cluster           = lookup(var.cluster_tags, "definedTags", {})
+    persistent_volume = {}
+    service_lb        = {}
+    workers           = {}
+    bastion           = lookup(var.bastion_tags, "definedTags", {})
+    operator          = lookup(var.operator_tags, "definedTags", {})
+    vcn               = {}
+  }
+}

--- a/examples/oke-cluster-with-network/output.tf
+++ b/examples/oke-cluster-with-network/output.tf
@@ -1,0 +1,61 @@
+# Copyright (c) 2023 Oracle Corporation and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl
+
+# Terraform
+output "state_id" { value = module.oke.state_id }
+
+# Identity
+output "dynamic_group_ids" { value = module.oke.dynamic_group_ids }
+output "policy_statements" { value = module.oke.policy_statements }
+
+# Network
+output "vcn_id" { value = module.oke.vcn_id }
+output "drg_id" { value = module.oke.drg_id }
+output "ig_route_table_id" { value = module.oke.ig_route_table_id }
+output "nat_route_table_id" { value = module.oke.nat_route_table_id }
+
+# NSGs
+output "nsg_ids" { value = module.oke.nsg_ids }
+
+# Bastion
+output "bastion_id" { value = module.oke.bastion_id }
+output "bastion_public_ip" { value = module.oke.bastion_public_ip }
+output "bastion_subnet_id" { value = module.oke.bastion_subnet_id }
+output "bastion_nsg_id" { value = coalesce(var.bastion_nsg_id, "none") != "none" ? var.bastion_nsg_id : module.oke.bastion_nsg_id }
+output "bastion_ssh_command" { value = module.oke.ssh_to_bastion }
+output "bastion_ssh_secret_id" { value = var.ssh_kms_secret_id }
+
+# Operator
+output "operator_id" { value = module.oke.operator_id }
+output "operator_private_ip" { value = module.oke.operator_private_ip }
+output "operator_subnet_id" { value = module.oke.operator_subnet_id }
+output "operator_nsg_id" { value = coalesce(var.operator_nsg_id, "none") != "none" ? var.operator_nsg_id : module.oke.operator_nsg_id }
+output "operator_ssh_command" { value = module.oke.ssh_to_operator }
+output "operator_ssh_secret_id" { value = var.ssh_kms_secret_id }
+
+# Cluster
+output "cluster_id" { value = module.oke.cluster_id }
+output "cluster_endpoints" { value = module.oke.cluster_endpoints }
+output "cluster_kubeconfig" { value = module.oke.cluster_kubeconfig }
+output "cluster_ca_cert" { value = module.oke.cluster_ca_cert }
+output "control_plane_subnet_id" { value = module.oke.control_plane_subnet_id }
+output "int_lb_subnet_id" { value = module.oke.int_lb_subnet_id }
+output "pub_lb_subnet_id" { value = module.oke.pub_lb_subnet_id }
+output "control_plane_nsg_id" { value = coalesce(var.control_plane_nsg_id, "none") != "none" ? var.control_plane_nsg_id : module.oke.control_plane_nsg_id }
+
+output "bastion_subnet_cidr" { value = lookup(module.oke.subnet_cidrs, "bastion", null) }
+output "operator_subnet_cidr" { value = lookup(module.oke.subnet_cidrs, "operator", null) }
+output "control_plane_subnet_cidr" { value = lookup(module.oke.subnet_cidrs, "cp", null) }
+output "worker_subnet_cidr" { value = lookup(module.oke.subnet_cidrs, "workers", null) }
+output "pod_subnet_cidr" { value = lookup(module.oke.subnet_cidrs, "pods", null) }
+output "int_lb_subnet_cidr" { value = lookup(module.oke.subnet_cidrs, "int_lb", null) }
+output "pub_lb_subnet_cidr" { value = lookup(module.oke.subnet_cidrs, "pub_lb", null) }
+output "fss_subnet_cidr" { value = lookup(module.oke.subnet_cidrs, "fss", null) }
+
+output "worker_subnet_id" { value = module.oke.worker_subnet_id }
+output "worker_nsg_id" { value = coalesce(var.worker_nsg_id, "none") != "none" ? var.worker_nsg_id : module.oke.worker_nsg_id }
+output "pod_subnet_id" { value = module.oke.pod_subnet_id }
+output "pod_nsg_id" { value = coalesce(var.pod_nsg_id, "none") != "none" ? var.pod_nsg_id : module.oke.pod_nsg_id }
+output "fss_id" { value = module.oke.fss_id }
+output "fss_subnet_id" { value = module.oke.fss_subnet_id }
+output "fss_nsg_id" { value = coalesce(var.fss_nsg_id, "none") != "none" ? var.fss_nsg_id : module.oke.fss_nsg_id }

--- a/examples/oke-cluster-with-network/schema.yaml
+++ b/examples/oke-cluster-with-network/schema.yaml
@@ -1,0 +1,1746 @@
+# Copyright (c) 2023 Oracle Corporation and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl
+
+title: "OKE: Network & Cluster"
+description: OKE cluster with VCN network resources
+informationalText: "Connect to operator host using the SSH command below for Kubernetes endpoint access."
+schemaVersion: 1.1.0
+version: "20230304"
+locale: "en"
+
+variableGroups:
+  - title: "Hidden"
+    visible: false
+    variables:
+      - api_fingerprint
+      - current_user_ocid
+      - tenancy_ocid
+      - region
+      - output_detail
+      - timezone
+      - subnets
+      - await_node_readiness
+      - calico_helm_values
+      - calico_helm_values_files
+
+  - title: "Identity"
+    variables:
+      - compartment_ocid
+      - create_iam_resources
+      - create_iam_tag_namespace
+      - create_iam_defined_tags
+      - create_iam_autoscaler_policy
+      - create_iam_kms_policy
+      - create_iam_operator_policy
+      - create_iam_worker_policy
+      - use_defined_tags
+      - tag_namespace
+
+  - title: "Network"
+    variables:
+      - ${create_vcn}
+      - assign_dns
+      - vcn_id
+      - vcn_name
+      - vcn_cidrs
+      - vcn_dns_label
+      - ig_route_table_id
+      - vcn_create_internet_gateway
+      - vcn_create_nat_gateway
+      - vcn_create_service_gateway
+      - nat_gateway_id
+      - nat_route_table_id
+      - nat_gateway_public_ip_id
+      - service_gateway_id
+      - enable_waf
+      - create_drg
+      - drg_id
+      - local_peering_gateways
+      - lockdown_default_seclist
+      - create_nsgs
+
+  - title: "Bastion"
+    variables:
+      - bastion_subnet_create
+      - bastion_subnet_newbits
+      - bastion_subnet_id
+      - bastion_nsg_id
+      - bastion_allowed_cidrs
+      - ${create_bastion}
+      - bastion_public_ip
+      - bastion_is_public
+      - bastion_upgrade
+      - bastion_availability_domain
+      - bastion_image_os
+      - bastion_image_os_version
+      - bastion_image_id
+      - bastion_user
+      - bastion_shape_name
+      - bastion_shape_ocpus
+      - bastion_shape_memory
+      - bastion_shape_boot
+      - bastion_shape
+      - bastion_tags
+
+  - title: "SSH"
+    variables:
+      - ssh_public_key
+      - ssh_kms_vault_id
+      - ssh_kms_secret_id
+
+  - title: "Operator"
+    variables:
+      - operator_subnet_create
+      - operator_subnet_newbits
+      - operator_subnet_id
+      - operator_nsg_id
+      - ${create_operator}
+      - operator_upgrade
+      - operator_availability_domain
+      - operator_private_ip
+      - operator_image_os
+      - operator_image_os_version
+      - operator_image_id
+      - operator_user
+      - operator_shape_name
+      - operator_shape_ocpus
+      - operator_shape_memory
+      - operator_shape_boot
+      - operator_shape
+      - operator_use_encryption
+      - operator_volume_kms_vault_id
+      - operator_volume_kms_key_id
+      - operator_pv_transit_encryption
+      - operator_install_helm
+      - operator_install_k9s
+      - operator_install_kubectx
+      - operator_tags
+
+  - title: "Cluster"
+    variables:
+      - control_plane_is_public
+      - control_plane_subnet_create
+      - control_plane_subnet_newbits
+      - control_plane_subnet_id
+      - control_plane_nsg_id
+      - control_plane_allowed_cidrs
+      - int_lb_subnet_create
+      - int_lb_subnet_newbits
+      - int_lb_subnet_id
+      - pub_lb_subnet_create
+      - pub_lb_subnet_newbits
+      - pub_lb_subnet_id
+      - load_balancers
+      - allow_rules_internal_lb
+      - allow_rules_public_lb
+      - ${create_cluster}
+      - cluster_name
+      - cluster_type
+      - cluster_id
+      - kubernetes_version
+      - cluster_dns
+      - cluster_ca_cert
+      - cluster_use_encryption
+      - cluster_kms_vault_id
+      - cluster_kms_key_id
+      - cni_type
+      - pods_cidr
+      - services_cidr
+      - preferred_load_balancer
+      - use_signed_images
+      - configure_ocir
+      - ocir_username
+      - ocir_email_address
+      - ocir_kms_vault_id
+      - ocir_secret_id
+      - ocir_secret_namespace
+      - ocir_secret_name
+      - cluster_tags
+
+  - title: "Workers"
+    variables:
+      - worker_is_public
+      - worker_subnet_create
+      - worker_subnet_newbits
+      - worker_subnet_id
+      - worker_nsg_id
+      - allow_worker_ssh_access
+      - allow_worker_internet_access
+      - allow_node_port_access
+      - pod_subnet_create
+      - pod_subnet_newbits
+      - pod_subnet_id
+      - pod_nsg_id
+      - allow_pod_internet_access
+      - fss_subnet_create
+      - fss_subnet_newbits
+      - fss_subnet_id
+      - fss_nsg_id
+
+  - title: "Extensions"
+    visible: ${create_cluster}
+    variables:
+      - metrics_server_install
+      - prometheus_install
+      - cluster_autoscaler_install
+      - gatekeeper_install
+      - multus_install
+      - calico_install
+
+  - title: "Cluster Autoscaler"
+    visible:
+      and:
+        - ${create_cluster}
+        - cluster_autoscaler_install
+    variables:
+      - ${cluster_autoscaler_namespace}
+      - ${cluster_autoscaler_helm_version}
+      - ${cluster_autoscaler_helm_values}
+      - ${cluster_autoscaler_helm_values_files}
+
+  - title: "Metrics Server"
+    visible:
+      and:
+        - ${create_cluster}
+        - metrics_server_install
+    variables:
+      - metrics_server_namespace
+      - metrics_server_helm_version
+      - metrics_server_helm_values
+      - metrics_server_helm_values_files
+
+  - title: "Prometheus"
+    visible:
+      and:
+        - ${create_cluster}
+        - prometheus_install
+    variables:
+      - prometheus_namespace
+      - prometheus_reapply
+      - prometheus_helm_version
+      - prometheus_helm_values
+      - prometheus_helm_values_files
+
+  - title: "Gatekeeper"
+    visible:
+      and:
+        - ${create_cluster}
+        - gatekeeper_install
+    variables:
+      - gatekeeper_namespace
+      - gatekeeper_helm_version
+      - gatekeeper_helm_values
+      - gatekeeper_helm_values_files
+
+  - title: "Multus"
+    visible:
+      and:
+        - ${create_cluster}
+        - multus_install
+    variables:
+      - multus_namespace
+      - multus_daemonset_url
+      - multus_version
+
+  - title: "Calico"
+    visible:
+      and:
+        - ${create_cluster}
+        - calico_install
+    variables:
+      - calico_namespace
+      - calico_reapply
+      - calico_apiserver_install
+      - calico_version
+      - calico_url
+      - calico_typha_replicas
+      - calico_mtu
+      - calico_helm_version
+
+variables:
+  # Identity
+  api_fingerprint:
+    required: false
+    visible: false
+  current_user_ocid:
+    title: User
+    type: ocid
+    required: true
+  tenancy_ocid:
+    title: Tenancy
+    type: oci:identity:compartment:id
+    required: true
+  compartment_ocid:
+    title: Compartment
+    description: The default compartment for created resources.
+    type: oci:identity:compartment:id
+    required: true
+  region:
+    required: true
+    title: Region
+    type: oci:identity:region:name
+  defined_tags:
+    visible: false
+  freeform_tags:
+    visible: false
+  create_iam_resources:
+    default: false
+    description: Whether to create any IAM dynamic groups, policies, and tags.
+    required: true
+    title: Create IAM resources
+    type: boolean
+  create_iam_tag_namespace:
+    default: false
+    required: true
+    title: Create tag namespace
+    type: boolean
+    visible: ${create_iam_resources}
+  create_iam_defined_tags:
+    default: false
+    required: true
+    title: Create defined tags
+    type: boolean
+    visible: ${create_iam_resources}
+  create_iam_autoscaler_policy:
+    title: Create IAM policy for Cluster Autoscaler
+    required: false
+    visible: ${create_iam_resources}
+    type: enum
+    enum: [Never, Auto, Always]
+    default: Auto
+  create_iam_kms_policy:
+    title: Create IAM policy for KMS
+    required: false
+    visible: ${create_iam_resources}
+    type: enum
+    enum: [Never, Auto, Always]
+    default: Auto
+  create_iam_operator_policy:
+    title: Create IAM policy for operater cluster management
+    required: false
+    visible: ${create_iam_resources}
+    type: enum
+    enum: [Never, Auto, Always]
+    default: Auto
+  create_iam_worker_policy:
+    title: Create IAM policy for self-managed worker nodes
+    required: false
+    visible: ${create_iam_resources}
+    type: enum
+    enum: [Never, Auto, Always]
+    default: Auto
+  use_defined_tags:
+    title: Use defined tags
+    default: false
+    type: boolean
+  tag_namespace:
+    title: Tag namespace
+    visible:
+      or:
+        - ${create_iam_tag_namespace}
+        - ${create_iam_defined_tags}
+        - ${use_defined_tags}
+  timezone:
+    title: Timezone
+    type: string
+    # type: oci:identity:region:name
+    # required: true
+  output_detail:
+    title: Output detail
+    type: boolean
+    default: false
+    required: true
+
+  # VCN
+  network_compartment_id:
+    required: false
+    visible: false
+  create_vcn:
+    title: Create VCN
+    type: boolean
+    default: true
+  vcn_id:
+    title: Existing VCN
+    type: oci:core:vcn:id
+    required: true
+    dependsOn:
+      compartmentId: ${compartment_ocid}
+    visible: { not: [create_vcn] }
+  vcn_name:
+    title: Virtual Cloud Network (VCN) name
+    description: Display name for the created VCN. Defaults to 'oke' suffixed with the generated Terraform 'state_id' value.
+    type: string
+    visible: ${create_vcn}
+  assign_dns:
+    title: Assign DNS records
+    type: boolean
+    required: true
+    visible: ${create_vcn}
+  vcn_dns_label:
+    title: DNS label
+    description: DNS label for the created VCN. Defaults to the generated Terraform 'state_id' value.
+    visible:
+      and:
+        - ${create_vcn}
+        - ${assign_dns}
+  vcn_cidrs:
+    title: CIDR ranges
+    description: Comma-separated list of CIDR blocks for the created VCN.
+    type: string
+    required: true
+    visible: ${create_vcn}
+  lockdown_default_seclist:
+    title: Secure default security list
+    type: boolean
+    required: true
+    visible: ${create_vcn}
+  vcn_create_internet_gateway:
+    title: Create internet gateway
+    type: enum
+    enum: [Never, Auto, Always]
+    default: Auto
+    required: true
+    visible: ${create_vcn}
+  vcn_create_nat_gateway:
+    title: Create service gateway
+    type: enum
+    enum: [Never, Auto, Always]
+    default: Auto
+    required: true
+    visible: ${create_vcn}
+  vcn_create_service_gateway:
+    title: Create NAT gateway
+    type: enum
+    enum: [Never, Auto, Always]
+    default: Auto
+    required: true
+    visible: ${create_vcn}
+  local_peering_gateways:
+    title: Local peering gateways
+    visible: false
+  ig_route_table_id:
+    title: Internet Gateway Route Table
+    type: ocid
+    required: false
+    visible: { not: [create_vcn] }
+  service_gateway_id:
+    title: Service gateway
+    description: Existing service gateway in the VCN.
+    type: oci:core:servicegateway:id
+    required: true
+    visible:
+      not:
+        - ${create_vcn}
+    dependsOn:
+      compartmentId: ${compartment_ocid}
+      vcnId: ${vcn_id}
+  nat_gateway_id:
+    title: NAT gateway
+    description: Existing NAT gateway in the VCN.
+    type: oci:core:natgateway:id
+    required: true
+    visible:
+      not:
+        - ${create_vcn}
+    dependsOn:
+      compartmentId: ${compartment_ocid}
+      vcnId: ${vcn_id}
+  nat_route_table_id:
+    title: NAT Gateway Route Table
+    description: NAT Gateway Route Table.
+    type: ocid
+    required: false
+    visible: false
+  nat_gateway_public_ip_id:
+    required: false
+    visible: false
+
+  # NSGs
+  create_nsgs:
+    title: Create NSGs
+    description: Create standard network security groups and traffic rules. Additional configuration may be required when disabled, e.g. providing existing NSGs, subnet security lists, etc.
+    type: boolean
+    default: true
+    required: true
+  bastion_nsg_id:
+    title: Additional Network Security Group
+    type: oci:core:nsg:id
+    # additionalProps:
+    #   allowMultiple: true
+    dependsOn:
+      compartmentId: ${compartment_ocid}
+      vcnId: ${vcn_id}
+    visible: { not: [create_vcn] }
+  bastion_allowed_cidrs:
+    title: Comma-separated list of CIDR blocks allowed SSH access to the bastion host.
+    type: string
+    required: false
+    visible: ${create_nsgs}
+  operator_nsg_id:
+    title: Additional Network Security Group
+    type: oci:core:nsg:id
+    # additionalProps:
+    #   allowMultiple: true
+    dependsOn:
+      compartmentId: ${compartment_ocid}
+      vcnId: ${vcn_id}
+    visible: { not: [create_vcn] }
+  control_plane_nsg_id:
+    title: Additional Network Security Group
+    type: oci:core:nsg:id
+    # additionalProps:
+    #   allowMultiple: true
+    dependsOn:
+      compartmentId: ${compartment_ocid}
+      vcnId: ${vcn_id}
+    visible: { not: [create_vcn] }
+  control_plane_allowed_cidrs:
+    title: Comma-separated list of CIDR blocks allowed access to the OKE control plane.
+    type: string
+    required: false
+    visible: ${create_nsgs}
+  pod_nsg_id:
+    title: Additional Network Security Group for pods
+    type: oci:core:nsg:id
+    # additionalProps:
+    #   allowMultiple: true
+    dependsOn:
+      compartmentId: ${compartment_ocid}
+      vcnId: ${vcn_id}
+    visible:
+      and:
+        - eq: [cni_type, NPN]
+        - not: [create_vcn ]
+  worker_nsg_id:
+    title: Additional Network Security Group for workers
+    type: oci:core:nsg:id
+    # additionalProps:
+    #   allowMultiple: true
+    dependsOn:
+      compartmentId: ${compartment_ocid}
+      vcnId: ${vcn_id}
+    visible: { not: [create_vcn] }
+  fss_nsg_id:
+    title: Additional Network Security Group for FSS
+    type: oci:core:nsg:id
+    # additionalProps:
+    #   allowMultiple: true
+    dependsOn:
+      compartmentId: ${compartment_ocid}
+      vcnId: ${vcn_id}
+    visible:
+      and:
+        - ${create_fss}
+        - not: [create_vcn]
+
+  control_plane_is_public:
+    title: Public Kubernetes control plane
+    type: boolean
+    default: false
+    required: false
+    visible: ${create_nsgs}
+  worker_is_public:
+    title: Public Kubernetes worker nodes
+    type: boolean
+    default: false
+    required: true
+    visible: ${create_nsgs}
+  allow_node_port_access:
+    title: Allow NodePort access
+    type: boolean
+    default: false
+    required: true
+    visible: ${create_nsgs}
+  allow_worker_ssh_access:
+    title: Allow worker SSH access
+    type: boolean
+    default: true
+    required: true
+    visible: ${create_nsgs}
+  allow_worker_internet_access:
+    title: Allow worker egress to internet
+    type: boolean
+    default: true
+    required: true
+    visible: ${create_nsgs}
+  allow_pod_internet_access:
+    title: Allow pod egress to internet
+    type: boolean
+    required: true
+    default: true
+    visible:
+      and:
+        - create_nsgs
+        - eq: [cni_type, NPN]
+  allow_rules_internal_lb:
+    title: Additional internal load balancer rules
+    additionalProps:
+      allowMultiple: true
+    required: false
+    visible: ${create_nsgs}
+  allow_rules_public_lb:
+    title: Additional public load balancer rules
+    additionalProps:
+      allowMultiple: true
+    required: false
+    visible: ${create_nsgs}
+
+  create_drg:
+    title: Create DRG
+    description: Create a Dynamic Routing Gateway and attach it to the VCN.
+    type: boolean
+    default: false
+    required: false
+    visible: false
+  drg_id:
+    title: Dynamic Routing Gateway
+    description: Existing Dynamic Routing Gateway to attach to the VCN.
+    type: ocid
+    required: false
+    visible: { not: [create_drg] }
+  drg_display_name:
+    title: DRG display name
+    visible: ${create_drg}
+  enable_waf:
+    title: Enable WAF
+    type: boolean
+    default: false
+    required: false
+    visible: false
+  load_balancers:
+    title: Load balancers
+    type: enum
+    enum: [Public, Internal, Both]
+    default: Internal
+    required: true
+    visible:
+      or:
+        - ${create_cluster}
+        - ${create_nsgs}
+
+  # Subnets
+  subnets:
+    visible: false
+  control_plane_subnet_create:
+    title: Create control plane subnet
+    type: enum
+    enum: [Never, Auto, Always]
+    default: Auto
+    required: true
+  control_plane_subnet_newbits:
+    title: Control plane subnet size
+    description: The number of network prefix bits added to the VCN CIDR block for the created subnet address range (i.e. a higher value is smaller). Refer to the Terraform <a href=https://developer.hashicorp.com/terraform/language/functions/cidrsubnets>cidrsubnets</a> function for more information.
+    type: number
+    visible:
+      and:
+        - ${create_vcn}
+        - not:
+            - eq:
+                - ${control_plane_subnet_create}
+                - Never
+  control_plane_subnet_id:
+    title: Control plane subnet
+    type: oci:core:subnet:id
+    required: true
+    dependsOn:
+      compartmentId: ${compartment_ocid}
+      vcnId: ${vcn_id}
+      hidePublicSubnet: false
+      hidePrivateSubnet: false
+      hideRegionalSubnet: false
+      hideAdSubnet: true
+    visible:
+      and:
+        - not:
+            - ${create_vcn}
+        - eq:
+            - ${control_plane_subnet_create}
+            - Never
+  int_lb_subnet_create:
+    title: Create internal load balancer subnet
+    type: enum
+    enum: [Never, Auto, Always]
+    default: Auto
+    required: true
+  int_lb_subnet_newbits:
+    title: Internal load balancer subnet size
+    description: The number of network prefix bits added to the VCN CIDR block for the created subnet address range (i.e. a higher value is smaller). Refer to the Terraform <a href=https://developer.hashicorp.com/terraform/language/functions/cidrsubnets>cidrsubnets</a> function for more information.
+    type: number
+    visible:
+      not:
+        - eq:
+            - ${int_lb_subnet_create}
+            - Never
+  int_lb_subnet_id:
+    title: Internal load balancer subnet
+    type: oci:core:subnet:id
+    required: false
+    dependsOn:
+      compartmentId: ${compartment_ocid}
+      vcnId: ${vcn_id}
+      hidePublicSubnet: false
+      hidePrivateSubnet: false
+      hideRegionalSubnet: false
+      hideAdSubnet: true
+    visible:
+      and:
+        - not:
+            - ${create_vcn}
+        - eq:
+            - ${int_lb_subnet_create}
+            - Never
+  pub_lb_subnet_create:
+    title: Create public load balancer subnet
+    type: enum
+    enum: [Never, Auto, Always]
+    default: Auto
+    required: true
+  pub_lb_subnet_newbits:
+    title: Public load balancer subnet size
+    description: The number of network prefix bits added to the VCN CIDR block for the created subnet address range (i.e. a higher value is smaller). Refer to the Terraform <a href=https://developer.hashicorp.com/terraform/language/functions/cidrsubnets>cidrsubnets</a> function for more information.
+    type: number
+    visible:
+      not:
+        - eq:
+            - ${pub_lb_subnet_create}
+            - Never
+  pub_lb_subnet_id:
+    title: Public load balancer subnet
+    type: oci:core:subnet:id
+    required: false
+    dependsOn:
+      compartmentId: ${compartment_ocid}
+      vcnId: ${vcn_id}
+      hidePublicSubnet: false
+      hidePrivateSubnet: false
+      hideRegionalSubnet: false
+      hideAdSubnet: true
+    visible:
+      and:
+        - not:
+            - ${create_vcn}
+        - eq:
+            - ${pub_lb_subnet_create}
+            - Never
+  worker_subnet_create:
+    title: Create worker subnet
+    type: enum
+    enum: [Never, Auto, Always]
+    default: Auto
+    required: true
+  worker_subnet_newbits:
+    title: Worker subnet size
+    description: The number of network prefix bits added to the VCN CIDR block for the created subnet address range (i.e. a higher value is smaller). Refer to the Terraform <a href=https://developer.hashicorp.com/terraform/language/functions/cidrsubnets>cidrsubnets</a> function for more information.
+    type: number
+    visible:
+      and:
+        - ${create_vcn}
+        - not:
+            - eq:
+                - ${worker_subnet_create}
+                - Never
+  worker_subnet_id:
+    title: Worker subnet
+    type: oci:core:subnet:id
+    required: false
+    dependsOn:
+      compartmentId: ${compartment_ocid}
+      vcnId: ${vcn_id}
+      hidePublicSubnet: false
+      hidePrivateSubnet: false
+      hideRegionalSubnet: false
+      hideAdSubnet: false
+    visible:
+      and:
+        - not:
+            - ${create_vcn}
+        - eq:
+            - ${worker_subnet_create}
+            - Never
+
+  bastion_subnet_create:
+    title: Create bastion subnet
+    type: enum
+    enum: [Never, Auto, Always]
+    default: Auto
+    required: true
+  bastion_subnet_newbits:
+    title: Bastion subnet size
+    description: The number of network prefix bits added to the VCN CIDR block for the created subnet address range (i.e. a higher value is smaller). Refer to the Terraform <a href=https://developer.hashicorp.com/terraform/language/functions/cidrsubnets>cidrsubnets</a> function for more information.
+    type: number
+    visible:
+      and:
+        - ${create_vcn}
+        - not:
+            - eq:
+                - ${bastion_subnet_create}
+                - Never
+  bastion_subnet_id:
+    title: Bastion subnet
+    type: oci:core:subnet:id
+    required: false
+    dependsOn:
+      compartmentId: ${compartment_ocid}
+      vcnId: ${vcn_id}
+      hidePublicSubnet: false
+      hidePrivateSubnet: false
+      hideRegionalSubnet: false
+      hideAdSubnet: false
+    visible:
+      and:
+        - not:
+            - ${create_vcn}
+        - eq:
+            - ${bastion_subnet_create}
+            - Never
+
+  operator_subnet_create:
+    title: Create operator subnet
+    type: enum
+    enum: [Never, Auto, Always]
+    default: Auto
+    required: true
+  operator_subnet_newbits:
+    title: Operator subnet size
+    description: The number of network prefix bits added to the VCN CIDR block for the created subnet address range (i.e. a higher value is smaller). Refer to the Terraform <a href=https://developer.hashicorp.com/terraform/language/functions/cidrsubnets>cidrsubnets</a> function for more information.
+    type: number
+    visible:
+      and:
+        - ${create_vcn}
+        - not:
+            - eq:
+                - ${operator_subnet_create}
+                - Never
+  operator_subnet_id:
+    title: Operator subnet
+    type: oci:core:subnet:id
+    required: false
+    dependsOn:
+      compartmentId: ${compartment_ocid}
+      vcnId: ${vcn_id}
+      hidePublicSubnet: false
+      hidePrivateSubnet: false
+      hideRegionalSubnet: false
+      hideAdSubnet: false
+    visible:
+      and:
+        - not:
+            - ${create_vcn}
+        - eq:
+            - ${operator_subnet_create}
+            - Never
+
+  pod_subnet_create:
+    title: Create pod subnet
+    type: enum
+    enum: [Never, Auto, Always]
+    default: Auto
+    required: true
+  pod_subnet_newbits:
+    title: Pod subnet size
+    description: The number of network prefix bits added to the VCN CIDR block for the created subnet address range (i.e. a higher value is smaller). Refer to the Terraform <a href=https://developer.hashicorp.com/terraform/language/functions/cidrsubnets>cidrsubnets</a> function for more information.
+    type: number
+    visible:
+      and:
+        - ${create_vcn}
+        - not:
+            - eq:
+                - ${pod_subnet_create}
+                - Never
+  pod_subnet_id:
+    title: Pod subnet
+    type: oci:core:subnet:id
+    required: false
+    dependsOn:
+      compartmentId: ${compartment_ocid}
+      vcnId: ${vcn_id}
+      hidePublicSubnet: true
+      hidePrivateSubnet: false
+      hideRegionalSubnet: false
+      hideAdSubnet: false
+    visible:
+      and:
+        - not:
+            - ${create_vcn}
+        - eq:
+            - ${pod_subnet_create}
+            - Never
+  fss_subnet_create:
+    title: Create FSS subnet
+    type: enum
+    enum: [Never, Auto, Always]
+    default: Auto
+    required: true
+  fss_subnet_newbits:
+    title: FSS subnet size
+    description: The number of network prefix bits added to the VCN CIDR block for the created subnet address range (i.e. a higher value is smaller). Refer to the Terraform <a href=https://developer.hashicorp.com/terraform/language/functions/cidrsubnets>cidrsubnets</a> function for more information.
+    type: number
+    visible:
+      and:
+        - ${create_vcn}
+        - not:
+            - eq:
+                - ${fss_subnet_create}
+                - Never
+  fss_subnet_id:
+    title: FSS subnet
+    type: oci:core:subnet:id
+    required: false
+    dependsOn:
+      compartmentId: ${compartment_ocid}
+      vcnId: ${vcn_id}
+      hidePublicSubnet: false
+      hidePrivateSubnet: false
+      hideRegionalSubnet: false
+      hideAdSubnet: false
+    visible:
+      and:
+        - not:
+            - ${create_vcn}
+        - eq:
+            - ${fss_subnet_create}
+            - Never
+
+  # SSH
+  ssh_public_key:
+    title: SSH Public Key
+    type: oci:core:ssh:publickey
+    pattern: "((^(ssh-rsa AAAAB3NzaC1yc2|ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNT|ecdsa-sha2-nistp384 AAAAE2VjZHNhLXNoYTItbmlzdHAzODQAAAAIbmlzdHAzOD|ecdsa-sha2-nistp521 AAAAE2VjZHNhLXNoYTItbmlzdHA1MjEAAAAIbmlzdHA1Mj|ssh-ed25519 AAAAC3NzaC1lZDI1NTE5|ssh-dss AAAAB3NzaC1kc3)[0-9A-Za-z+\/]+[=]{0,3})( [^,]*)?)(,((ssh-rsa AAAAB3NzaC1yc2|ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNT|ecdsa-sha2-nistp384 AAAAE2VjZHNhLXNoYTItbmlzdHAzODQAAAAIbmlzdHAzOD|ecdsa-sha2-nistp521 AAAAE2VjZHNhLXNoYTItbmlzdHA1MjEAAAAIbmlzdHA1Mj|ssh-ed25519 AAAAC3NzaC1lZDI1NTE5|ssh-dss AAAAB3NzaC1kc3)[0-9A-Za-z+\/]+[=]{0,3})( [^,]*)?)*$"
+    required: false
+  ssh_kms_vault_id:
+    title: SSH Vault
+    description: The OCI Vault used to encrypt the SSH key pair.
+    type: oci:kms:vault:id
+    required: true
+    dependsOn:
+      compartmentId: ${compartment_ocid}
+  ssh_kms_secret_id:
+    title: SSH Vault secret
+    description: The OCI Vault secret containing the SSH private key.
+    type: oci:kms:secret:id
+    required: true
+    dependsOn:
+      compartmentId: ${compartment_ocid}
+      vaultId: ${ssh_kms_vault_id}
+
+  # Bastion
+  create_bastion:
+    title: Create bastion instance
+    type: boolean
+    default: false
+    required: true
+  bastion_availability_domain:
+    title: Availability domain
+    type: oci:identity:availabilitydomain:name
+    required: false
+    dependsOn:
+      compartmentId: ${compartment_ocid}
+    visible: ${create_bastion}
+  bastion_public_ip:
+    title: Bastion IP
+    description: The address of an existing bastion host for SSH access to operator/cluster resources.
+    type: string
+    required: true
+    visible: { not: [create_bastion] }
+  bastion_user:
+    title: User
+    type: string
+    default: opc
+    required: true
+  bastion_shape_name:
+    title: Shape
+    type: oci:core:instanceshape:name
+    default: "VM.Standard.E4.Flex"
+    required: true
+    dependsOn:
+      compartmentId: ${compartment_ocid}
+    visible: ${create_bastion}
+  bastion_shape_ocpus:
+    title: OCPUs (Cores)
+    type: number
+    default: 4
+    required: true
+    dependsOn:
+      compartmentId: ${compartment_ocid}
+    visible: ${create_bastion}
+  bastion_shape_memory:
+    title: Memory (GB)
+    type: number
+    default: 16
+    required: true
+    dependsOn:
+      compartmentId: ${compartment_ocid}
+    visible: ${create_bastion}
+  bastion_shape_boot:
+    title: Boot volume size (GB)
+    type: number
+    default: 50
+    required: true
+    dependsOn:
+      compartmentId: ${compartment_ocid}
+    visible: ${create_bastion}
+  bastion_shape:
+    visible: false
+  bastion_image_os:
+    title: Image OS
+    description: Image operating system.
+    type: enum
+    default: "Oracle Autonomous Linux"
+    enum: ["Oracle Autonomous Linux", "Oracle Linux"]
+    required: true
+    visible:
+      and:
+        - ${create_bastion}
+        - not:
+            - eq:
+                - ${bastion_image_type}
+                - custom
+  bastion_image_os_version:
+    title: Image OS version
+    description: Image operating system version.
+    type: enum
+    default: "8.7"
+    enum: ["7.9", "8.7"]
+    required: true
+    visible:
+      and:
+        - ${create_bastion}
+        - not:
+            - eq:
+                - ${bastion_image_type}
+                - custom
+  bastion_image_type:
+    title: Image type
+    type: enum
+    default: platform
+    enum: [platform, custom]
+    required: true
+    visible: false
+  bastion_image_id:
+    title: Image ID
+    type: oci:core:image:id
+    required: false
+    dependsOn:
+      compartmentId: ${compartment_ocid}
+      operatingSystem: ${bastion_image_os}
+      operatingSystemVersion: ${bastion_image_os_version}
+      shape: ${bastion_shape_name}
+    visible: ${create_bastion}
+  bastion_is_public:
+    title: Public network
+    description: Public network and address for bastion host.
+    type: boolean
+    default: true
+    required: true
+    visible:
+      or:
+        - ${bastion_subnet_create}
+        - ${create_bastion}
+  bastion_upgrade:
+    title: Upgrade OS
+    description: Upgrade the operating system on boot.
+    type: boolean
+    default: false
+    required: true
+    visible: ${create_bastion}
+  bastion_tags:
+    type: oci:identity:tag:value
+    required: false
+    title: Tagging
+    description: Tag values for created resources.
+    dependsOn:
+      compartmentId: ${compartment_ocid}
+    visible: ${create_bastion}
+
+  # Operator variables
+  create_operator:
+    title: Create operator instance
+    description: Provision an OCI Compute instance configured with IAM access to interact with the OKE Kubernetes endpoint, e.g. through a bastion host for private networks. Required for installation of extensions using the module.
+    type: boolean
+    default: true
+    required: false
+  operator_availability_domain:
+    title: Availability domain
+    type: oci:identity:availabilitydomain:name
+    required: false
+    dependsOn:
+      compartmentId: ${compartment_ocid}
+    visible: ${create_operator}
+  operator_private_ip:
+    title: Operator IP
+    type: string
+    required: false
+    visible:
+      not:
+        - ${create_operator}
+  operator_user:
+    title: User
+    type: string
+    default: opc
+    required: true
+  operator_shape_name:
+    title: Shape
+    type: oci:core:instanceshape:name
+    default: "VM.Standard.E4.Flex"
+    required: true
+    dependsOn:
+      compartmentId: ${compartment_ocid}
+    visible: ${create_bastion}
+  operator_shape_ocpus:
+    title: OCPUs (Cores)
+    type: number
+    default: 4
+    required: true
+    dependsOn:
+      compartmentId: ${compartment_ocid}
+    visible: ${create_bastion}
+  operator_shape_memory:
+    title: Memory (GB)
+    type: number
+    default: 16
+    required: true
+    dependsOn:
+      compartmentId: ${compartment_ocid}
+    visible: ${create_bastion}
+  operator_shape_boot:
+    title: Boot volume size (GB)
+    type: number
+    default: 50
+    required: true
+    dependsOn:
+      compartmentId: ${compartment_ocid}
+    visible: ${create_bastion}
+  operator_shape:
+    visible: false
+  operator_image_os:
+    title: Image OS
+    type: enum
+    default: "Oracle Linux"
+    enum: ["Oracle Linux"]
+    required: true
+    visible:
+      and:
+        - ${create_operator}
+        - not:
+            - eq:
+                - ${operator_image_type}
+                - custom
+  operator_image_os_version:
+    title: Image OS version
+    type: enum
+    default: "8"
+    enum: ["7.9", "8"]
+    required: true
+    visible:
+      and:
+        - ${create_operator}
+        - not:
+            - eq:
+                - ${operator_image_type}
+                - custom
+  operator_image_type:
+    title: Image type
+    type: enum
+    default: platform
+    enum: [platform, custom]
+    required: true
+    visible: false
+  operator_image_id:
+    title: Image ID
+    type: oci:core:image:id
+    required: false
+    visible: ${create_operator}
+    dependsOn:
+      compartmentId: ${compartment_ocid}
+      operatingSystem: ${operator_image_os}
+      operatingSystemVersion: ${operator_image_os_version}
+      shape: ${operator_shape_name}
+  operator_pv_transit_encryption:
+    title: In-transit volume encryption
+    type: boolean
+    visible: ${create_operator}
+  operator_use_encryption:
+    title: Use encryption
+    type: boolean
+    default: false
+    required: true
+    visible: ${create_operator}
+  operator_volume_kms_vault_id:
+    title: KMS volume encryption vault
+    description: Vault containing operator volume encryption keys.
+    type: oci:kms:vault:id
+    required: false
+    dependsOn:
+      compartmentId: ${compartment_ocid}
+    visible:
+      and:
+        - ${create_operator}
+        - operator_use_encryption
+  operator_volume_kms_key_id:
+    title: KMS volume encryption key
+    type: oci:kms:key:id
+    dependsOn:
+      compartmentId: ${compartment_ocid}
+      vaultId: ${operator_volume_kms_vault_id}
+    visible:
+      and:
+        - ${create_operator}
+        - operator_use_encryption
+  operator_upgrade:
+    title: Upgrade OS
+    description: Upgrade the operating system on boot.
+    type: boolean
+    default: false
+    required: true
+    visible: ${create_operator}
+  operator_install_helm:
+    title: Install Helm
+    type: boolean
+    visible: ${create_operator}
+  operator_install_k9s:
+    title: Install K9s
+    type: boolean
+    default: true
+    visible: ${create_operator}
+  operator_install_kubectx:
+    title: Install Kubectx
+    type: boolean
+    visible: ${create_operator}
+  operator_tags:
+    type: oci:identity:tag:value
+    required: false
+    title: Tagging
+    description: Tag values for created resources.
+    dependsOn:
+      compartmentId: ${compartment_ocid}
+    visible: ${create_operator}
+
+  # Cluster
+  create_cluster:
+    title: Create cluster
+    type: boolean
+    default: true
+    required: true
+  cluster_dns:
+    title: Cluster DNS address
+    type: string
+    required: false
+    visible:
+      not:
+        - ${create_cluster}
+        - eq:
+            - cluster_id
+            - null
+  cluster_ca_cert:
+    title: Cluster CA certificate
+    description: Base64+PEM-encoded cluster CA certificate for self-managed nodes.
+    #  Determined automatically when 'create_cluster' = true or 'cluster_id' is provided.
+    visible:
+      not:
+        - ${create_cluster}
+        - eq:
+            - cluster_id
+            - null
+  cluster_use_encryption:
+    title: Use encryption
+    type: boolean
+    default: false
+    required: true
+    visible: ${create_cluster}
+  cluster_kms_vault_id:
+    title: Cluster etcd KMS encryption vault
+    type: oci:kms:vault:id
+    required: true
+    dependsOn:
+      compartmentId: ${compartment_ocid}
+    visible:
+      and:
+        - ${create_cluster}
+        - cluster_use_encryption
+  cluster_kms_key_id:
+    title: Cluster etcd KMS encryption key
+    type: oci:kms:key:id
+    required: true
+    dependsOn:
+      compartmentId: ${compartment_ocid}
+      vaultId: ${cluster_kms_vault_id}
+    visible:
+      and:
+        - ${create_cluster}
+        - cluster_use_encryption
+  cluster_id:
+    title: Cluster ID
+    type: oci:container:cluster:id
+    required: false
+    dependsOn:
+      compartmentId: ${compartment_ocid}
+    visible:
+      not:
+        - ${create_cluster}
+  cluster_name:
+    title: Cluster name
+    description: Display name for the created cluster. Defaults to 'oke' suffixed with the generated Terraform 'state_id' value.
+    type: string
+    required: false
+    visible: ${create_cluster}
+  cluster_type:
+    title: Cluster Type
+    type: enum
+    default: Basic
+    enum: [Basic, Enhanced]
+    allowMultiple: false
+    required: true
+    visible: ${create_cluster}
+  cni_type:
+    title: CNI Type
+    type: enum
+    default: Flannel
+    enum: [Flannel, NPN]
+    allowMultiple: false
+    required: true
+    visible: ${create_cluster}
+  kubernetes_version:
+    type: oci:kubernetes:versions:id
+    title: Kubernetes version
+    description: The Kubernetes version for the created OKE cluster and managed nodes.
+    default: "v1.25.4"
+    required: true
+    dependsOn:
+      compartmentId: ${compartment_ocid}
+      clusterOptionId: "all"
+    visible: ${create_cluster}
+  pods_cidr:
+    title: Pod CIDR
+    visible:
+      and:
+        - ${create_cluster}
+        - eq:
+            - ${cni_type}
+            - NPN
+  services_cidr:
+    title: Service CIDR
+    visible: ${create_cluster}
+  preferred_load_balancer:
+    title: Preferred load balancer
+    type: enum
+    default: Internal
+    enum: [Internal, Public]
+    allowMultiple: false
+    required: true
+    visible: ${create_cluster}
+  use_signed_images:
+    title: Use signed images
+    type: boolean
+    default: false
+    required: true
+    visible: ${create_cluster}
+
+  # OCIR
+  configure_ocir:
+    title: Configure container registry (OCIR)
+    type: boolean
+    default: false
+    visible: ${create_cluster}
+  ocir_username:
+    title: Username
+    visible:
+      and:
+        - ${create_cluster}
+        - configure_ocir
+  ocir_email_address:
+    title: Email address
+    visible:
+      and:
+        - ${create_cluster}
+        - configure_ocir
+  ocir_kms_vault_id:
+    title: Vault ID
+    type: oci:kms:vault:id
+    required: false
+    dependsOn:
+      compartmentId: ${compartment_ocid}
+    visible:
+      and:
+        - ${create_cluster}
+        - configure_ocir
+  ocir_kms_secret_id:
+    title: Vault secret ID
+    type: oci:kms:secret:id
+    required: false
+    dependsOn:
+      compartmentId: ${compartment_ocid}
+      vaultId: ${ocir_kms_vault_id}
+    visible:
+      and:
+        - ${create_cluster}
+        - configure_ocir
+  ocir_secret_namespace:
+    title: Secret namespace
+    visible:
+      and:
+        - ${create_cluster}
+        - configure_ocir
+  ocir_secret_name:
+    title: Secret name
+    visible:
+      and:
+        - ${create_cluster}
+        - configure_ocir
+
+  cluster_tags:
+    type: oci:identity:tag:value
+    required: false
+    title: Tagging
+    description: Tag values for created resources.
+    dependsOn:
+      compartmentId: ${compartment_ocid}
+    visible: ${create_cluster}
+
+  # CNI: Calico
+  calico_install:
+    title: Install Calico
+    description: Deploy Calico with Oracle Cloud configuration. See <a href=https://docs.tigera.io/calico/latest/getting-started>Install Calico</a> for more information.
+    type: boolean
+    default: false
+    required: true
+  calico_namespace:
+    title: Kubernetes namespace
+    type: string
+  calico_reapply:
+    title: Re-apply
+    type: boolean
+    default: false
+    required: true
+  calico_apiserver_install:
+    title: Install Calico API Server
+    type: boolean
+    default: false
+    required: true
+  calico_mode:
+    visible: false
+  calico_staging_dir:
+    visible: false
+  calico_typha_install:
+    title: Install Typha
+    visible: ${calico_install}
+  calico_helm_version:
+    visible: false
+  calico_mtu:
+    visible: false
+  calico_typha_replicas:
+    visible: false
+  calico_url:
+    visible: false
+  calico_version:
+    visible: false
+
+  # Metrics server
+  metrics_server_install:
+    title: Install Metrics Server
+    description: Deploy the Kubernetes Metrics Server with Oracle Cloud configuration. See <a href=https://github.com/kubernetes-sigs/metrics-server>kubernetes-sigs/metrics-server</a> for more information.
+    type: boolean
+    default: false
+    required: true
+  metrics_server_namespace:
+    title: Kubernetes namespace
+    type: string
+  metrics_server_helm_version:
+    title: Helm chart version
+    type: string
+  metrics_server_helm_values:
+    title: Helm chart values
+    visible: false
+  metrics_server_helm_values_files:
+    title: Helm chart values files
+    visible: false
+
+  # Cluster autoscaler
+  cluster_autoscaler_install:
+    title: Install Cluster Autoscaler
+    description: Deploy the Kubernetes Cluster Autoscaler with Oracle Cloud configuration. See <a href=https://github.com/kubernetes/autoscaler>kubernetes/autoscaler</a> for more information.
+    type: boolean
+    default: false
+    required: true
+  cluster_autoscaler_namespace:
+    title: Kubernetes namespace
+    type: string
+  cluster_autoscaler_helm_version:
+    title: Helm chart version
+    type: string
+  cluster_autoscaler_helm_values:
+    title: Helm chart values
+    visible: false
+  cluster_autoscaler_helm_values_files:
+    title: Helm chart values files
+    visible: false
+
+  # Gatekeeper
+  gatekeeper_install:
+    title: Install Gatekeeper
+    description: Deploy Gatekeeper with Oracle Cloud configuration. See <a href=https://github.com/open-policy-agent/gatekeeper>open-policy-agent/gatekeeper</a> for more information.
+    type: boolean
+    default: false
+    required: true
+  gatekeeper_namespace:
+    title: Kubernetes namespace
+    type: string
+  gatekeeper_helm_version:
+    title: Helm chart version
+    type: string
+  gatekeeper_helm_values:
+    title: Helm chart values
+    visible: false
+  gatekeeper_helm_values_files:
+    title: Helm chart values files
+    visible: false
+
+  # Prometheus
+  prometheus_install:
+    title: Install Prometheus
+    description: Deploy Prometheus with Oracle Cloud configuration. See <a href=https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack>prometheus-community/kube-prometheus-stack</a> for more information.
+    type: boolean
+    default: false
+    required: true
+  prometheus_reapply:
+    title: Re-apply
+    type: boolean
+    default: false
+    required: true
+  prometheus_namespace:
+    title: Kubernetes namespace
+    type: string
+  prometheus_helm_version:
+    title: Helm chart version
+    type: string
+  prometheus_helm_values:
+    title: Helm chart values
+    visible: false
+  prometheus_helm_values_files:
+    title: Helm chart values files
+    visible: false
+
+  # Multus
+  multus_install:
+    title: Install Multus
+    description: Deploy Multus for extended CNI configuration. See <a href=https://github.com/k8snetworkplumbingwg/multus-cni>k8snetworkplumbingwg/multus-cni</a> for more information. Preempts existing CNI configuration, with the configured cluster CNI plugin used by default.
+    type: boolean
+    default: false
+    required: true
+  multus_namespace:
+    title: Kubernetes namespace
+    type: string
+  multus_daemonset_url:
+    title: Daemonset URL
+    description: The URL path to the Multus manifest. Leave unset for tags of <a href=https://github.com/k8snetworkplumbingwg/multus-cni>k8snetworkplumbingwg/multus-cni</a> using the configured Multus version.
+    type: string
+  multus_version:
+    title: Version
+    type: string
+
+outputGroups:
+  - title: Terraform
+    outputs:
+      - state_id
+  - title: Identity
+    outputs:
+      - dynamic_group_ids
+      - policy_statements
+  - title: Network
+    outputs:
+      - vcn_id
+      - ig_route_table_id
+      - nat_route_table_id
+      - drg_id
+      - network_security_rules
+  - title: Bastion
+    outputs:
+      - bastion_id
+      - bastion_subnet_id
+      - bastion_subnet_cidr
+      - bastion_nsg_id
+      - bastion_public_ip
+      - bastion_ssh_command
+      - bastion_ssh_secret_id
+  - title: Operator
+    outputs:
+      - operator_id
+      - operator_subnet_id
+      - operator_subnet_cidr
+      - operator_nsg_id
+      - operator_private_ip
+      - operator_ssh_command
+      - operator_ssh_secret_id
+  - title: Cluster
+    outputs:
+      - cluster_id
+      - cluster_endpoints
+      - control_plane_subnet_id
+      - control_plane_subnet_cidr
+      - control_plane_nsg_id
+      - int_lb_subnet_id
+      - int_lb_subnet_cidr
+      - int_lb_nsg_id
+      - pub_lb_subnet_id
+      - pub_lb_subnet_cidr
+      - pub_lb_nsg_id
+  - title: Workers
+    outputs:
+      - worker_subnet_id
+      - worker_subnet_cidr
+      - worker_nsg_id
+      - pod_subnet_id
+      - pod_subnet_cidr
+      - pod_nsg_id
+      - fss_subnet_id
+      - fss_subnet_cidr
+      - fss_nsg_id
+
+outputs:
+  # Terraform
+  state_id:
+    title: State ID
+    type: copyableString
+
+  # Identity
+  dynamic_group_ids:
+    title: Dynamic groups
+    type: list
+  policy_statements:
+    title: Policy statements
+    type: list
+
+  # Network
+  vcn_id:
+    title: VCN
+    type: ocid
+  drg_id:
+    title: Dynamic routing gateway
+    type: ocid
+  ig_route_table_id:
+    title: Internet gateway route table
+    type: ocid
+  nat_route_table_id:
+    title: NAT gateway route table
+    type: ocid
+  subnet_cidrs:
+    visible: false
+  subnet_ids:
+    visible: false
+  nsg_ids:
+    visible: false
+
+  # NSGs
+  network_security_rules:
+    visible: false
+
+  # Bastion
+  bastion_id:
+    title: Bastion instance
+    type: ocid
+  bastion_subnet_id:
+    title: Bastion subnet
+    type: ocid
+  bastion_subnet_cidr:
+    title: Bastion CIDR
+    type: string
+  bastion_nsg_id:
+    title: Bastion NSG
+    type: ocid
+  bastion_public_ip:
+    title: Bastion IP
+    type: copyableString
+  bastion_ssh_command:
+    title: Bastion SSH command
+    type: copyableString
+  bastion_ssh_secret_id:
+    title: Bastion SSH Vault secret
+    type: ocid
+
+  # Operator
+  operator_id:
+    title: Operator instance
+    type: ocid
+  operator_subnet_id:
+    title: Operator subnet
+    type: ocid
+  operator_subnet_cidr:
+    title: Operator CIDR
+    type: string
+  operator_nsg_id:
+    title: Operator NSG
+    type: ocid
+  operator_private_ip:
+    title: Operator IP
+    type: copyableString
+  operator_ssh_command:
+    title: Operator SSH command
+    type: copyableString
+  operator_ssh_secret_id:
+    title: Operator SSH Vault secret
+    type: ocid
+
+  # Cluster
+  cluster_id:
+    title: OKE cluster
+    type: ocid
+  cluster_endpoints:
+    title: Cluster endpoints
+    type: map
+  control_plane_subnet_id:
+    title: Control plane subnet
+    type: ocid
+  control_plane_subnet_cidr:
+    title: Control plane CIDR
+    type: string
+  control_plane_nsg_id:
+    title: Control plane NSG
+    type: ocid
+  int_lb_subnet_id:
+    title: Internal load balancer subnet
+    type: ocid
+  int_lb_subnet_cidr:
+    title: Internal load balancer CIDR
+    type: string
+  int_lb_nsg_id:
+    title: Internal load balancer NSG
+    type: ocid
+  pub_lb_subnet_id:
+    title: Public load balancer subnet
+    type: ocid
+  pub_lb_subnet_cidr:
+    title: Public load balancer CIDR
+    type: string
+  pub_lb_nsg_id:
+    title: Public load balancer NSG
+    type: ocid
+
+  # Workers
+  worker_subnet_id:
+    title: Worker subnet
+    type: ocid
+  worker_subnet_cidr:
+    title: Worker CIDR
+    type: string
+  worker_nsg_id:
+    title: Worker NSG
+    type: ocid
+  pod_subnet_id:
+    title: Pod subnet
+    type: ocid
+  pod_subnet_cidr:
+    title: Pod CIDR
+    type: string
+  pod_nsg_id:
+    title: Pod NSG
+    type: ocid
+
+  # FSS
+  fss_subnet_id:
+    title: File Storage Service subnet
+    type: ocid
+  fss_subnet_cidr:
+    title: File Storage Service CIDR
+    type: string
+  fss_nsg_id:
+    title: File Storage Service NSG
+    type: ocid

--- a/examples/oke-cluster-with-network/variables-bastion.tf
+++ b/examples/oke-cluster-with-network/variables-bastion.tf
@@ -1,0 +1,61 @@
+# Copyright (c) 2023 Oracle Corporation and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl
+
+variable "create_bastion" { default = true }
+variable "bastion_is_public" { default = true }
+variable "bastion_upgrade" { default = false }
+
+variable "bastion_public_ip" {
+  default = null
+  type    = string
+}
+
+variable "bastion_allowed_cidrs" {
+  default = "0.0.0.0/0"
+  type    = string
+}
+
+variable "bastion_availability_domain" {
+  default = null
+  type    = string
+}
+
+variable "bastion_user" {
+  default = "opc"
+  type    = string
+}
+
+variable "bastion_image_id" {
+  default = null
+  type    = string
+}
+
+variable "bastion_image_type" {
+  default = "platform"
+  type    = string
+}
+
+variable "bastion_image_os" {
+  default = "Oracle Autonomous Linux"
+  type    = string
+}
+
+variable "bastion_image_os_version" {
+  default = "8.7"
+  type    = string
+}
+
+variable "bastion_shape" {
+  default = {
+    shape            = "VM.Standard.E4.Flex",
+    ocpus            = 1,
+    memory           = 4,
+    boot_volume_size = 50
+  }
+  type = map(any)
+}
+
+variable "bastion_tags" {
+  default = {}
+  type    = map(any)
+}

--- a/examples/oke-cluster-with-network/variables-cluster.tf
+++ b/examples/oke-cluster-with-network/variables-cluster.tf
@@ -1,0 +1,54 @@
+# Copyright (c) 2023 Oracle Corporation and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl
+
+variable "create_cluster" { default = true }
+variable "cluster_type" {
+  description = "The cluster type. See <a href=https://docs.oracle.com/en-us/iaas/Content/ContEng/Tasks/contengworkingwithenhancedclusters.htm>Working with Enhanced Clusters and Basic Clusters</a> for more information. NOTE: An Enhanced cluster is required for self-managed worker pools (mode != Node Pool)."
+  type        = string
+}
+variable "cluster_name" {
+  default = null
+  type    = string
+}
+variable "cni_type" { type = string }
+variable "pods_cidr" {
+  default = "10.244.0.0/16"
+  type    = string
+}
+variable "services_cidr" {
+  default = "10.96.0.0/16"
+  type    = string
+}
+variable "kubernetes_version" { default = "v1.25.4" }
+
+variable "cluster_kms_vault_id" {
+  default = null
+  type    = string
+}
+variable "cluster_kms_key_id" {
+  default = ""
+  type    = string
+}
+
+variable "use_signed_images" {
+  default = false
+  type    = bool
+}
+variable "image_signing_keys" {
+  default = []
+  type    = set(string)
+}
+
+variable "load_balancers" {
+  default = "Public"
+  type    = string
+}
+variable "preferred_load_balancer" {
+  default = "Public"
+  type    = string
+}
+
+variable "cluster_tags" {
+  default = {}
+  type    = map(any)
+}

--- a/examples/oke-cluster-with-network/variables-extensions.tf
+++ b/examples/oke-cluster-with-network/variables-extensions.tf
@@ -1,0 +1,92 @@
+# Copyright (c) 2023 Oracle Corporation and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl
+
+# CNI: Calico
+
+variable "calico_install" { default = false }
+variable "calico_reapply" { default = false }
+variable "calico_version" { default = "3.24.1" }
+variable "calico_mode" { default = "policy-only" }
+variable "calico_mtu" { default = 0 }
+variable "calico_url" { default = "" }
+variable "calico_apiserver_install" { default = false }
+variable "calico_typha_install" { default = false }
+variable "calico_typha_replicas" { default = 0 }
+variable "calico_staging_dir" { default = "/tmp/calico_install" }
+variable "calico_namespace" { default = "network" }
+variable "calico_helm_version" { default = "3.25.0" }
+# variable "calico_helm_values" {
+#   default = {}
+#   type    = map(string)
+# }
+# variable "calico_helm_values_files" {
+#   default = []
+#   type    = list(string)
+# }
+
+# CNI: Multus
+
+variable "multus_install" { default = false }
+variable "multus_namespace" { default = "network" }
+variable "multus_daemonset_url" {
+  default = null
+  type    = string
+}
+variable "multus_version" { default = "3.9.3" }
+
+# Metrics server
+
+variable "metrics_server_install" { default = false }
+variable "metrics_server_namespace" { default = "metrics" }
+variable "metrics_server_helm_version" { default = "3.8.3" }
+# variable "metrics_server_helm_values" {
+#   default = {}
+#   type    = map(string)
+# }
+# variable "metrics_server_helm_values_files" {
+#   default = []
+#   type    = list(string)
+# }
+
+# Cluster autoscaler
+
+variable "cluster_autoscaler_install" { default = false }
+variable "cluster_autoscaler_namespace" { default = "kube-system" }
+variable "cluster_autoscaler_helm_version" { default = "9.24.0" }
+# variable "cluster_autoscaler_helm_values" {
+#   default = {}
+#   type    = map(string)
+# }
+# variable "cluster_autoscaler_helm_values_files" {
+#   default = []
+#   type    = list(string)
+# }
+
+# Prometheus
+
+variable "prometheus_install" { default = false }
+variable "prometheus_reapply" { default = false }
+variable "prometheus_namespace" { default = "metrics" }
+variable "prometheus_helm_version" { default = "45.2.0" }
+# variable "prometheus_helm_values" {
+#   default = {}
+#   type    = map(string)
+# }
+# variable "prometheus_helm_values_files" {
+#   default = []
+#   type    = list(string)
+# }
+
+# Gatekeeper
+
+variable "gatekeeper_install" { default = false }
+variable "gatekeeper_namespace" { default = "kube-system" }
+variable "gatekeeper_helm_version" { default = "3.11.0" }
+# variable "gatekeeper_helm_values" {
+#   default = {}
+#   type    = map(string)
+# }
+# variable "gatekeeper_helm_values_files" {
+#   default = []
+#   type    = list(string)
+# }

--- a/examples/oke-cluster-with-network/variables-iam.tf
+++ b/examples/oke-cluster-with-network/variables-iam.tf
@@ -1,0 +1,83 @@
+# Copyright (c) 2023 Oracle Corporation and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl
+
+variable "tenancy_ocid" {
+  default = null
+  type    = string
+}
+
+variable "current_user_ocid" {
+  default = null
+  type    = string
+}
+
+variable "compartment_ocid" {
+  default = null
+  type    = string
+}
+
+variable "region" {
+  default = null
+  type    = string
+}
+
+variable "create_iam_autoscaler_policy" {
+  default = "Auto"
+  type    = string
+}
+
+variable "create_iam_kms_policy" {
+  default = "Auto"
+  type    = string
+}
+
+variable "create_iam_operator_policy" {
+  default = "Auto"
+  type    = string
+}
+
+variable "create_iam_worker_policy" {
+  default = "Auto"
+  type    = string
+}
+
+variable "create_iam_resources" { default = false }
+variable "create_iam_tag_namespace" { default = false }
+variable "create_iam_defined_tags" { default = false }
+variable "use_defined_tags" {
+  default     = false
+  description = "Add existing tags in the configured namespace to created resources when applicable."
+  type        = bool
+}
+
+variable "tag_namespace" {
+  default     = "oke"
+  description = "Tag namespace containing standard tags for resources created by the module: [state_id, role, pool, cluster_autoscaler]."
+  type        = string
+}
+
+variable "freeform_tags" {
+  default = {
+    cluster           = {}
+    persistent_volume = {}
+    service_lb        = {}
+    workers           = {}
+    bastion           = {}
+    operator          = {}
+    vcn               = {}
+  }
+  type = any
+}
+
+variable "defined_tags" {
+  default = {
+    cluster           = {}
+    persistent_volume = {}
+    service_lb        = {}
+    workers           = {}
+    bastion           = {}
+    operator          = {}
+    vcn               = {}
+  }
+  type = any
+}

--- a/examples/oke-cluster-with-network/variables-network.tf
+++ b/examples/oke-cluster-with-network/variables-network.tf
@@ -1,0 +1,74 @@
+# Copyright (c) 2023 Oracle Corporation and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl
+
+variable "create_vcn" { default = true }
+
+variable "vcn_name" {
+  default = null
+  type    = string
+}
+
+variable "vcn_id" {
+  default = null
+  type    = string
+}
+
+variable "vcn_create_nat_gateway" { default = "Auto" }
+variable "vcn_create_internet_gateway" { default = "Auto" }
+variable "vcn_create_service_gateway" { default = "Always" }
+variable "ig_route_table_id" {
+  default = null
+  type    = string
+}
+variable "service_gateway_id" {
+  default = null
+  type    = string
+}
+variable "nat_gateway_id" {
+  default = null
+  type    = string
+}
+variable "nat_route_table_id" {
+  default = null
+  type    = string
+}
+
+variable "create_drg" { default = false }
+variable "drg_display_name" {
+  default = null
+  type    = string
+}
+variable "drg_id" {
+  default = null
+  type    = string
+}
+
+variable "internet_gateway_route_rules" {
+  default = null
+  type    = list(map(string))
+}
+variable "local_peering_gateways" {
+  default = null
+  type    = map(any)
+}
+variable "lockdown_default_seclist" { default = true }
+
+variable "nat_gateway_route_rules" {
+  default = null
+  type    = list(map(string))
+}
+variable "nat_gateway_public_ip_id" {
+  default = null
+  type    = string
+}
+
+variable "vcn_cidrs" { default = "10.0.0.0/16" }
+variable "vcn_dns_label" {
+  default = null
+  type    = string
+}
+
+variable "assign_dns" { default = true }
+variable "control_plane_is_public" { default = false }
+variable "enable_waf" { default = false }
+variable "worker_is_public" { default = false }

--- a/examples/oke-cluster-with-network/variables-nsgs.tf
+++ b/examples/oke-cluster-with-network/variables-nsgs.tf
@@ -1,0 +1,25 @@
+# Copyright (c) 2023 Oracle Corporation and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl
+
+variable "create_nsgs" { default = true }
+variable "allow_node_port_access" { default = false }
+variable "allow_pod_internet_access" { default = true }
+variable "allow_worker_internet_access" { default = true }
+variable "allow_worker_ssh_access" { default = false }
+variable "bastion_nsg_id" { default = "" }
+variable "control_plane_allowed_cidrs" { default = "" }
+variable "control_plane_nsg_id" { default = "" }
+variable "fss_nsg_id" { default = "" }
+variable "operator_nsg_id" { default = "" }
+variable "pod_nsg_id" { default = "" }
+variable "worker_nsg_id" { default = "" }
+
+variable "allow_rules_internal_lb" {
+  default = {}
+  type    = any
+}
+
+variable "allow_rules_public_lb" {
+  default = {}
+  type    = any
+}

--- a/examples/oke-cluster-with-network/variables-operator.tf
+++ b/examples/oke-cluster-with-network/variables-operator.tf
@@ -1,0 +1,58 @@
+# Copyright (c) 2023 Oracle Corporation and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl
+
+variable "create_operator" { default = true }
+variable "operator_install_helm" { default = true }
+variable "operator_install_k9s" { default = false }
+variable "operator_install_kubectx" { default = true }
+variable "operator_pv_transit_encryption" { default = false }
+variable "operator_upgrade" { default = false }
+variable "operator_availability_domain" {
+  default = null
+  type    = string
+}
+variable "operator_cloud_init" {
+  default = []
+  type    = list(map(string))
+}
+
+variable "operator_user" { default = "opc" }
+variable "operator_image_id" {
+  default = null
+  type    = string
+}
+variable "operator_image_os" { default = "Oracle Linux" }
+variable "operator_image_os_version" { default = "8" }
+variable "operator_image_type" {
+  default = "Platform"
+  type    = string
+  validation {
+    condition     = contains(["custom", "platform"], lower(var.operator_image_type))
+    error_message = "Accepted values are custom or platform"
+  }
+}
+variable "operator_shape" {
+  default = {
+    shape            = "VM.Standard.E4.Flex",
+    ocpus            = 1,
+    memory           = 4,
+    boot_volume_size = 50
+  }
+  type = map(any)
+}
+variable "operator_volume_kms_vault_id" {
+  default = null
+  type    = string
+}
+variable "operator_volume_kms_key_id" {
+  default = null
+  type    = string
+}
+variable "operator_private_ip" {
+  default = null
+  type    = string
+}
+variable "operator_tags" {
+  default = {}
+  type    = map(any)
+}

--- a/examples/oke-cluster-with-network/variables-subnets.tf
+++ b/examples/oke-cluster-with-network/variables-subnets.tf
@@ -1,0 +1,53 @@
+# Copyright (c) 2023 Oracle Corporation and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl
+
+variable "bastion_subnet_create" { default = "Auto" }
+variable "operator_subnet_create" { default = "Auto" }
+variable "control_plane_subnet_create" { default = "Auto" }
+variable "int_lb_subnet_create" { default = "Auto" }
+variable "pub_lb_subnet_create" { default = "Auto" }
+variable "worker_subnet_create" { default = "Auto" }
+variable "pod_subnet_create" { default = "Auto" }
+variable "fss_subnet_create" { default = "Auto" }
+
+variable "bastion_subnet_newbits" { default = 13 }
+variable "control_plane_subnet_newbits" { default = 13 }
+variable "fss_subnet_newbits" { default = 11 }
+variable "int_lb_subnet_newbits" { default = 11 }
+variable "operator_subnet_newbits" { default = 13 }
+variable "pod_subnet_newbits" { default = 2 }
+variable "pub_lb_subnet_newbits" { default = 11 }
+variable "worker_subnet_newbits" { default = 2 }
+
+variable "bastion_subnet_id" {
+  type    = string
+  default = null
+}
+variable "control_plane_subnet_id" {
+  type    = string
+  default = null
+}
+variable "fss_subnet_id" {
+  type    = string
+  default = null
+}
+variable "int_lb_subnet_id" {
+  type    = string
+  default = null
+}
+variable "operator_subnet_id" {
+  type    = string
+  default = null
+}
+variable "pod_subnet_id" {
+  type    = string
+  default = null
+}
+variable "pub_lb_subnet_id" {
+  type    = string
+  default = null
+}
+variable "worker_subnet_id" {
+  type    = string
+  default = null
+}

--- a/examples/oke-cluster-with-network/variables.tf
+++ b/examples/oke-cluster-with-network/variables.tf
@@ -1,0 +1,47 @@
+# Copyright (c) 2023 Oracle Corporation and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl
+
+locals {
+  ssh_public_key = try(base64decode(var.ssh_public_key), var.ssh_public_key)
+}
+
+# General
+
+variable "output_detail" { default = false }
+variable "timezone" { default = "Etc/UTC" }
+
+# SSH
+
+variable "ssh_public_key" {
+  default = null
+  type    = string
+}
+variable "ssh_kms_vault_id" {
+  default = null
+  type    = string
+}
+variable "ssh_kms_secret_id" {
+  default = null
+  type    = string
+}
+
+# Oracle Container Image Registry (OCIR)
+
+variable "ocir_email_address" {
+  default = null
+  type    = string
+}
+variable "ocir_kms_vault_id" {
+  default = null
+  type    = string
+}
+variable "ocir_kms_secret_id" {
+  default = null
+  type    = string
+}
+variable "ocir_secret_name" { default = "ocirsecret" }
+variable "ocir_secret_namespace" { default = "default" }
+variable "ocir_username" {
+  default = null
+  type    = string
+}

--- a/examples/oke-network-only/main.tf
+++ b/examples/oke-network-only/main.tf
@@ -1,0 +1,128 @@
+# Copyright (c) 2023 Oracle Corporation and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl
+
+data "oci_identity_region_subscriptions" "home" {
+  tenancy_id = var.tenancy_ocid
+  filter {
+    name   = "is_home_region"
+    values = [true]
+  }
+}
+
+data "oci_secrets_secretbundle" "ssh_key" {
+  count     = var.create_bastion ? 1 : 0
+  secret_id = var.ssh_kms_secret_id
+}
+
+locals {
+  ssh_key_bundle         = sensitive(one(data.oci_secrets_secretbundle.ssh_key[*].secret_bundle_content))
+  ssh_key_bundle_content = sensitive(var.create_bastion ? lookup(one(local.ssh_key_bundle), "content", null) : null)
+}
+
+module "oke" {
+  source         = "github.com/devoncrouse/terraform-oci-oke.git?ref=5.x-stack&depth=1"
+  providers      = { oci.home = oci.home }
+  tenancy_id     = var.tenancy_ocid
+  compartment_id = var.compartment_ocid
+
+  # Identity
+  create_iam_resources     = true
+  create_iam_tag_namespace = var.create_iam_tag_namespace
+  create_iam_defined_tags  = var.create_iam_tag_namespace || var.create_iam_defined_tags
+  use_defined_tags         = var.use_defined_tags
+  tag_namespace            = var.tag_namespace
+
+  # Network
+  create_vcn                  = var.create_vcn
+  vcn_id                      = var.vcn_id
+  vcn_cidrs                   = split(",", var.vcn_cidrs)
+  vcn_create_internet_gateway = var.vcn_create_internet_gateway ? "always" : "never"
+  vcn_create_nat_gateway      = var.vcn_create_nat_gateway ? "always" : "never"
+  vcn_create_service_gateway  = var.vcn_create_service_gateway ? "always" : "never"
+  vcn_name                    = var.vcn_name
+  vcn_dns_label               = var.vcn_dns_label
+  assign_dns                  = var.assign_dns
+  ig_route_table_id           = var.ig_route_table_id
+  local_peering_gateways      = var.local_peering_gateways
+  lockdown_default_seclist    = var.lockdown_default_seclist
+  nat_gateway_public_ip_id    = var.nat_gateway_public_ip_id
+  nat_route_table_id          = var.nat_route_table_id
+  create_drg                  = var.create_drg
+  drg_id                      = var.drg_id
+  drg_display_name            = var.drg_display_name
+
+  subnets = {
+    bastion  = { create = var.bastion_subnet_create ? "always" : "never", newbits = var.bastion_subnet_newbits, id = var.bastion_subnet_id }
+    operator = { create = var.operator_subnet_create ? "always" : "never", newbits = var.operator_subnet_newbits, id = var.operator_subnet_id }
+    cp       = { create = var.control_plane_subnet_create ? "always" : "never", newbits = var.control_plane_subnet_newbits, id = var.control_plane_subnet_id }
+    int_lb   = { create = var.int_lb_subnet_create ? "always" : "never", newbits = var.int_lb_subnet_newbits, id = var.int_lb_subnet_id }
+    pub_lb   = { create = var.pub_lb_subnet_create ? "always" : "never", newbits = var.pub_lb_subnet_newbits, id = var.pub_lb_subnet_id }
+    workers  = { create = var.worker_subnet_create ? "always" : "never", newbits = var.worker_subnet_newbits, id = var.worker_subnet_id }
+    pods     = { create = var.pod_subnet_create ? "always" : "never", newbits = var.pod_subnet_newbits, id = var.pod_subnet_id }
+    fss      = { create = var.fss_subnet_create ? "always" : "never", newbits = var.fss_subnet_newbits, id = var.fss_subnet_id }
+  }
+
+  # Network Security
+  create_nsgs                  = var.create_nsgs
+  create_nsgs_always           = true
+  allow_node_port_access       = var.allow_node_port_access
+  allow_pod_internet_access    = var.allow_pod_internet_access
+  allow_rules_internal_lb      = var.allow_rules_internal_lb
+  allow_rules_public_lb        = var.allow_rules_public_lb
+  allow_worker_internet_access = var.allow_worker_internet_access
+  allow_worker_ssh_access      = var.allow_worker_ssh_access
+  enable_waf                   = var.enable_waf
+  bastion_allowed_cidrs        = compact(split(",", var.bastion_allowed_cidrs))
+  bastion_nsg_ids              = compact(split(",", var.bastion_nsg_id))
+  control_plane_allowed_cidrs  = compact(split(",", var.control_plane_allowed_cidrs))
+  control_plane_is_public      = var.control_plane_is_public
+  control_plane_nsg_ids        = compact(split(",", var.control_plane_nsg_id))
+  fss_nsg_ids                  = compact(split(",", var.fss_nsg_id))
+  load_balancers               = lower(var.load_balancers)
+  operator_nsg_ids             = compact(split(",", var.operator_nsg_id))
+  pod_nsg_ids                  = compact(split(",", var.pod_nsg_id))
+  worker_is_public             = var.worker_is_public
+  worker_nsg_ids               = compact(split(",", var.worker_nsg_id))
+
+  # Bastion
+  bastion_availability_domain = var.bastion_availability_domain
+  bastion_image_id            = var.bastion_image_id
+  bastion_image_os            = var.bastion_image_os
+  bastion_image_os_version    = var.bastion_image_os_version
+  bastion_image_type          = lower(var.bastion_image_type)
+  bastion_is_public           = var.bastion_is_public
+  bastion_shape               = var.bastion_shape
+  bastion_upgrade             = var.bastion_upgrade
+  bastion_user                = var.bastion_user
+  create_bastion              = var.create_bastion
+
+  # SSH
+  ssh_public_key  = local.ssh_public_key
+  ssh_private_key = sensitive(local.ssh_key_bundle_content)
+
+  # Cluster
+  create_cluster          = false
+  preferred_load_balancer = lower(var.preferred_load_balancer)
+  create_fss              = false
+  create_operator         = false
+
+  freeform_tags = { # TODO Remaining tags in schema
+    cluster           = {}
+    persistent_volume = {}
+    service_lb        = {}
+    workers           = {}
+    bastion           = lookup(var.bastion_tags, "freeformTags", {})
+    operator          = {}
+    vcn               = {}
+  }
+
+  defined_tags = { # TODO Remaining tags in schema
+    cluster           = {}
+    persistent_volume = {}
+    service_lb        = {}
+    workers           = {}
+    bastion           = lookup(var.bastion_tags, "definedTags", {})
+    operator          = {}
+    vcn               = {}
+  }
+}

--- a/examples/oke-network-only/output.tf
+++ b/examples/oke-network-only/output.tf
@@ -1,0 +1,48 @@
+# Copyright (c) 2023 Oracle Corporation and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl
+
+# Terraform
+output "state_id" { value = module.oke.state_id }
+
+# Network
+output "vcn_id" { value = module.oke.vcn_id }
+output "drg_id" { value = module.oke.drg_id }
+output "ig_route_table_id" { value = module.oke.ig_route_table_id }
+output "nat_route_table_id" { value = module.oke.nat_route_table_id }
+
+# Bastion
+output "bastion_id" { value = module.oke.bastion_id }
+output "bastion_public_ip" { value = module.oke.bastion_public_ip }
+output "bastion_subnet_id" { value = module.oke.bastion_subnet_id }
+output "bastion_subnet_cidr" { value = lookup(module.oke.subnet_cidrs, "bastion", null) }
+output "bastion_nsg_id" { value = module.oke.bastion_nsg_id }
+output "bastion_ssh_command" { value = module.oke.ssh_to_bastion }
+output "bastion_ssh_secret_id" { value = var.ssh_kms_secret_id }
+
+# Operator
+output "operator_subnet_id" { value = module.oke.operator_subnet_id }
+output "operator_subnet_cidr" { value = lookup(module.oke.subnet_cidrs, "operator", null) }
+output "operator_nsg_id" { value = module.oke.operator_nsg_id }
+
+# Cluster
+output "control_plane_subnet_id" { value = module.oke.control_plane_subnet_id }
+output "control_plane_subnet_cidr" { value = lookup(module.oke.subnet_cidrs, "cp", null) }
+output "control_plane_nsg_id" { value = module.oke.control_plane_nsg_id }
+output "int_lb_subnet_id" { value = module.oke.int_lb_subnet_id }
+output "pub_lb_subnet_id" { value = module.oke.pub_lb_subnet_id }
+output "int_lb_nsg_id" { value = module.oke.int_lb_nsg_id }
+output "int_lb_subnet_cidr" { value = lookup(module.oke.subnet_cidrs, "int_lb", null) }
+output "pub_lb_nsg_id" { value = module.oke.pub_lb_nsg_id }
+output "pub_lb_subnet_cidr" { value = lookup(module.oke.subnet_cidrs, "pub_lb", null) }
+
+# Workers
+output "worker_subnet_id" { value = module.oke.worker_subnet_id }
+output "worker_subnet_cidr" { value = lookup(module.oke.subnet_cidrs, "workers", null) }
+output "worker_nsg_id" { value = module.oke.worker_nsg_id }
+output "pod_subnet_id" { value = module.oke.pod_subnet_id }
+output "pod_subnet_cidr" { value = lookup(module.oke.subnet_cidrs, "pods", null) }
+output "pod_nsg_id" { value = module.oke.pod_nsg_id }
+output "fss_id" { value = module.oke.fss_id }
+output "fss_subnet_id" { value = module.oke.fss_subnet_id }
+output "fss_subnet_cidr" { value = lookup(module.oke.subnet_cidrs, "fss", null) }
+output "fss_nsg_id" { value = module.oke.fss_nsg_id }

--- a/examples/oke-network-only/schema.yaml
+++ b/examples/oke-network-only/schema.yaml
@@ -1,0 +1,958 @@
+# Copyright (c) 2023 Oracle Corporation and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl
+
+title: "OKE: Network Only"
+description: Common Virtual Cloud Network resources for OKE cluster installations.
+schemaVersion: 1.1.0
+version: "20230304"
+locale: "en"
+
+variableGroups:
+  - title: "Hidden"
+    visible: false
+    variables:
+      - api_fingerprint
+      - current_user_ocid
+      - tenancy_ocid
+      - region
+      - subnets
+      - bastion_public_ip
+
+  - title: "Identity"
+    variables:
+      - compartment_ocid
+      - create_iam_tag_namespace
+      - create_iam_defined_tags
+      - use_defined_tags
+      - tag_namespace
+
+  - title: "VCN"
+    variables:
+      - ${create_vcn}
+      - assign_dns
+      - vcn_id
+      - vcn_name
+      - vcn_cidrs
+      - vcn_dns_label
+      - ig_route_table_id
+      - vcn_create_internet_gateway
+      - vcn_create_nat_gateway
+      - vcn_create_service_gateway
+      - nat_gateway_id
+      - nat_route_table_id
+      - nat_gateway_public_ip_id
+      - service_gateway_id
+      - create_drg
+      - drg_id
+      - local_peering_gateways
+
+  - title: "Security"
+    variables:
+      - ${create_nsgs}
+      - lockdown_default_seclist
+      - enable_waf
+
+  - title: "Bastion"
+    variables:
+      - bastion_is_public
+      - bastion_subnet_create
+      - bastion_subnet_newbits
+      - bastion_subnet_id
+      - bastion_nsg_id
+      - bastion_allowed_cidrs
+      - ${create_bastion}
+      - bastion_upgrade
+      - bastion_availability_domain
+      - bastion_image_os
+      - bastion_image_os_version
+      - bastion_image_id
+      - bastion_user
+      - bastion_shape_name
+      - bastion_shape_ocpus
+      - bastion_shape_memory
+      - bastion_shape_boot
+      - bastion_shape
+      - bastion_tags
+
+  - title: "SSH"
+    visible: ${create_bastion}
+    variables:
+      - ssh_public_key
+      - ssh_kms_vault_id
+      - ssh_kms_secret_id
+
+  - title: "Operator"
+    variables:
+      - operator_subnet_create
+      - operator_subnet_newbits
+      - operator_subnet_id
+      - operator_nsg_id
+
+  - title: "Control Plane"
+    variables:
+      - control_plane_is_public
+      - control_plane_subnet_create
+      - control_plane_subnet_newbits
+      - control_plane_subnet_id
+      - control_plane_nsg_id
+      - control_plane_allowed_cidrs
+
+  - title: "Load Balancers"
+    variables:
+      - load_balancers
+      - preferred_load_balancer
+      - allow_rules_internal_lb
+      - allow_rules_public_lb
+      - int_lb_subnet_create
+      - int_lb_subnet_newbits
+      - int_lb_subnet_id
+      - pub_lb_subnet_create
+      - pub_lb_subnet_newbits
+      - pub_lb_subnet_id
+
+  - title: "Workers"
+    variables:
+      - worker_is_public
+      - worker_subnet_create
+      - worker_subnet_newbits
+      - worker_subnet_id
+      - worker_nsg_id
+      - allow_worker_ssh_access
+      - allow_worker_internet_access
+      - allow_node_port_access
+      - pod_subnet_create
+      - pod_subnet_newbits
+      - pod_subnet_id
+      - pod_nsg_id
+      - allow_pod_internet_access
+      - fss_subnet_create
+      - fss_subnet_newbits
+      - fss_subnet_id
+      - fss_nsg_id
+
+variables:
+  # Identity
+  api_fingerprint:
+    required: false
+    visible: false
+  current_user_ocid:
+    title: User
+    type: ocid
+    required: true
+  tenancy_ocid:
+    title: Tenancy
+    type: oci:identity:compartment:id
+    required: true
+  compartment_ocid:
+    title: Compartment
+    description: The default compartment for created resources.
+    type: oci:identity:compartment:id
+    required: true
+  region:
+    required: true
+    title: Region
+    type: oci:identity:region:name
+  defined_tags:
+    visible: false
+  freeform_tags:
+    visible: false
+  create_iam_tag_namespace:
+    default: false
+    required: true
+    title: Create tag namespace
+    type: boolean
+  create_iam_defined_tags:
+    default: false
+    required: true
+    title: Create defined tags
+    type: boolean
+  use_defined_tags:
+    title: Use defined tags
+    default: false
+    type: boolean
+  tag_namespace:
+    title: Tag namespace
+    visible:
+      or:
+        - ${create_iam_tag_namespace}
+        - ${create_iam_defined_tags}
+        - ${use_defined_tags}
+
+  # VCN
+  create_vcn:
+    title: Create VCN
+    type: boolean
+    default: true
+  vcn_id:
+    title: Existing VCN
+    type: oci:core:vcn:id
+    required: true
+    dependsOn:
+      compartmentId: ${compartment_ocid}
+    visible: { not: [create_vcn] }
+  vcn_name:
+    title: Virtual Cloud Network (VCN) name
+    description: Display name for the created VCN. Defaults to 'oke' suffixed with the generated Terraform 'state_id' value.
+    type: string
+    visible: ${create_vcn}
+  assign_dns:
+    title: Assign DNS records
+    type: boolean
+    required: true
+    visible: ${create_vcn}
+  vcn_dns_label:
+    title: DNS label
+    description: DNS label for the created VCN. Defaults to the generated Terraform 'state_id' value.
+    visible:
+      and:
+        - ${create_vcn}
+        - ${assign_dns}
+  vcn_cidrs:
+    title: CIDR ranges
+    description: Comma-separated list of CIDR blocks for the created VCN.
+    type: string
+    required: true
+    visible: ${create_vcn}
+  lockdown_default_seclist:
+    title: Secure default security list
+    type: boolean
+    required: true
+    visible: ${create_vcn}
+  vcn_create_internet_gateway:
+    title: Create internet gateway
+    type: boolean
+    required: true
+    visible: ${create_vcn}
+  vcn_create_nat_gateway:
+    title: Create service gateway
+    type: boolean
+    required: true
+    visible: ${create_vcn}
+  vcn_create_service_gateway:
+    title: Create NAT gateway
+    type: boolean
+    required: true
+    visible: ${create_vcn}
+  local_peering_gateways:
+    title: Local peering gateways
+    visible: false
+  ig_route_table_id:
+    title: Internet Gateway Route Table
+    type: ocid
+    required: false
+    visible:
+      not:
+        - ${create_vcn}
+  service_gateway_id:
+    title: Service gateway
+    description: Existing service gateway in the VCN for access to Oracle Cloud services.
+    type: oci:core:servicegateway:id
+    required: true
+    visible:
+      not:
+        - ${create_vcn}
+    dependsOn:
+      compartmentId: ${compartment_ocid}
+      vcnId: ${vcn_id}
+  nat_gateway_id:
+    title: NAT gateway
+    description: Existing NAT gateway in the VCN for private network egress.
+    type: oci:core:natgateway:id
+    required: true
+    visible:
+      not:
+        - ${create_vcn}
+    dependsOn:
+      compartmentId: ${compartment_ocid}
+      vcnId: ${vcn_id}
+  nat_route_table_id:
+    title: NAT Gateway Route Table
+    type: ocid
+    required: false
+    visible: false
+  nat_gateway_public_ip_id:
+    required: false
+    visible: false
+
+  # NSGs
+  create_nsgs:
+    title: Create NSGs
+    description: Create standard network security groups and traffic rules. Additional configuration may be required when disabled, e.g. providing existing NSGs, subnet security lists, etc.
+    type: boolean
+    default: true
+    required: true
+  bastion_nsg_id:
+    title: Additional Network Security Group
+    type: oci:core:nsg:id
+    # additionalProps:
+    #   allowMultiple: true
+    dependsOn:
+      compartmentId: ${compartment_ocid}
+      vcnId: ${vcn_id}
+    visible: { not: [create_vcn] }
+  bastion_allowed_cidrs:
+    title: Comma-separated list of CIDR blocks allowed SSH access to the bastion host.
+    type: string
+    required: false
+    visible: ${create_nsgs}
+  operator_nsg_id:
+    title: Additional Network Security Group
+    type: oci:core:nsg:id
+    # additionalProps:
+    #   allowMultiple: true
+    dependsOn:
+      compartmentId: ${compartment_ocid}
+      vcnId: ${vcn_id}
+    visible: { not: [create_vcn] }
+  control_plane_nsg_id:
+    title: Additional Network Security Group
+    type: oci:core:nsg:id
+    # additionalProps:
+    #   allowMultiple: true
+    dependsOn:
+      compartmentId: ${compartment_ocid}
+      vcnId: ${vcn_id}
+    visible: { not: [create_vcn] }
+  control_plane_allowed_cidrs:
+    title: Comma-separated list of CIDR blocks allowed access to the OKE control plane.
+    type: string
+    required: false
+    visible: ${create_nsgs}
+  pod_nsg_id:
+    title: Additional Network Security Group for pods
+    type: oci:core:nsg:id
+    # additionalProps:
+    #   allowMultiple: true
+    dependsOn:
+      compartmentId: ${compartment_ocid}
+      vcnId: ${vcn_id}
+    visible: { not: [create_vcn] }
+  worker_nsg_id:
+    title: Additional Network Security Group for workers
+    type: oci:core:nsg:id
+    # additionalProps:
+    #   allowMultiple: true
+    dependsOn:
+      compartmentId: ${compartment_ocid}
+      vcnId: ${vcn_id}
+    visible: { not: [create_vcn] }
+  fss_nsg_id:
+    title: Additional Network Security Group for FSS
+    type: oci:core:nsg:id
+    # additionalProps:
+    #   allowMultiple: true
+    dependsOn:
+      compartmentId: ${compartment_ocid}
+      vcnId: ${vcn_id}
+    visible:
+      and:
+        - ${create_fss}
+        - not: [create_vcn]
+
+  control_plane_is_public:
+    title: Public Kubernetes control plane
+    type: boolean
+    default: false
+    required: true
+    visible: ${create_nsgs}
+  preferred_load_balancer:
+    title: Preferred load balancer
+    type: enum
+    default: Internal
+    enum: [Internal, Public]
+    allowMultiple: false
+    required: true
+  worker_is_public:
+    title: Public Kubernetes worker nodes
+    type: boolean
+    default: false
+    required: true
+    visible: ${create_nsgs}
+  allow_node_port_access:
+    title: Allow NodePort access
+    type: boolean
+    default: false
+    required: true
+    visible: ${create_nsgs}
+  allow_worker_ssh_access:
+    title: Allow worker SSH access
+    type: boolean
+    default: true
+    required: true
+    visible: ${create_nsgs}
+  allow_worker_internet_access:
+    title: Allow worker egress to internet
+    type: boolean
+    default: true
+    required: true
+    visible: ${create_nsgs}
+  allow_pod_internet_access:
+    title: Allow pod egress to internet
+    type: boolean
+    required: false
+    default: true
+    visible: ${create_nsgs}
+  allow_rules_internal_lb:
+    title: Additional internal load balancer rules
+    additionalProps:
+      allowMultiple: true
+    required: false
+    visible: ${create_nsgs}
+  allow_rules_public_lb:
+    title: Additional public load balancer rules
+    additionalProps:
+      allowMultiple: true
+    required: false
+    visible: ${create_nsgs}
+
+  create_drg:
+    title: Create DRG
+    description: Create a Dynamic Routing Gateway and attach it to the VCN.
+    type: boolean
+    default: false
+    required: false
+    visible: false
+  drg_id:
+    title: Dynamic Routing Gateway
+    description: Existing Dynamic Routing Gateway to attach to the VCN.
+    type: ocid
+    required: false
+    visible: { not: [create_drg] }
+  drg_display_name:
+    title: DRG display name
+    visible: ${create_drg}
+  enable_waf:
+    title: Enable WAF
+    type: boolean
+    default: false
+    required: false
+    visible: false
+  load_balancers:
+    title: Load balancers
+    type: enum
+    enum: [Public, Internal, Both]
+    default: Internal
+    required: true
+    visible:
+      or:
+        - ${create_cluster}
+        - ${create_nsgs}
+
+  bastion_is_public:
+    title: Public network
+    description: Public network and address for bastion host.
+    type: boolean
+    default: true
+    required: true
+    visible:
+      or:
+        - ${bastion_subnet_create}
+        - ${create_bastion}
+  bastion_subnet_create:
+    title: Create bastion subnet
+    type: boolean
+    default: true
+    required: true
+  bastion_subnet_newbits:
+    title: Bastion subnet size
+    description: The number of network prefix bits added to the VCN CIDR block for the created subnet address range (i.e. a higher value is smaller). Refer to the Terraform <a href=https://developer.hashicorp.com/terraform/language/functions/cidrsubnets>cidrsubnets</a> function for more information.
+    type: number
+    visible: ${bastion_subnet_create}
+  bastion_subnet_id:
+    title: Bastion subnet
+    type: oci:core:subnet:id
+    required: true
+    dependsOn:
+      compartmentId: ${compartment_ocid}
+      vcnId: ${vcn_id}
+      hidePublicSubnet: { not: [bastion_is_public] }
+      hidePrivateSubnet: ${bastion_is_public}
+      hideRegionalSubnet: false
+      hideAdSubnet: false
+    visible:
+      not:
+        - or:
+            - ${bastion_subnet_create}
+            - ${create_vcn}
+            - not:
+                - ${create_bastion}
+  create_bastion:
+    title: Create bastion instance
+    type: boolean
+    default: true
+    required: true
+  bastion_availability_domain:
+    title: Availability domain
+    type: oci:identity:availabilitydomain:name
+    required: false
+    dependsOn:
+      compartmentId: ${compartment_ocid}
+    visible: ${create_bastion}
+  bastion_user:
+    title: User
+    type: string
+    default: opc
+    required: true
+    visible: ${create_bastion}
+  bastion_shape_name:
+    title: Shape
+    type: oci:core:instanceshape:name
+    default: "VM.Standard.E4.Flex"
+    required: true
+    dependsOn:
+      compartmentId: ${compartment_ocid}
+    visible: ${create_bastion}
+  bastion_shape_ocpus:
+    title: OCPUs (Cores)
+    type: number
+    default: 4
+    required: true
+    dependsOn:
+      compartmentId: ${compartment_ocid}
+    visible: ${create_bastion}
+  bastion_shape_memory:
+    title: Memory (GB)
+    type: number
+    default: 16
+    required: true
+    dependsOn:
+      compartmentId: ${compartment_ocid}
+    visible: ${create_bastion}
+  bastion_shape_boot:
+    title: Boot volume size (GB)
+    type: number
+    default: 50
+    required: true
+    dependsOn:
+      compartmentId: ${compartment_ocid}
+    visible: ${create_bastion}
+  bastion_shape:
+    visible: false
+  bastion_image_os:
+    title: Image OS
+    description: Image operating system.
+    type: enum
+    default: "Oracle Autonomous Linux"
+    enum: ["Oracle Autonomous Linux", "Oracle Linux"]
+    required: true
+    visible:
+      and:
+        - ${create_bastion}
+        - not:
+            - eq:
+                - ${bastion_image_type}
+                - custom
+  bastion_image_os_version:
+    title: Image OS version
+    description: Image operating system version.
+    type: enum
+    default: "8.7"
+    enum: ["7.9", "8.7"]
+    required: true
+    visible:
+      and:
+        - ${create_bastion}
+        - not:
+            - eq:
+                - ${bastion_image_type}
+                - custom
+  bastion_image_type:
+    title: Image type
+    type: enum
+    default: platform
+    enum: [platform, custom]
+    required: true
+    visible: false
+  bastion_image_id:
+    title: Image ID
+    type: oci:core:image:id
+    required: false
+    dependsOn:
+      compartmentId: ${compartment_ocid}
+      operatingSystem: ${bastion_image_os}
+      operatingSystemVersion: ${bastion_image_os_version}
+      shape: ${bastion_shape_name}
+    visible: ${create_bastion}
+  bastion_upgrade:
+    title: Upgrade OS
+    description: Upgrade the operating system on boot.
+    type: boolean
+    default: false
+    required: true
+    visible: ${create_bastion}
+  bastion_tags:
+    type: oci:identity:tag:value
+    required: false
+    title: Tagging
+    description: Tag values for created resources.
+    dependsOn:
+      compartmentId: ${compartment_ocid}
+    visible: ${create_bastion}
+
+  # SSH
+  ssh_public_key:
+    title: SSH Public Key
+    type: oci:core:ssh:publickey
+    pattern: "((^(ssh-rsa AAAAB3NzaC1yc2|ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNT|ecdsa-sha2-nistp384 AAAAE2VjZHNhLXNoYTItbmlzdHAzODQAAAAIbmlzdHAzOD|ecdsa-sha2-nistp521 AAAAE2VjZHNhLXNoYTItbmlzdHA1MjEAAAAIbmlzdHA1Mj|ssh-ed25519 AAAAC3NzaC1lZDI1NTE5|ssh-dss AAAAB3NzaC1kc3)[0-9A-Za-z+\/]+[=]{0,3})( [^,]*)?)(,((ssh-rsa AAAAB3NzaC1yc2|ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNT|ecdsa-sha2-nistp384 AAAAE2VjZHNhLXNoYTItbmlzdHAzODQAAAAIbmlzdHAzOD|ecdsa-sha2-nistp521 AAAAE2VjZHNhLXNoYTItbmlzdHA1MjEAAAAIbmlzdHA1Mj|ssh-ed25519 AAAAC3NzaC1lZDI1NTE5|ssh-dss AAAAB3NzaC1kc3)[0-9A-Za-z+\/]+[=]{0,3})( [^,]*)?)*$"
+    required: false
+  ssh_kms_vault_id:
+    title: SSH Vault
+    description: The OCI Vault used to encrypt the SSH key pair.
+    type: oci:kms:vault:id
+    required: true
+    dependsOn:
+      compartmentId: ${compartment_ocid}
+  ssh_kms_secret_id:
+    title: SSH Vault secret
+    description: The OCI Vault secret containing the SSH private key.
+    type: oci:kms:secret:id
+    required: true
+    dependsOn:
+      compartmentId: ${compartment_ocid}
+      vaultId: ${ssh_kms_vault_id}
+
+  operator_subnet_create:
+    title: Create operator subnet
+    type: boolean
+    required: true
+  operator_subnet_newbits:
+    title: Operator subnet size
+    description: The number of network prefix bits added to the VCN CIDR block for the created subnet address range (i.e. a higher value is smaller). Refer to the Terraform <a href=https://developer.hashicorp.com/terraform/language/functions/cidrsubnets>cidrsubnets</a> function for more information.
+    type: number
+    visible: ${operator_subnet_create}
+  operator_subnet_id:
+    title: Operator subnet
+    type: oci:core:subnet:id
+    required: false
+    dependsOn:
+      compartmentId: ${compartment_ocid}
+      vcnId: ${vcn_id}
+      hidePublicSubnet: true
+      hidePrivateSubnet: false
+      hideRegionalSubnet: false
+      hideAdSubnet: false
+    visible:
+      not:
+        - or:
+            - ${operator_subnet_create}
+            - ${create_vcn}
+  control_plane_subnet_create:
+    title: Create control plane subnet
+    type: boolean
+    required: true
+  control_plane_subnet_newbits:
+    title: Control plane subnet size
+    description: The number of network prefix bits added to the VCN CIDR block for the created subnet address range (i.e. a higher value is smaller). Refer to the Terraform <a href=https://developer.hashicorp.com/terraform/language/functions/cidrsubnets>cidrsubnets</a> function for more information.
+    type: number
+    visible: ${control_plane_subnet_create}
+  control_plane_subnet_id:
+    title: Control plane subnet
+    type: oci:core:subnet:id
+    required: false
+    dependsOn:
+      compartmentId: ${compartment_ocid}
+      vcnId: ${vcn_id}
+      hidePublicSubnet: { not: [control_plane_is_public] }
+      hidePrivateSubnet: ${control_plane_is_public}
+      hideRegionalSubnet: false
+      hideAdSubnet: true
+    visible:
+      not:
+        - or:
+            - ${control_plane_subnet_create}
+            - ${create_vcn}
+  int_lb_subnet_create:
+    title: Create internal load balancer subnet
+    type: boolean
+    required: true
+  int_lb_subnet_newbits:
+    title: Internal load balancer subnet size
+    description: The number of network prefix bits added to the VCN CIDR block for the created subnet address range (i.e. a higher value is smaller). Refer to the Terraform <a href=https://developer.hashicorp.com/terraform/language/functions/cidrsubnets>cidrsubnets</a> function for more information.
+    type: number
+    visible: ${int_lb_subnet_create}
+  int_lb_subnet_id:
+    title: Internal load balancer subnet
+    type: oci:core:subnet:id
+    required: false
+    dependsOn:
+      compartmentId: ${compartment_ocid}
+      vcnId: ${vcn_id}
+      hidePublicSubnet: true
+      hidePrivateSubnet: false
+      hideRegionalSubnet: false
+      hideAdSubnet: true
+    visible:
+      not:
+        - or:
+            - ${create_vcn}
+            - ${int_lb_subnet_create}
+  pub_lb_subnet_create:
+    title: Create public load balancer subnet
+    type: boolean
+    required: true
+  pub_lb_subnet_newbits:
+    title: Public load balancer subnet size
+    description: The number of network prefix bits added to the VCN CIDR block for the created subnet address range (i.e. a higher value is smaller). Refer to the Terraform <a href=https://developer.hashicorp.com/terraform/language/functions/cidrsubnets>cidrsubnets</a> function for more information.
+    type: number
+    visible: ${pub_lb_subnet_create}
+  pub_lb_subnet_id:
+    title: Public load balancer subnet
+    type: oci:core:subnet:id
+    required: false
+    dependsOn:
+      compartmentId: ${compartment_ocid}
+      vcnId: ${vcn_id}
+      hidePublicSubnet: false
+      hidePrivateSubnet: true
+      hideRegionalSubnet: false
+      hideAdSubnet: true
+    visible:
+      not:
+        - or:
+            - ${create_vcn}
+            - ${pub_lb_subnet_create}
+  worker_subnet_create:
+    title: Create worker subnet
+    type: boolean
+    required: true
+  worker_subnet_newbits:
+    title: Worker subnet size
+    description: The number of network prefix bits added to the VCN CIDR block for the created subnet address range (i.e. a higher value is smaller). Refer to the Terraform <a href=https://developer.hashicorp.com/terraform/language/functions/cidrsubnets>cidrsubnets</a> function for more information.
+    type: number
+    visible: ${worker_subnet_create}
+  worker_subnet_id:
+    title: Worker subnet
+    type: oci:core:subnet:id
+    required: false
+    dependsOn:
+      compartmentId: ${compartment_ocid}
+      vcnId: ${vcn_id}
+      hidePublicSubnet: { not: [worker_is_public] }
+      hidePrivateSubnet: ${worker_is_public}
+      hideRegionalSubnet: false
+      hideAdSubnet: false
+    visible:
+      not:
+        - or:
+            - ${worker_subnet_create}
+            - ${create_vcn}
+
+  pod_subnet_create:
+    title: Create pod subnet
+    type: boolean
+    required: true
+  pod_subnet_newbits:
+    title: Pod subnet size
+    description: The number of network prefix bits added to the VCN CIDR block for the created subnet address range (i.e. a higher value is smaller). Refer to the Terraform <a href=https://developer.hashicorp.com/terraform/language/functions/cidrsubnets>cidrsubnets</a> function for more information.
+    type: number
+    visible: ${pod_subnet_create}
+  pod_subnet_id:
+    title: Pod subnet
+    type: oci:core:subnet:id
+    required: false
+    dependsOn:
+      compartmentId: ${compartment_ocid}
+      vcnId: ${vcn_id}
+      hidePublicSubnet: true
+      hidePrivateSubnet: false
+      hideRegionalSubnet: false
+      hideAdSubnet: true
+    visible:
+      not:
+        - or:
+            - ${pod_subnet_create}
+            - ${create_vcn}
+  fss_subnet_create:
+    title: Create FSS subnet
+    type: boolean
+    required: true
+  fss_subnet_newbits:
+    title: FSS subnet size
+    description: The number of network prefix bits added to the VCN CIDR block for the created subnet address range (i.e. a higher value is smaller). Refer to the Terraform <a href=https://developer.hashicorp.com/terraform/language/functions/cidrsubnets>cidrsubnets</a> function for more information.
+    type: number
+    visible: ${fss_subnet_create}
+  fss_subnet_id:
+    title: FSS subnet
+    type: oci:core:subnet:id
+    required: false
+    dependsOn:
+      compartmentId: ${compartment_ocid}
+      vcnId: ${vcn_id}
+      hidePublicSubnet: false
+      hidePrivateSubnet: false
+      hideRegionalSubnet: false
+      hideAdSubnet: false
+    visible:
+      not:
+        - or:
+            - ${fss_subnet_create}
+            - ${create_vcn}
+
+outputGroups:
+  - title: Terraform
+    outputs:
+      - state_id
+  - title: Network
+    outputs:
+      - vcn_id
+      - ig_route_table_id
+      - nat_route_table_id
+      - drg_id
+  - title: Bastion
+    outputs:
+      - bastion_id
+      - bastion_subnet_id
+      - bastion_subnet_cidr
+      - bastion_nsg_id
+      - bastion_public_ip
+      - bastion_ssh_command
+      - bastion_ssh_secret_id
+  - title: Operator
+    outputs:
+      - operator_subnet_id
+      - operator_subnet_cidr
+      - operator_nsg_id
+  - title: Cluster
+    outputs:
+      - control_plane_subnet_id
+      - control_plane_subnet_cidr
+      - control_plane_nsg_id
+      - int_lb_subnet_id
+      - int_lb_subnet_cidr
+      - int_lb_nsg_id
+      - pub_lb_subnet_id
+      - pub_lb_subnet_cidr
+      - pub_lb_nsg_id
+  - title: Workers
+    outputs:
+      - worker_subnet_id
+      - worker_subnet_cidr
+      - worker_nsg_id
+      - pod_subnet_id
+      - pod_subnet_cidr
+      - pod_nsg_id
+      - fss_subnet_id
+      - fss_subnet_cidr
+      - fss_nsg_id
+
+outputs:
+  # Terraform
+  state_id:
+    title: State ID
+    type: copyableString
+
+  # Network
+  vcn_id:
+    title: VCN
+    type: ocid
+  drg_id:
+    title: Dynamic routing gateway
+    type: ocid
+  ig_route_table_id:
+    title: Internet gateway route table
+    type: ocid
+  nat_route_table_id:
+    title: NAT gateway route table
+    type: ocid
+  subnet_cidrs:
+    visible: false
+  subnet_ids:
+    visible: false
+  nsg_ids:
+    visible: false
+  network_security_rules:
+    visible: false
+
+  # Bastion
+  bastion_id:
+    title: Bastion instance
+    type: ocid
+  bastion_subnet_id:
+    title: Bastion subnet
+    type: ocid
+  bastion_subnet_cidr:
+    title: Bastion CIDR
+    type: string
+  bastion_nsg_id:
+    title: Bastion NSG
+    type: ocid
+  bastion_public_ip:
+    title: Bastion IP
+    type: copyableString
+  bastion_ssh_command:
+    title: Bastion SSH command
+    type: copyableString
+  bastion_ssh_secret_id:
+    title: Bastion SSH Vault secret
+    type: ocid
+
+  # Operator
+  operator_subnet_id:
+    title: Operator subnet
+    type: ocid
+  operator_subnet_cidr:
+    title: Operator CIDR
+    type: string
+  operator_nsg_id:
+    title: Operator NSG
+    type: ocid
+
+  # Cluster
+  control_plane_subnet_id:
+    title: Control plane subnet
+    type: ocid
+  control_plane_subnet_cidr:
+    title: Control plane CIDR
+    type: string
+  control_plane_nsg_id:
+    title: Control plane NSG
+    type: ocid
+  int_lb_subnet_id:
+    title: Internal load balancer subnet
+    type: ocid
+  int_lb_subnet_cidr:
+    title: Internal load balancer CIDR
+    type: string
+  int_lb_nsg_id:
+    title: Internal load balancer NSG
+    type: ocid
+  pub_lb_subnet_id:
+    title: Public load balancer subnet
+    type: ocid
+  pub_lb_subnet_cidr:
+    title: Public load balancer CIDR
+    type: string
+  pub_lb_nsg_id:
+    title: Public load balancer NSG
+    type: ocid
+
+  # Workers
+  worker_subnet_id:
+    title: Worker subnet
+    type: ocid
+  worker_subnet_cidr:
+    title: Worker CIDR
+    type: string
+  worker_nsg_id:
+    title: Worker NSG
+    type: ocid
+  pod_subnet_id:
+    title: Pod subnet
+    type: ocid
+  pod_subnet_cidr:
+    title: Pod CIDR
+    type: string
+  pod_nsg_id:
+    title: Pod NSG
+    type: ocid
+
+  # FSS
+  fss_subnet_id:
+    title: File Storage Service subnet
+    type: ocid
+  fss_subnet_cidr:
+    title: File Storage Service CIDR
+    type: string
+  fss_nsg_id:
+    title: File Storage Service NSG
+    type: ocid

--- a/examples/oke-network-only/variables-bastion.tf
+++ b/examples/oke-network-only/variables-bastion.tf
@@ -1,0 +1,85 @@
+# Copyright (c) 2023 Oracle Corporation and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl
+
+locals {
+  # SSH key precedence: base64-encoded PEM > raw PEM > file PEM > null
+  ssh_public_key = try(base64decode(var.ssh_public_key), var.ssh_public_key)
+}
+
+variable "create_bastion" { default = true }
+variable "bastion_is_public" { default = true }
+variable "bastion_upgrade" { default = false }
+
+variable "bastion_allowed_cidrs" {
+  default = "0.0.0.0/0"
+  type    = string
+}
+
+variable "bastion_availability_domain" {
+  default = null
+  type    = string
+}
+
+variable "bastion_nsg_id" {
+  default = ""
+  type    = string
+}
+
+variable "bastion_user" {
+  default = "opc"
+  type    = string
+}
+
+variable "bastion_image_id" {
+  default = null
+  type    = string
+}
+
+variable "bastion_image_type" {
+  default = "platform"
+  type    = string
+  validation {
+    condition     = contains(["custom", "platform"], lower(var.bastion_image_type))
+    error_message = "Accepted values are custom or platform"
+  }
+}
+
+variable "bastion_image_os" {
+  default = "Oracle Autonomous Linux"
+  type    = string
+}
+
+variable "bastion_image_os_version" {
+  default = "8.7"
+  type    = string
+}
+
+variable "bastion_shape" {
+  default = {
+    shape            = "VM.Standard.E4.Flex",
+    ocpus            = 1,
+    memory           = 4,
+    boot_volume_size = 50
+  }
+  type = map(any)
+}
+
+variable "bastion_tags" {
+  default = {}
+  type    = map(any)
+}
+
+variable "ssh_public_key" {
+  default = null
+  type    = string
+}
+
+variable "ssh_kms_vault_id" {
+  default = null
+  type    = string
+}
+
+variable "ssh_kms_secret_id" {
+  default = null
+  type    = string
+}

--- a/examples/oke-network-only/variables-iam.tf
+++ b/examples/oke-network-only/variables-iam.tf
@@ -1,0 +1,67 @@
+# Copyright (c) 2023 Oracle Corporation and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl
+
+variable "tenancy_ocid" {
+  default = null
+  type    = string
+}
+
+variable "current_user_ocid" {
+  default = null
+  type    = string
+}
+
+variable "compartment_ocid" {
+  default = null
+  type    = string
+}
+
+variable "region" {
+  default = null
+  type    = string
+}
+
+variable "api_fingerprint" {
+  default = null
+  type    = string
+}
+
+variable "create_iam_tag_namespace" { default = false }
+variable "create_iam_defined_tags" { default = false }
+variable "use_defined_tags" {
+  default     = false
+  description = "Add existing tags in the configured namespace to created resources when applicable."
+  type        = bool
+}
+
+variable "tag_namespace" {
+  default     = "oke"
+  description = "Tag namespace containing standard tags for resources created by the module: [state_id, role, pool, cluster_autoscaler]."
+  type        = string
+}
+
+variable "freeform_tags" {
+  default = {
+    cluster           = {}
+    persistent_volume = {}
+    service_lb        = {}
+    workers           = {}
+    bastion           = {}
+    operator          = {}
+    vcn               = {}
+  }
+  type = any
+}
+
+variable "defined_tags" {
+  default = {
+    cluster           = {}
+    persistent_volume = {}
+    service_lb        = {}
+    workers           = {}
+    bastion           = {}
+    operator          = {}
+    vcn               = {}
+  }
+  type = any
+}

--- a/examples/oke-network-only/variables-network.tf
+++ b/examples/oke-network-only/variables-network.tf
@@ -1,0 +1,97 @@
+# Copyright (c) 2023 Oracle Corporation and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl
+
+variable "create_vcn" { default = true }
+variable "assign_dns" { default = true }
+variable "control_plane_is_public" { default = false }
+variable "enable_waf" { default = false }
+variable "worker_is_public" { default = false }
+
+variable "vcn_name" {
+  default = null
+  type    = string
+}
+
+variable "vcn_id" {
+  default = null
+  type    = string
+}
+
+variable "vcn_create_nat_gateway" {
+  default = true
+  type    = bool
+}
+
+variable "vcn_create_internet_gateway" {
+  default = true
+  type    = bool
+}
+
+variable "vcn_create_service_gateway" {
+  default = true
+  type    = bool
+}
+
+variable "ig_route_table_id" {
+  default = null
+  type    = string
+}
+
+variable "nat_route_table_id" {
+  default = null
+  type    = string
+}
+
+variable "create_drg" { default = false }
+
+variable "drg_display_name" {
+  default = null
+  type    = string
+}
+
+variable "drg_id" {
+  default = null
+  type    = string
+}
+
+variable "internet_gateway_route_rules" {
+  default = null
+  type    = list(map(string))
+}
+
+variable "local_peering_gateways" {
+  default = null
+  type    = map(any)
+}
+
+variable "lockdown_default_seclist" { default = true }
+
+variable "nat_gateway_route_rules" {
+  default = null
+  type    = list(map(string))
+}
+
+variable "nat_gateway_public_ip_id" {
+  default = null
+  type    = string
+}
+
+variable "vcn_cidrs" {
+  default = "10.0.0.0/16"
+  type    = string
+}
+
+variable "vcn_dns_label" {
+  default = null
+  type    = string
+}
+
+variable "load_balancers" {
+  default = "Internal"
+  type    = string
+}
+
+variable "preferred_load_balancer" {
+  default = "Internal"
+  type    = string
+}

--- a/examples/oke-network-only/variables-nsgs.tf
+++ b/examples/oke-network-only/variables-nsgs.tf
@@ -1,0 +1,48 @@
+# Copyright (c) 2023 Oracle Corporation and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl
+
+variable "create_nsgs" { default = true }
+variable "allow_node_port_access" { default = false }
+variable "allow_pod_internet_access" { default = true }
+variable "allow_worker_internet_access" { default = true }
+variable "allow_worker_ssh_access" { default = false }
+
+variable "allow_rules_internal_lb" {
+  default = {}
+  type    = any
+}
+
+variable "allow_rules_public_lb" {
+  default = {}
+  type    = any
+}
+
+variable "control_plane_allowed_cidrs" {
+  default = ""
+  type    = string
+}
+
+variable "control_plane_nsg_id" {
+  default = ""
+  type    = string
+}
+
+variable "worker_nsg_id" {
+  default = ""
+  type    = string
+}
+
+variable "pod_nsg_id" {
+  default = ""
+  type    = string
+}
+
+variable "fss_nsg_id" {
+  default = ""
+  type    = string
+}
+
+variable "operator_nsg_id" {
+  default = ""
+  type    = string
+}

--- a/examples/oke-network-only/variables-subnets.tf
+++ b/examples/oke-network-only/variables-subnets.tf
@@ -1,0 +1,53 @@
+# Copyright (c) 2023 Oracle Corporation and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl
+
+variable "bastion_subnet_create" { default = true }
+variable "control_plane_subnet_create" { default = true }
+variable "fss_subnet_create" { default = true }
+variable "int_lb_subnet_create" { default = true }
+variable "operator_subnet_create" { default = true }
+variable "pod_subnet_create" { default = true }
+variable "pub_lb_subnet_create" { default = true }
+variable "worker_subnet_create" { default = true }
+
+variable "bastion_subnet_newbits" { default = 13 }
+variable "control_plane_subnet_newbits" { default = 13 }
+variable "fss_subnet_newbits" { default = 11 }
+variable "int_lb_subnet_newbits" { default = 11 }
+variable "operator_subnet_newbits" { default = 13 }
+variable "pod_subnet_newbits" { default = 2 }
+variable "pub_lb_subnet_newbits" { default = 11 }
+variable "worker_subnet_newbits" { default = 2 }
+
+variable "bastion_subnet_id" {
+  type    = string
+  default = null
+}
+variable "control_plane_subnet_id" {
+  type    = string
+  default = null
+}
+variable "fss_subnet_id" {
+  type    = string
+  default = null
+}
+variable "int_lb_subnet_id" {
+  type    = string
+  default = null
+}
+variable "operator_subnet_id" {
+  type    = string
+  default = null
+}
+variable "pod_subnet_id" {
+  type    = string
+  default = null
+}
+variable "pub_lb_subnet_id" {
+  type    = string
+  default = null
+}
+variable "worker_subnet_id" {
+  type    = string
+  default = null
+}

--- a/examples/oke-workers/main.tf
+++ b/examples/oke-workers/main.tf
@@ -1,0 +1,95 @@
+# Copyright (c) 2023 Oracle Corporation and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl
+
+data "oci_identity_region_subscriptions" "home" {
+  tenancy_id = var.tenancy_ocid
+  filter {
+    name   = "is_home_region"
+    values = [true]
+  }
+}
+
+locals {
+  worker_image_id   = coalesce(var.worker_image_custom_id, var.worker_image_platform_id, "none")
+  worker_image_type = contains(["platform", "custom"], lower(var.worker_image_type)) ? "custom" : "oke"
+
+  worker_cloud_init = var.worker_cloud_init_configure ? [{
+    content_type = "text/x-shellscript",
+    content      = var.worker_pool_mode == "Node Pool" ? var.worker_cloud_init_oke : var.worker_cloud_init_byon
+  }] : []
+}
+
+module "oke" {
+  source    = "github.com/devoncrouse/terraform-oci-oke.git?ref=5.x-stack&depth=1"
+  providers = { oci.home = oci.home }
+
+  # Identity
+  tenancy_id     = var.tenancy_ocid
+  compartment_id = var.compartment_ocid
+
+  create_iam_resources         = true
+  create_iam_autoscaler_policy = var.create_iam_autoscaler_policy ? "always" : "never"
+  create_iam_worker_policy     = var.create_iam_worker_policy ? "always" : "never"
+  create_nsgs                  = false
+  create_bastion               = false
+  create_operator              = false
+  create_cluster               = false
+
+  # Network
+  create_vcn     = false
+  vcn_id         = var.vcn_id
+  assign_dns     = var.assign_dns
+  worker_nsg_ids = compact([var.worker_nsg_id])
+  pod_nsg_ids    = compact([var.pod_nsg_id])
+  subnets = {
+    workers = { id = var.worker_subnet_id }
+    pods    = { id = var.pod_subnet_id }
+  }
+
+  # Cluster
+  cluster_id              = var.cluster_id
+  cni_type                = lower(var.cni_type)
+  control_plane_is_public = false # workers only need private
+
+  # Workers
+  ssh_public_key   = local.ssh_public_key
+  worker_pool_size = var.worker_pool_size
+  worker_pool_mode = lookup({
+    "Node Pool"       = "node-pool"
+    "Instances"       = "instances"
+    "Instance Pool"   = "instance-pool",
+    "Cluster Network" = "cluster-network",
+  }, var.worker_pool_mode, "node-pool")
+
+  worker_image_type       = lower(local.worker_image_type)
+  worker_image_id         = local.worker_image_id
+  worker_image_os         = var.worker_image_os
+  worker_image_os_version = var.worker_image_os_version
+  worker_cloud_init       = local.worker_cloud_init
+
+  worker_shape = {
+    shape            = var.worker_shape
+    ocpus            = var.worker_ocpus
+    memory           = var.worker_memory
+    boot_volume_size = var.worker_boot_volume_size
+  }
+
+  worker_pools = {
+    "${var.worker_pool_name}" = {
+      description = lookup({
+        "Node Pool"       = "OKE-managed Node Pool"
+        "Instances"       = "Self-managed Instances"
+        "Instance Pool"   = "Self-managed Instance Pool"
+        "Cluster Network" = "Self-managed Cluster Network"
+      }, var.worker_pool_mode, "")
+    }
+  }
+
+  freeform_tags = {
+    workers = lookup(var.worker_tags, "freeformTags", {})
+  }
+
+  defined_tags = {
+    workers = lookup(var.worker_tags, "definedTags", {})
+  }
+}

--- a/examples/oke-workers/output.tf
+++ b/examples/oke-workers/output.tf
@@ -1,0 +1,34 @@
+# Copyright (c) 2023 Oracle Corporation and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl
+
+# Terraform
+output "state_id" { value = module.oke.state_id }
+
+# Network
+output "worker_subnet_id" { value = var.worker_subnet_id }
+output "worker_nsg_id" { value = var.worker_nsg_id }
+
+# Identity
+output "dynamic_group_ids" { value = module.oke.dynamic_group_ids }
+output "policy_statements" { value = module.oke.policy_statements }
+output "create_iam_autoscaler_policy" { value = var.create_iam_autoscaler_policy }
+output "create_iam_worker_policy" { value = var.create_iam_worker_policy }
+
+# Cluster
+output "cluster_id" { value = var.cluster_id }
+output "apiserver_private_host" { value = module.oke.apiserver_private_host }
+
+# Workers
+output "worker_pool_name" { value = var.worker_pool_name }
+output "worker_pool_mode" { value = var.worker_pool_mode }
+output "worker_shape" { value = var.worker_shape }
+output "worker_pool_size" { value = var.worker_pool_size }
+output "worker_image_id" { value = local.worker_image_id }
+output "autoscale" { value = var.autoscale }
+
+output "worker_pool_ids" {
+  value = concat(
+    values(module.oke.worker_pool_ids),
+    values(module.oke.worker_instance_ids),
+  )
+}

--- a/examples/oke-workers/output.tf
+++ b/examples/oke-workers/output.tf
@@ -28,7 +28,7 @@ output "autoscale" { value = var.autoscale }
 
 output "worker_pool_ids" {
   value = concat(
-    values(module.oke.worker_pool_ids),
-    values(module.oke.worker_instance_ids),
+    values(coalesce(module.oke.worker_pool_ids, {})),
+    values(coalesce(module.oke.worker_instance_ids, {})),
   )
 }

--- a/examples/oke-workers/schema.yaml
+++ b/examples/oke-workers/schema.yaml
@@ -1,0 +1,519 @@
+# Copyright (c) 2023 Oracle Corporation and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl
+
+title: "OKE: Worker Pool"
+description: Kubernetes worker nodes for an OKE cluster
+schemaVersion: 1.1.0
+version: "20230304"
+locale: "en"
+
+variableGroups:
+  - title: "Hidden"
+    visible: false
+    variables:
+      - api_fingerprint
+      - config_file_profile
+      - current_user_ocid
+      - user_id
+      - tenancy_id
+      - tenancy_ocid
+      - region
+      - kubernetes_version
+      - apiserver_private_host
+      - cluster_ca_cert
+
+  - title: "Identity"
+    variables:
+      - compartment_ocid
+      - create_iam_autoscaler_policy
+      - create_iam_worker_policy
+      - use_defined_tags
+      - tag_namespace
+
+  - title: "Cluster"
+    variables:
+      - cluster_id
+      - cni_type
+      - kubeproxy_mode
+      - worker_node_labels
+
+  - title: "Network"
+    variables:
+      - vcn_id
+      - assign_dns
+      - vcn_dns_label
+      - worker_subnet_id
+      - worker_nsg_id
+      - pod_subnet_id
+      - pod_nsg_id
+      - fss_subnet_id
+      - fss_nsg_id
+
+  - title: "SSH"
+    variables:
+      - ssh_public_key
+
+  - title: "Image"
+    variables:
+      - worker_image_type
+      - worker_image_os
+      - worker_image_os_version
+      - worker_image_platform_id
+      - worker_image_custom_id
+
+  - title: "Instances"
+    variables:
+      - worker_pool_name
+      - worker_pool_mode
+      - worker_shape
+      - worker_pool_size
+      - worker_ocpus
+      - worker_memory
+      - worker_boot_volume_size
+      - worker_block_volume_type
+      - worker_use_encryption
+      - worker_volume_kms_vault_id
+      - worker_volume_kms_key_id
+      - worker_pv_transit_encryption
+      - worker_cloud_init_configure
+      - worker_cloud_init
+      - worker_cloud_init_byon
+      - worker_cloud_init_oke
+      - autoscale
+      - drain
+      - worker_tags
+
+variables:
+  # Identity
+  current_user_ocid:
+    title: User
+    type: ocid
+    required: true
+  tenancy_ocid:
+    title: Tenancy
+    type: oci:identity:compartment:id
+    required: true
+  compartment_ocid:
+    title: Compartment
+    description: The default compartment for created resources.
+    type: oci:identity:compartment:id
+    required: true
+  region:
+    required: true
+    title: Region
+    type: oci:identity:region:name
+  create_iam_autoscaler_policy:
+    title: Authorize instance(s) to manage pools with Cluster Autoscaler
+    description: |
+      Create the required Identity policy with a dynamic group to authorize pool management by worker nodes for Cluster Autoscaler. See <a href=https://docs.oracle.com/en-us/iaas/Content/ContEng/Tasks/contengusingclusterautoscaler.htm>Using the Kubernetes Cluster Autoscaler</a> for more information.
+    type: boolean
+    default: false
+    required: true
+    visible: { not: [autoscale] }
+  create_iam_worker_policy:
+    title: Authorize instance(s) to join the target cluster
+    description: |
+      Create the required Identity policy with a dynamic group to authorize self-managed worker node membership for an OKE cluster, e.g. `Allow dynamic-group ... to {CLUSTER_JOIN} in compartment id ... where { target.cluster.id = '...' }`. See <a href=https://docs.oracle.com/en-us/iaas/Content/Identity/policyreference/contengpolicyreference.htm#Details_for_Container_Engine_for_Kubernetes>Container Engine for Kubernetes Self-managed nodes</a> for more information.
+    type: boolean
+    default: false
+    required: true
+    visible:
+      not:
+        - eq:
+            - worker_pool_mode
+            - Node Pool
+  use_defined_tags:
+    title: Use defined tags
+    default: false
+    type: boolean
+  tag_namespace:
+    title: Tag namespace
+    visible: ${use_defined_tags}
+
+  # VCN
+  vcn_id:
+    title: Virtual Cloud Network
+    type: oci:core:vcn:id
+    required: true
+    dependsOn:
+      compartmentId: ${compartment_ocid}
+  assign_dns:
+    title: Assign DNS records
+    type: boolean
+    default: false
+    required: true
+  worker_subnet_id:
+    title: Worker subnet
+    description: VCN subnet for the primary network interface of created worker node(s).
+    type: oci:core:subnet:id
+    required: true
+    dependsOn:
+      compartmentId: ${compartment_ocid}
+      vcnId: ${vcn_id}
+      hidePublicSubnet: false
+      hidePrivateSubnet: false
+      hideRegionalSubnet: false
+      hideAdSubnet: false
+  worker_nsg_id:
+    title: Worker Network Security Group
+    description: Network Security Groups for the created worker node(s), used to configure network access to instances. See <a href=https://docs.oracle.com/en-us/iaas/Content/ContEng/Concepts/contengnetworkconfig.htm#securitylistconfig>Security Rule Configuration in ... Network Security Groups</a> for more information.
+    type: oci:core:nsg:id
+    # additionalProps:
+    #   allowMultiple: true
+    required: true
+    dependsOn:
+      compartmentId: ${compartment_ocid}
+      vcnId: ${vcn_id}
+  pod_subnet_id:
+    title: Pod subnet
+    description: VCN subnet for the primary network interface of created worker node(s).
+    type: oci:core:subnet:id
+    dependsOn:
+      compartmentId: ${compartment_ocid}
+      vcnId: ${vcn_id}
+      hidePublicSubnet: false
+      hidePrivateSubnet: false
+      hideRegionalSubnet: false
+      hideAdSubnet: false
+  pod_nsg_id:
+    title: Pod Network Security Group
+    description: Network Security Groups for the created worker node(s), used to configure network access to instances. See <a href=https://docs.oracle.com/en-us/iaas/Content/ContEng/Concepts/contengnetworkconfig.htm#securitylistconfig>Security Rule Configuration in ... Network Security Groups</a> for more information.
+    type: oci:core:nsg:id
+    # additionalProps:
+    #   allowMultiple: true
+    dependsOn:
+      compartmentId: ${compartment_ocid}
+      vcnId: ${vcn_id}
+  fss_subnet_id:
+    title: FSS subnet
+    type: oci:core:subnet:id
+    dependsOn:
+      compartmentId: ${compartment_ocid}
+      vcnId: ${vcn_id}
+      hidePublicSubnet: false
+      hidePrivateSubnet: false
+      hideRegionalSubnet: false
+      hideAdSubnet: false
+  fss_nsg_id:
+    title: FSS Network Security Group
+    type: oci:core:nsg:id
+    # additionalProps:
+    #   allowMultiple: true
+    dependsOn:
+      compartmentId: ${compartment_ocid}
+      vcnId: ${vcn_id}
+    visible:
+      and:
+        - ${create_fss}
+        - not: [create_vcn]
+
+  # SSH
+  ssh_public_key:
+    title: SSH Public Key
+    type: oci:core:ssh:publickey
+    pattern: "((^(ssh-rsa AAAAB3NzaC1yc2|ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNT|ecdsa-sha2-nistp384 AAAAE2VjZHNhLXNoYTItbmlzdHAzODQAAAAIbmlzdHAzOD|ecdsa-sha2-nistp521 AAAAE2VjZHNhLXNoYTItbmlzdHA1MjEAAAAIbmlzdHA1Mj|ssh-ed25519 AAAAC3NzaC1lZDI1NTE5|ssh-dss AAAAB3NzaC1kc3)[0-9A-Za-z+\/]+[=]{0,3})( [^,]*)?)(,((ssh-rsa AAAAB3NzaC1yc2|ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNT|ecdsa-sha2-nistp384 AAAAE2VjZHNhLXNoYTItbmlzdHAzODQAAAAIbmlzdHAzOD|ecdsa-sha2-nistp521 AAAAE2VjZHNhLXNoYTItbmlzdHA1MjEAAAAIbmlzdHA1Mj|ssh-ed25519 AAAAC3NzaC1lZDI1NTE5|ssh-dss AAAAB3NzaC1kc3)[0-9A-Za-z+\/]+[=]{0,3})( [^,]*)?)*$"
+    required: false
+
+  # Cluster
+  cluster_id:
+    title: Cluster
+    type: oci:container:cluster:id
+    required: true
+    dependsOn:
+      compartmentId: ${compartment_ocid}
+  cni_type:
+    title: CNI Type
+    description: The CNI type ('Flannel' or 'NPN') of the target OKE cluster.
+    type: enum
+    default: Flannel
+    enum: [Flannel, NPN]
+    allowMultiple: false
+    required: true
+    visible:
+      eq: [worker_pool_mode, Node Pool]
+  apiserver_private_host:
+    title: Cluster private endpoint
+    description: |
+      Private OKE endpoint IP address only - no protocol/port. Retrieve from an existing kubeconfig with: `kubectl config view --raw -o json | jq -rcM '.clusters[0].cluster.server' | cut -d: -f2 | tr -d '/'`
+    type: string
+    required: false
+  cluster_ca_cert:
+    title: Cluster CA certificate
+    description: |
+      Base64+PEM-encoded cluster CA certificate for a trusted connection to the OKE managed control plane. Retrieve from an existing kubeconfig with: `kubectl config view --raw -o json | jq -rcM '.clusters[0].cluster["certificate-authority-data"]'
+    type: text
+    multiline: true
+
+  # Worker
+  worker_pool_name:
+    title: Pool name
+    description: Display name for created worker node resources.
+    type: string
+    default: "oke-worker"
+    required: true
+  worker_pool_mode:
+    title: Resource type
+    description: Type of Oracle Cloud Compute resources for the created worker nodes.
+    type: enum
+    default: Instance Pool
+    enum: [Node Pool, Instances, Instance Pool, Cluster Network]
+    required: true
+  worker_pool_size:
+    title: Number of worker nodes
+    type: number
+    default: 1
+    required: true
+  worker_shape:
+    title: Shape
+    # type: oci:core:instanceshapewithflex:name
+    type: oci:core:instanceshape:name
+    default: "VM.Standard.E4.Flex"
+    required: true
+    dependsOn:
+      compartmentId: ${compartment_ocid}
+  worker_ocpus:
+    title: OCPUs
+    type: number
+    default: 2
+    required: false
+  worker_memory:
+    title: Memory (GB)
+    type: number
+    default: 16
+    required: false
+  worker_boot_volume_size:
+    title: Boot volume size (GB)
+    type: number
+    required: false
+  worker_image_type:
+    title: Image type
+    description: Whether to use a Platform, OKE, or Custom image for worker nodes.
+    type: enum
+    default: OKE
+    enum: [OKE, Platform, Custom]
+    required: true
+  worker_image_os:
+    title: Operating system
+    type: enum
+    default: "Oracle Linux"
+    enum: ["Oracle Linux"]
+    required: true
+    visible:
+      not:
+        - eq:
+            - worker_image_type
+            - Custom
+  worker_image_os_version:
+    title: Operating system version
+    type: enum
+    default: "8"
+    enum: ["7.9", "8"]
+    required: true
+    visible:
+      not:
+        - eq:
+            - worker_image_type
+            - Custom
+  worker_image_id:
+    visible: false
+  worker_image_custom_id:
+    title: Image ID
+    type: ocid
+    default: ocid1.image.oc1.ap-osaka-1.aaaaaaaaea5wfsravwlatdyq7x72nb7ci7xmc4aer3ncdfjkumup2fhvkrgq
+    required: true
+    visible:
+      eq:
+        - worker_image_type
+        - Custom
+  worker_image_platform_id:
+    title: Image
+    type: oci:core:image:id
+    required: true
+    dependsOn:
+      compartmentId: ${compartment_ocid}
+      operatingSystem: ${worker_image_os}
+      operatingSystemVersion: ${worker_image_os_version}
+      shape: ${worker_shape_name}
+    visible:
+      eq:
+        - worker_image_type
+        - Platform
+  worker_cloud_init:
+    visible: false
+  worker_cloud_init_configure:
+    type: boolean
+    title: Custom cloud-init
+  worker_cloud_init_byon:
+    title: Cloud-init script
+    type: text
+    multiline: true
+    required: true
+    description: |
+      Custom cloud-init script for worker node startup configuration. Must include the default OKE initialization call to join the cluster and begin operation.
+    visible:
+      and:
+        - worker_cloud_init_configure
+        - not:
+            - eq:
+                - worker_pool_mode
+                - Node Pool
+  worker_cloud_init_oke:
+    title: Cloud-init script
+    type: text
+    multiline: true
+    required: true
+    description: |
+      Custom cloud-init script for self-managed worker node startup configuration. Must uncomment and define the two required parameters and include the default OKE initialization call to join the cluster and begin operation.
+    visible:
+      and:
+        - worker_cloud_init_configure
+        - eq:
+            - worker_pool_mode
+            - Node Pool
+  worker_block_volume_type:
+    title: Block volume type
+    type: enum
+    enum: [Paravirtualized, iSCSI]
+    default: Paravirtualized
+    required: true
+  worker_node_labels:
+    title: Node labels
+    type: map
+    required: false
+  worker_use_encryption:
+    title: KMS volume encryption
+    type: boolean
+    default: false
+    required: true
+  worker_volume_kms_vault_id:
+    title: KMS volume encryption vault
+    description: Vault containing operator volume encryption keys.
+    type: oci:kms:vault:id
+    required: false
+    dependsOn:
+      compartmentId: ${compartment_ocid}
+    visible: worker_use_encryption
+  worker_volume_kms_key_id:
+    title: KMS volume encryption key
+    type: oci:kms:key:id
+    dependsOn:
+      compartmentId: ${compartment_ocid}
+      vaultId: ${worker_volume_kms_vault_id}
+    required: false
+    visible: worker_use_encryption
+  worker_pv_transit_encryption:
+    title: In-transit volume encryption
+    type: boolean
+    default: false
+    visible:
+      eq:
+        - worker_block_volume_type
+        - Paravirtualized
+  kubeproxy_mode:
+    title: Kubeproxy mode
+    type: enum
+    enum: [IPTables, IPVS]
+    default: IPTables
+    required: true
+  worker_tags:
+    title: Tagging
+    type: oci:identity:tag:value
+    required: false
+    description: Tag values for created resources.
+    dependsOn:
+      compartmentId: ${compartment_ocid}
+  autoscale:
+    title: Manage with Cluster Autoscaler
+    description: |
+      Include pool in Dynamic Group for policies required by the Cluster Autoscaler. See <a href=https://docs.oracle.com/en-us/iaas/Content/ContEng/Tasks/contengusingclusterautoscaler.htm>Using the Kubernetes Cluster Autoscaler</a> for more information.
+    type: boolean
+    default: false
+    required: true
+    visible:
+      and:
+        - eq: [worker_pool_mode, Node Pool]
+        - not: [create_iam_autoscaler_policy]
+
+  drain:
+    title: Cordon & Drain
+    description: |
+      Move non-Daemonset workloads off of the pool. See also: <a href=https://kubernetes.io/docs/tasks/administer-cluster/safely-drain-node/>Safely Drain a Node</a>, <a href=https://kubernetes.io/docs/tasks/run-application/configure-pdb/#protecting-an-application-with-a-poddisruptionbudget>Protecting an Application with a PodDisruptionBudget</a>.
+    type: boolean
+    default: false
+    required: true
+
+outputGroups:
+  - title: Identity
+    outputs:
+      - state_id
+      - create_iam_autoscaler_policy
+      - create_iam_worker_policy
+      - dynamic_group_ids
+      - policy_statements
+  - title: Network
+    outputs:
+      - worker_subnet_id
+      - worker_nsg_id
+  - title: Cluster
+    outputs:
+      - cluster_id
+      - apiserver_private_host
+  - title: Workers
+    outputs:
+      - worker_pool_name
+      - worker_pool_ids
+      - worker_pool_mode
+      - worker_pool_size
+      - worker_shape
+      - worker_image_id
+      - autoscale
+
+outputs:
+  state_id:
+    title: Terraform state ID
+    type: copyableString
+  worker_pool_mode:
+    title: Resource type
+    type: string
+  worker_pool_name:
+    title: Pool name
+    type: string
+  worker_pool_size:
+    title: Size
+    type: number
+  cluster_id:
+    title: Cluster
+    type: ocid
+  apiserver_private_host:
+    title: Cluster private endpoint IP
+    type: copyableString
+  dynamic_group_ids:
+    title: Dynamic groups
+    type: list
+  policy_statements:
+    title: Policy statements
+    type: list
+  worker_subnet_id:
+    title: Subnet
+    type: ocid
+  worker_nsg_id:
+    title: Network Security Group
+    type: ocid
+  worker_pool_ids:
+    title: Pool
+    type: list
+  worker_image_id:
+    title: Image
+    type: ocid
+  worker_shape:
+    title: Shape
+    type: string
+  create_iam_autoscaler_policy:
+    title: Create Cluster Autoscaler policy
+    type: boolean
+  create_iam_worker_policy:
+    title: Create self-managed worker policy
+    type: string
+  autoscale:
+    title: Manage with Cluster Autoscaler
+    type: string

--- a/examples/oke-workers/variables.tf
+++ b/examples/oke-workers/variables.tf
@@ -1,0 +1,148 @@
+# Copyright (c) 2023 Oracle Corporation and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl
+
+locals {
+  ssh_public_key = try(base64decode(var.ssh_public_key), var.ssh_public_key)
+}
+
+# Identity
+
+# Automatically populated by Resource Manager
+variable "tenancy_ocid" { type = string }
+variable "current_user_ocid" { type = string }
+variable "compartment_ocid" { type = string }
+variable "region" { type = string }
+variable "use_defined_tags" {
+  default     = false
+  description = "Add existing tags in the configured namespace to created resources when applicable."
+  type        = bool
+}
+
+variable "tag_namespace" {
+  default     = "oke"
+  description = "Tag namespace containing standard tags for resources created by the module: [state_id, role, pool, cluster_autoscaler]."
+  type        = string
+}
+
+variable "create_iam_autoscaler_policy" { default = false }
+variable "create_iam_worker_policy" { default = false }
+variable "autoscale" { default = false }
+
+# SSH
+
+variable "ssh_public_key" {
+  default = null
+  type    = string
+}
+
+# Cluster
+
+variable "cluster_id" {
+  default = null
+  type    = string
+}
+variable "cni_type" { default = "Flannel" }
+variable "kubernetes_version" {
+  default = "v1.25.4"
+  type    = string
+}
+
+# Worker pools
+variable "worker_pool_mode" {
+  default = "Instances"
+  type    = string
+  validation {
+    condition     = contains(["Node Pool", "Instances", "Instance Pool", "Cluster Network"], var.worker_pool_mode)
+    error_message = "Accepted values are Node Pool, Instances, Instance Pool, or Cluster Network"
+  }
+}
+variable "worker_pool_size" {
+  default = 1
+  type    = number
+}
+
+# Workers: network
+
+variable "vcn_id" {
+  default = null
+  type    = string
+}
+variable "assign_dns" { default = true }
+variable "fss_nsg_id" { default = "" }
+variable "fss_subnet_id" { default = "" }
+variable "pod_nsg_id" { default = "" }
+variable "pod_subnet_id" { default = "" }
+variable "worker_nsg_id" { default = "" }
+variable "worker_subnet_id" { type = string }
+variable "kubeproxy_mode" { type = string }
+
+# Workers: instance
+
+variable "worker_block_volume_type" { type = string }
+variable "worker_node_labels" {
+  default = {}
+  type    = map(string)
+}
+variable "worker_image_type" { type = string }
+variable "worker_image_id" {
+  default = null
+  type    = string
+}
+variable "worker_image_os" {
+  default = "Oracle Linux"
+  type    = string
+}
+variable "worker_image_os_version" {
+  default = "8"
+  type    = string
+}
+
+variable "worker_pool_name" { type = string }
+
+variable "worker_shape" { default = "VM.Standard.E4.Flex" }
+variable "worker_ocpus" { default = 2 }
+variable "worker_memory" { default = 16 }
+variable "worker_boot_volume_size" { default = 50 }
+variable "worker_pv_transit_encryption" { default = false }
+
+variable "worker_cloud_init_configure" { type = bool }
+variable "worker_cloud_init_oke" {
+  default = <<-EOT
+  #!/usr/bin/env bash
+  curl --fail -H "Authorization: Bearer Oracle" -L0 http://169.254.169.254/opc/v2/instance/metadata/oke_init_script | base64 --decode >/var/run/oke-init.sh
+  bash /etc/oke/oke-install.sh
+  EOT
+  type    = string
+}
+variable "worker_cloud_init_byon" {
+  default = <<-EOT
+  #!/usr/bin/env bash
+  #apiserver_host="10.0.0.1"
+  #ca_base64="LS0tLS1...LS0tCg==" # kubectl config view --raw -o json | jq -rcM '.clusters[0].cluster["certificate-authority-data"]'
+  bash /etc/oke/oke-install.sh --apiserver-endpoint "$\{apiserver_host}" --kubelet-ca-cert "$\{ca_base64}"
+  EOT
+  type    = string
+}
+
+variable "worker_volume_kms_key_id" {
+  default = null
+  type    = string
+}
+variable "worker_volume_kms_vault_id" {
+  default = null
+  type    = string
+}
+
+variable "worker_image_platform_id" {
+  default = null
+  type    = string
+}
+variable "worker_image_custom_id" {
+  default = null
+  type    = string
+}
+
+variable "worker_tags" {
+  default = {}
+  type    = map(any)
+}

--- a/examples/vars-workers-advanced.auto.tfvars
+++ b/examples/vars-workers-advanced.auto.tfvars
@@ -1,0 +1,58 @@
+# Copyright (c) 2017, 2023 Oracle Corporation and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl
+
+worker_image_id   = "ocid1.image..."
+worker_image_type = "custom"
+worker_shape      = { shape = "VM.Standard.E4.Flex", ocpus = 2, memory = 16, boot_volume_size = 50 }
+worker_cloud_init = [
+  {
+    content      = <<-EOT
+    runcmd:
+    - echo "Global cloud_init using cloud-config"
+    EOT
+    content_type = "text/cloud-config",
+  },
+]
+
+worker_pools = {
+  np1 = { mode = "node-pool", size = 1, shape = "VM.Standard.E4.Flex", create = false },
+  wg1 = {
+    description = "Self-managed Cluster Network", create = false,
+    mode        = "cluster-network", size = 1, shape = "BM.GPU.B4.8", placement_ads = [1],
+    cloud_init = [
+      {
+        content = <<-EOT
+        #!/usr/bin/env bash
+        echo "Pool-specific cloud_init using shell script"
+        EOT
+      },
+    ],
+    secondary_vnics = {
+      "vnic-display-name" = { nic_index = 1, subnet_id = "ocid1.subnet..." },
+    },
+  },
+  wg_np-vm-ol7 = {
+    description = "OKE-managed Node Pool with OKE Oracle Linux 7 image", create = false,
+    mode        = "node-pool", size = 1, size_max = 2, os = "Oracle Linux", os_version = "7", autoscale = true,
+  },
+  wg_np-vm-ol8 = {
+    description = "OKE-managed Node Pool with OKE Oracle Linux 8 image", create = false,
+    mode        = "node-pool", size = 1, size_max = 3, os = "Oracle Linux", os_version = "8", autoscale = true,
+  },
+  wg_np-vm-custom = {
+    description = "OKE-managed Node Pool with custom image", create = true,
+    mode        = "node-pool", image_type = "custom", size = 1, allow_autoscaler = true,
+  },
+  wg_ip-vm-custom = {
+    description = "Self-managed Instance Pool with custom image", create = false,
+    mode        = "instance-pool", image_type = "custom", size = 1, allow_autoscaler = true,
+    node_labels = { "keya" : "valuea", "keyb" : "valueb" },
+    secondary_vnics = {
+      "vnic-display-name" = {},
+    },
+  },
+  wg_cn-bm-rdma = {
+    description = "Self-managed Cluster Network", create = false,
+    mode        = "cluster-network", image_type = "custom", size = 1, shape = "BM.GPU.B4.8", placement_ads = [1],
+  },
+}

--- a/examples/vars-workers-autoscaling.auto.tfvars
+++ b/examples/vars-workers-autoscaling.auto.tfvars
@@ -1,0 +1,15 @@
+# Copyright (c) 2017, 2023 Oracle Corporation and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl
+
+# Example worker pool configurations with cluster autoscaler
+
+worker_pools = {
+  np-autoscaled = {
+    description = "Node pool managed by cluster autoscaler",
+    size        = 1, size_max = 2, autoscale = true,
+  },
+  np-autoscaler = {
+    description = "Node pool with cluster autoscaler scheduling allowed",
+    size        = 1, allow_autoscaler = true,
+  },
+}

--- a/examples/vars-workers-basic.auto.tfvars
+++ b/examples/vars-workers-basic.auto.tfvars
@@ -1,0 +1,19 @@
+# Copyright (c) 2017, 2023 Oracle Corporation and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl
+
+# Example worker pool configurations
+
+worker_pools = {
+  np-vm-ol7 = {
+    description = "OKE-managed Node Pool with OKE Oracle Linux 7 image",
+    mode        = "node-pool", size = 1, size_max = 2, os = "Oracle Linux", os_version = "7", autoscale = true,
+  },
+  np-vm-ol8 = {
+    description = "OKE-managed Node Pool with OKE Oracle Linux 8 image",
+    mode        = "node-pool", size = 1, size_max = 3, os = "Oracle Linux", os_version = "8", autoscale = true,
+  },
+  np-vm-custom = {
+    description = "OKE-managed Node Pool with custom image",
+    mode        = "node-pool", image_type = "custom", size = 1, allow_autoscaler = true,
+  },
+}

--- a/examples/vars-workers-drained.auto.tfvars
+++ b/examples/vars-workers-drained.auto.tfvars
@@ -1,0 +1,18 @@
+# Copyright (c) 2017, 2023 Oracle Corporation and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl
+
+# Example worker pool configurations with cordoned/drained workloads
+
+worker_pools = {
+  np-active = {
+    description = "Node pool with active workers",
+  },
+  np-draining = {
+    description = "Node pool with scheduling disabled and draining",
+    drain       = true,
+  },
+  np-disabled = {
+    description = "Node pool with resource creation disabled (destroyed)",
+    create      = false,
+  },
+}

--- a/module-operator.tf
+++ b/module-operator.tf
@@ -57,7 +57,7 @@ module "operator" {
   shape                 = var.operator_shape
   ssh_private_key       = sensitive(local.ssh_private_key) # to await cloud-init completion
   ssh_public_key        = local.ssh_public_key
-  subnet_id             = lookup(module.network.subnet_ids, "operator", lookup(module.network.subnet_ids, "workers"))
+  subnet_id             = lookup(module.network.subnet_ids, "operator", "")
   timezone              = var.timezone
   upgrade               = var.operator_upgrade
   user                  = var.operator_user

--- a/module-workers.tf
+++ b/module-workers.tf
@@ -64,13 +64,13 @@ module "workers" {
   timezone              = var.timezone
   volume_kms_key_id     = var.worker_volume_kms_key_id
   worker_nsg_ids        = concat(var.worker_nsg_ids, [module.network.worker_nsg_id])
-  worker_subnet_id      = lookup(module.network.subnet_ids, "workers")
+  worker_subnet_id      = lookup(module.network.subnet_ids, "workers", "")
   preemptible_config    = var.worker_preemptible_config
 
   # FSS
   create_fss              = var.create_fss
   fss_availability_domain = coalesce(var.fss_availability_domain, local.ad_numbers_to_names[1])
-  fss_subnet_id           = lookup(module.network.subnet_ids, "fss", lookup(module.network.subnet_ids, "workers"))
+  fss_subnet_id           = lookup(module.network.subnet_ids, "fss", "")
   fss_nsg_ids             = var.fss_nsg_ids
   fss_mount_path          = var.fss_mount_path
   fss_max_fs_stat_bytes   = var.fss_max_fs_stat_bytes

--- a/modules/bastion/compute.tf
+++ b/modules/bastion/compute.tf
@@ -73,7 +73,7 @@ resource "oci_core_instance" "bastion" {
   }
 
   lifecycle {
-    ignore_changes = [availability_domain, defined_tags, freeform_tags, metadata, source_details]
+    ignore_changes = [availability_domain, defined_tags, freeform_tags, metadata, source_details, display_name]
 
     precondition {
       condition     = coalesce(var.image_id, "none") != "none"

--- a/modules/cluster/cluster.tf
+++ b/modules/cluster/cluster.tf
@@ -32,6 +32,7 @@ resource "oci_containerengine_cluster" "k8s_cluster" {
   kms_key_id         = coalesce(var.cluster_kms_key_id, "none") != "none" ? var.cluster_kms_key_id : null
   kubernetes_version = var.kubernetes_version
   name               = var.cluster_name
+  type               = var.cluster_type
   vcn_id             = var.vcn_id
 
   cluster_pod_network_options {

--- a/modules/cluster/cluster.tf
+++ b/modules/cluster/cluster.tf
@@ -81,6 +81,10 @@ resource "oci_containerengine_cluster" "k8s_cluster" {
     service_lb_subnet_ids = compact([var.service_lb_subnet_id])
   }
 
+  timeouts {
+    update = "120m"
+  }
+
   lifecycle {
     ignore_changes = [defined_tags, freeform_tags, cluster_pod_network_options]
 

--- a/modules/iam/group-workers.tf
+++ b/modules/iam/group-workers.tf
@@ -13,7 +13,6 @@ locals {
   ])) : local.worker_compartment_rule
 
   cluster_join_where_clause = format("ALL {%s}", join(", ", compact([
-    "target.resource.kind = 'cluster'",
     var.create_iam_worker_policy ? "target.cluster.id = '${var.cluster_id}'" : null,
   ])))
 

--- a/modules/iam/tagging.tf
+++ b/modules/iam/tagging.tf
@@ -14,7 +14,7 @@ data "oci_identity_tag_namespaces" "oke" {
 }
 
 data "oci_identity_tags" "oke" {
-  count            = var.create_iam_resources ? 1 : 0
+  count            = var.create_iam_resources && local.tag_namespace_id_found != null ? 1 : 0
   provider         = oci.home
   tag_namespace_id = local.tag_namespace_id_found
   state            = "ACTIVE" // TODO Support reactivation of retired tag w/ update

--- a/modules/network/nsg-bastion.tf
+++ b/modules/network/nsg-bastion.tf
@@ -37,7 +37,7 @@ resource "oci_core_network_security_group" "bastion" {
   defined_tags   = local.defined_tags
   freeform_tags  = local.freeform_tags
   lifecycle {
-    ignore_changes = [defined_tags, freeform_tags]
+    ignore_changes = [defined_tags, freeform_tags, display_name]
   }
 }
 

--- a/modules/network/nsg-controlplane.tf
+++ b/modules/network/nsg-controlplane.tf
@@ -73,7 +73,7 @@ resource "oci_core_network_security_group" "cp" {
   defined_tags   = local.defined_tags
   freeform_tags  = local.freeform_tags
   lifecycle {
-    ignore_changes = [defined_tags, freeform_tags]
+    ignore_changes = [defined_tags, freeform_tags, display_name]
   }
 }
 

--- a/modules/network/nsg-fss.tf
+++ b/modules/network/nsg-fss.tf
@@ -41,7 +41,7 @@ resource "oci_core_network_security_group" "fss" {
   defined_tags   = local.defined_tags
   freeform_tags  = local.freeform_tags
   lifecycle {
-    ignore_changes = [defined_tags, freeform_tags]
+    ignore_changes = [defined_tags, freeform_tags, display_name]
   }
 }
 

--- a/modules/network/nsg-loadbalancers-int.tf
+++ b/modules/network/nsg-loadbalancers-int.tf
@@ -32,7 +32,7 @@ resource "oci_core_network_security_group" "int_lb" {
   defined_tags   = local.defined_tags
   freeform_tags  = local.freeform_tags
   lifecycle {
-    ignore_changes = [defined_tags, freeform_tags]
+    ignore_changes = [defined_tags, freeform_tags, display_name]
   }
 }
 

--- a/modules/network/nsg-loadbalancers-pub.tf
+++ b/modules/network/nsg-loadbalancers-pub.tf
@@ -32,7 +32,7 @@ resource "oci_core_network_security_group" "pub_lb" {
   defined_tags   = local.defined_tags
   freeform_tags  = local.freeform_tags
   lifecycle {
-    ignore_changes = [defined_tags, freeform_tags]
+    ignore_changes = [defined_tags, freeform_tags, display_name]
   }
 }
 

--- a/modules/network/nsg-operator.tf
+++ b/modules/network/nsg-operator.tf
@@ -36,7 +36,7 @@ resource "oci_core_network_security_group" "operator" {
   defined_tags   = local.defined_tags
   freeform_tags  = local.freeform_tags
   lifecycle {
-    ignore_changes = [defined_tags, freeform_tags]
+    ignore_changes = [defined_tags, freeform_tags, display_name]
   }
 }
 

--- a/modules/network/nsg-pods.tf
+++ b/modules/network/nsg-pods.tf
@@ -54,7 +54,7 @@ resource "oci_core_network_security_group" "pods" {
   defined_tags   = local.defined_tags
   freeform_tags  = local.freeform_tags
   lifecycle {
-    ignore_changes = [defined_tags, freeform_tags]
+    ignore_changes = [defined_tags, freeform_tags, display_name]
   }
 }
 

--- a/modules/network/nsg-workers.tf
+++ b/modules/network/nsg-workers.tf
@@ -113,7 +113,7 @@ resource "oci_core_network_security_group" "workers" {
   defined_tags   = local.defined_tags
   freeform_tags  = local.freeform_tags
   lifecycle {
-    ignore_changes = [defined_tags, freeform_tags]
+    ignore_changes = [defined_tags, freeform_tags, display_name]
   }
 }
 

--- a/modules/network/subnets.tf
+++ b/modules/network/subnets.tf
@@ -15,7 +15,6 @@ locals {
             : (lookup(v, "id", null) != null ? "id"
       : "invalid"))))
     })
-    if lookup(v, "id", null) == null && lookup(v, "create", "auto") != "never" && tobool(lookup(lookup(local.subnet_info, k, {}), "create", true))
   }
 
   # Handle subnets configured with provided CIDRs
@@ -93,7 +92,7 @@ resource "oci_core_subnet" "oke" {
   for_each = { for k, v in local.subnet_info : k => v
     if(tobool(lookup(v, "create", true)) || lookup(lookup(var.subnets, k, {}), "create", "auto") == "always")
     && contains(keys(local.subnet_cidrs_all), k)
-    && lookup(var.subnets, "create", "auto") != "never"
+    && lookup(lookup(var.subnets, k, {}), "create", "auto") != "never"
   }
 
   compartment_id             = var.compartment_id

--- a/modules/network/subnets.tf
+++ b/modules/network/subnets.tf
@@ -108,7 +108,7 @@ resource "oci_core_subnet" "oke" {
 
   lifecycle {
     # TODO reflect default security_list_id instead of ignore
-    ignore_changes = [security_list_ids, freeform_tags, defined_tags, dns_label]
+    ignore_changes = [security_list_ids, freeform_tags, defined_tags, dns_label, display_name, cidr_block]
   }
 }
 
@@ -129,7 +129,7 @@ resource "oci_core_security_list" "oke" {
   freeform_tags  = local.freeform_tags
 
   lifecycle {
-    ignore_changes = [freeform_tags, defined_tags]
+    ignore_changes = [freeform_tags, defined_tags, display_name]
   }
 }
 
@@ -139,5 +139,5 @@ output "subnet_ids" {
 }
 
 output "subnet_cidrs" {
-  value = local.subnet_cidrs_all
+  value = merge(local.subnet_cidrs_all, try({ for k, v in oci_core_subnet.oke : k => v.cidr_block }, {}))
 }

--- a/modules/operator/compute.tf
+++ b/modules/operator/compute.tf
@@ -84,7 +84,7 @@ resource "oci_core_instance" "operator" {
   }
 
   lifecycle {
-    ignore_changes       = [defined_tags, freeform_tags, metadata]
+    ignore_changes       = [defined_tags, freeform_tags, metadata, display_name]
     replace_triggered_by = [null_resource.operator_changed]
     precondition {
       condition     = coalesce(var.image_id, "none") != "none"

--- a/modules/workers/cloudinit-oke.sh
+++ b/modules/workers/cloudinit-oke.sh
@@ -8,11 +8,20 @@ function run_oke_init() { # Initialize OKE worker node
   if [[ -f /etc/systemd/system/oke-init.service ]]; then
     systemctl --no-block enable --now oke-init.service
   elif [[ -f /etc/oke/oke-functions.sh ]] && [[ -f /etc/oke/oke-install.sh ]]; then
-    source /etc/oke/oke-functions.sh && bash /etc/oke/oke-install.sh \
-      --apiserver-endpoint "$(get_apiserver_host)" \
-      --cluster-dns "$(get_cluster_dns)" \
-      --kubelet-ca-cert "$(get_kubelet_client_ca)" \
-      --kubelet-extra-args "$(get_kubelet_extra_args)"
+    source /etc/oke/oke-functions.sh
+    local apiserver_host; apiserver_host=$(get_apiserver_host)
+    if [[ -z "${apiserver_host}" ]]; then
+      apiserver_host=$(get_imds_metadata | jq -rcM '.apiserver_host')
+    fi
+
+    cluster_ca=$(get_kubelet_client_ca)
+    if [[ -z "${cluster_ca}" ]]; then
+      cluster_ca=$(get_imds_metadata | jq -rcM '.cluster_ca_cert' | base64 -d)
+    fi
+
+    bash /etc/oke/oke-install.sh \
+      --apiserver-endpoint "${apiserver_host}" \
+      --kubelet-ca-cert "${cluster_ca}"
   else # Retrieve base64-encoded script content from http, e.g. instance metadata
     local oke_init_url='http://169.254.169.254/opc/v2/instance/metadata/oke_init_script'
     curl --fail -H "Authorization: Bearer Oracle" -L0 "${oke_init_url}" \

--- a/modules/workers/fss.tf
+++ b/modules/workers/fss.tf
@@ -7,7 +7,7 @@ resource "oci_file_storage_file_system" "fss" {
   compartment_id      = var.compartment_id
   display_name        = "fss-${var.state_id}"
   lifecycle {
-    ignore_changes = [availability_domain, defined_tags]
+    ignore_changes = [availability_domain, defined_tags, display_name]
   }
 }
 
@@ -21,7 +21,7 @@ resource "oci_file_storage_mount_target" "fss" {
   nsg_ids             = var.fss_nsg_ids
 
   lifecycle {
-    ignore_changes = [availability_domain, defined_tags]
+    ignore_changes = [availability_domain, defined_tags, display_name]
   }
 }
 
@@ -31,6 +31,9 @@ resource "oci_file_storage_export_set" "fss" {
   display_name      = "fss-${var.state_id}"
   max_fs_stat_bytes = var.fss_max_fs_stat_bytes
   max_fs_stat_files = var.fss_max_fs_stat_files
+  lifecycle {
+    ignore_changes = [display_name]
+  }
 }
 
 resource "oci_file_storage_export" "fss" {

--- a/variables-common.tf
+++ b/variables-common.tf
@@ -16,6 +16,12 @@ locals {
   )
 }
 
+variable "state_id" {
+  default     = null
+  description = "Optional Terraform state_id from an existing deployment of the module to re-use with created resources."
+  type        = string
+}
+
 variable "output_detail" {
   default     = false
   description = "Whether to include detailed output in state."


### PR DESCRIPTION
* docs: Add Resource Manager Deploy examples
* fix: Remove unneeded subnet filter for correct creation logic
* fix: Ignore changes to display_name
* fix: Add missing cluster_type in sub-module definition
* feat: Add optional input for existing state_id
* fix: Correct self-managed policy syntax
* fix: Clean up subnets to create, consistent w/ seclists
* fix: No failure for undefined subnets when unused
* fix: Increase cluster update timeout for enhanced upgrade
* fix: Update cloud-init script
* fix: Override create map field for forced subnet
* fix: Handle null values for output
* fix: Skip tag retrieval without namespace ID