### PR TITLE
Explicitely type tag map variables in oke submodule

### DIFF
--- a/modules/oke/variables.tf
+++ b/modules/oke/variables.tf
@@ -133,9 +133,9 @@ variable "worker_nsgs" {
 }
 
 variable "freeform_tags" {
-  type = map(any)
+  type = map(map(string))
 }
 
 variable "defined_tags" {
-  type = map(any)
+  type = map(map(string))
 }


### PR DESCRIPTION
When trying to update defined_tags on a cluster, via the configuration:
```tf
  defined_tags = {
    oke = {
      cluster = {
        "NEW_KEY" = "NEW_TAG"
      }
      persistent_volume = {
        "NEW_KEY" = "NEW_TAG"
      }
      service_lb = {
        "NEW_KEY" = "NEW_TAG"
      }
      node_pool = {
        "NEW_KEY" = "NEW_TAG"
      }
      node = {
        "NEW_KEY" = "NEW_TAG"
      }
    }
  }
```

one gets these errors for the `cluster`, `persistent_volume`, `service_lb` parts:
```
╷
│ Error: Invalid function argument
│ 
│   on .terraform/modules/oke/modules/oke/cluster.tf line 72, in resource "oci_containerengine_cluster" "k8s_cluster":
│   72:       defined_tags  = lookup(var.defined_tags, "<PART>", {})
│     ├────────────────
│     │ while calling lookup(inputMap, key, default...)
│ 
│ Invalid value for "default" parameter: the default value must have the same type as the map elements.
```

this is because terraform cannot reconciliate the map string->string type of the tags submaps with the type of the empty map.

Fix this as outlined in https://github.com/hashicorp/terraform/issues/27509 by explicitely typing the submap variables.

`node_pool` and `node` do not suffer the same issue, as I assume the merge function does cleverer overload resolution, but more precision doesn't hurt.