### PR TITLE
Use lower bound version specification for oci provider

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -6,7 +6,7 @@ terraform {
     oci = {
       source                = "oracle/oci"
       configuration_aliases = [oci.home]
-      version               = "~> 4.115.0"
+      version               = ">= 4.115.0"
     }
   }
   required_version = ">= 1.2.0"


### PR DESCRIPTION
The oke module is a reusable module, hence it must not force the whole root module to un under a certain minor release of the oci provider.

Fixes: 830192e3e59c716f