### PR TITLE
feat: Add ability to override default cloud-init set by OKE in worker…

### DIFF
--- a/module-workers.tf
+++ b/module-workers.tf
@@ -42,30 +42,31 @@ module "workers" {
   worker_pools     = var.worker_pools
 
   # Workers
-  assign_dns            = var.assign_dns
-  assign_public_ip      = var.worker_is_public
-  block_volume_type     = var.worker_block_volume_type
-  cloud_init            = var.worker_cloud_init
-  cni_type              = var.cni_type
-  image_id              = var.worker_image_id
-  image_ids             = local.image_ids
-  image_os              = var.worker_image_os
-  image_os_version      = var.worker_image_os_version
-  image_type            = var.worker_image_type
-  kubeproxy_mode        = var.kubeproxy_mode
-  max_pods_per_node     = var.max_pods_per_node
-  node_labels           = var.worker_node_labels
-  node_metadata         = var.worker_node_metadata
-  pod_nsg_ids           = concat(var.pod_nsg_ids, var.cni_type == "npn" ? [module.network.pod_nsg_id] : [])
-  pod_subnet_id         = lookup(module.network.subnet_ids, "pods", "")
-  pv_transit_encryption = var.worker_pv_transit_encryption
-  shape                 = var.worker_shape
-  ssh_public_key        = local.ssh_public_key
-  timezone              = var.timezone
-  volume_kms_key_id     = var.worker_volume_kms_key_id
-  worker_nsg_ids        = concat(var.worker_nsg_ids, [module.network.worker_nsg_id])
-  worker_subnet_id      = lookup(module.network.subnet_ids, "workers", "")
-  preemptible_config    = var.worker_preemptible_config
+  assign_dns                 = var.assign_dns
+  assign_public_ip           = var.worker_is_public
+  block_volume_type          = var.worker_block_volume_type
+  cloud_init                 = var.worker_cloud_init
+  disable_default_cloud_init = var.worker_disable_default_cloud_init
+  cni_type                   = var.cni_type
+  image_id                   = var.worker_image_id
+  image_ids                  = local.image_ids
+  image_os                   = var.worker_image_os
+  image_os_version           = var.worker_image_os_version
+  image_type                 = var.worker_image_type
+  kubeproxy_mode             = var.kubeproxy_mode
+  max_pods_per_node          = var.max_pods_per_node
+  node_labels                = var.worker_node_labels
+  node_metadata              = var.worker_node_metadata
+  pod_nsg_ids                = concat(var.pod_nsg_ids, var.cni_type == "npn" ? [module.network.pod_nsg_id] : [])
+  pod_subnet_id              = lookup(module.network.subnet_ids, "pods", "")
+  pv_transit_encryption      = var.worker_pv_transit_encryption
+  shape                      = var.worker_shape
+  ssh_public_key             = local.ssh_public_key
+  timezone                   = var.timezone
+  volume_kms_key_id          = var.worker_volume_kms_key_id
+  worker_nsg_ids             = concat(var.worker_nsg_ids, [module.network.worker_nsg_id])
+  worker_subnet_id           = lookup(module.network.subnet_ids, "workers", "")
+  preemptible_config         = var.worker_preemptible_config
 
   # FSS
   create_fss              = var.create_fss

--- a/modules/workers/cloudinit.tf
+++ b/modules/workers/cloudinit.tf
@@ -7,6 +7,9 @@ locals {
 
   # https://canonical-cloud-init.readthedocs-hosted.com/en/latest/reference/merging.html
   default_cloud_init_merge_type = "list(append)+dict(no_replace,recurse_list)+str(append)"
+
+  # Placeholder to enable default cloud-init on worker pools where disable_default_cloud_init is false
+  default_cloud_init_enabled = true
 }
 
 # https://registry.terraform.io/providers/hashicorp/template/latest/docs/data-sources/cloudinit_config.html
@@ -28,60 +31,72 @@ data "cloudinit_config" "workers" {
   }
 
   # Set timezone
-  part {
-    content_type = "text/cloud-config"
-    # https://cloudinit.readthedocs.io/en/latest/reference/modules.html#timezone
-    content  = jsonencode({ timezone = var.timezone })
-    filename = "10-timezone.yml"
+  dynamic "part" {
+    for_each = each.value.disable_default_cloud_init ? [] : [local.default_cloud_init_enabled]
+    content {
+      content_type = "text/cloud-config"
+      # https://cloudinit.readthedocs.io/en/latest/reference/modules.html#timezone
+      content  = jsonencode({ timezone = var.timezone })
+      filename = "10-timezone.yml"
+    }
   }
 
   # Expand root filesystem to fill available space on volume
-  part {
-    content_type = "text/cloud-config"
-    content = jsonencode({
-      # https://cloudinit.readthedocs.io/en/latest/reference/modules.html#growpart
-      growpart = {
-        mode                     = "auto"
-        devices                  = ["/"]
-        ignore_growroot_disabled = false
-      }
+  dynamic "part" {
+    for_each = each.value.disable_default_cloud_init ? [] : [local.default_cloud_init_enabled]
+    content {
+      content_type = "text/cloud-config"
+      content = jsonencode({
+        # https://cloudinit.readthedocs.io/en/latest/reference/modules.html#growpart
+        growpart = {
+          mode                     = "auto"
+          devices                  = ["/"]
+          ignore_growroot_disabled = false
+        }
 
-      # https://cloudinit.readthedocs.io/en/latest/reference/modules.html#resizefs
-      resize_rootfs = true
+        # https://cloudinit.readthedocs.io/en/latest/reference/modules.html#resizefs
+        resize_rootfs = true
 
-      # Resize logical LVM root volume when utility is present
-      bootcmd = ["if [[ -f /usr/libexec/oci-growfs ]]; then /usr/libexec/oci-growfs -y; fi"]
-    })
-    filename   = "10-growpart.yml"
-    merge_type = local.default_cloud_init_merge_type
+        # Resize logical LVM root volume when utility is present
+        bootcmd = ["if [[ -f /usr/libexec/oci-growfs ]]; then /usr/libexec/oci-growfs -y; fi"]
+      })
+      filename   = "10-growpart.yml"
+      merge_type = local.default_cloud_init_merge_type
+    }
   }
 
   # Write extra OKE configuration to filesystem
-  part {
-    content_type = "text/cloud-config"
-    content = jsonencode({
-      write_files = [
-        {
-          content = var.apiserver_private_host
-          path    = "/etc/oke/oke-apiserver"
-        },
-        {
-          content  = var.cluster_ca_cert
-          encoding = "base64"
-          path     = "/etc/kubernetes/ca.crt"
-        },
-      ]
-    })
-    filename   = "50-oke-config.yml"
-    merge_type = local.default_cloud_init_merge_type
+  dynamic "part" {
+    for_each = each.value.disable_default_cloud_init ? [] : [local.default_cloud_init_enabled]
+    content {
+      content_type = "text/cloud-config"
+      content = jsonencode({
+        write_files = [
+          {
+            content = var.apiserver_private_host
+            path    = "/etc/oke/oke-apiserver"
+          },
+          {
+            content  = var.cluster_ca_cert
+            encoding = "base64"
+            path     = "/etc/kubernetes/ca.crt"
+          },
+        ]
+      })
+      filename   = "50-oke-config.yml"
+      merge_type = local.default_cloud_init_merge_type
+    }
   }
 
   # OKE startup initialization
-  part {
-    content_type = "text/x-shellscript"
-    content      = file("${path.module}/cloudinit-oke.sh")
-    filename     = "50-oke.sh"
-    merge_type   = local.default_cloud_init_merge_type
+  dynamic "part" {
+    for_each = each.value.disable_default_cloud_init ? [] : [local.default_cloud_init_enabled]
+    content {
+      content_type = "text/x-shellscript"
+      content      = file("${path.module}/cloudinit-oke.sh")
+      filename     = "50-oke.sh"
+      merge_type   = local.default_cloud_init_merge_type
+    }
   }
 
   lifecycle {

--- a/modules/workers/locals.tf
+++ b/modules/workers/locals.tf
@@ -9,33 +9,34 @@ locals {
   preemptible_config = { enable = false, is_preserve_boot_volume = false }
 
   worker_pool_defaults = {
-    preemptible_config    = local.preemptible_config
-    allow_autoscaler      = false
-    assign_public_ip      = var.assign_public_ip
-    autoscale             = false
-    block_volume_type     = var.block_volume_type
-    boot_volume_size      = local.boot_volume_size
-    cloud_init            = [] # empty pool-specific default
-    compartment_id        = var.compartment_id
-    create                = true
-    drain                 = false
-    image_id              = var.image_id
-    image_type            = var.image_type
-    memory                = local.memory
-    mode                  = var.worker_pool_mode
-    node_labels           = var.node_labels
-    nsg_ids               = [] # empty pool-specific default
-    ocpus                 = local.ocpus
-    os                    = var.image_os
-    os_version            = var.image_os_version
-    placement_ads         = var.ad_numbers
-    pod_nsg_ids           = var.pod_nsg_ids
-    pod_subnet_id         = coalesce(var.pod_subnet_id, var.worker_subnet_id, "none")
-    pv_transit_encryption = var.pv_transit_encryption
-    shape                 = local.shape
-    size                  = var.worker_pool_size
-    subnet_id             = var.worker_subnet_id
-    volume_kms_key_id     = var.volume_kms_key_id
+    preemptible_config         = local.preemptible_config
+    allow_autoscaler           = false
+    assign_public_ip           = var.assign_public_ip
+    autoscale                  = false
+    block_volume_type          = var.block_volume_type
+    boot_volume_size           = local.boot_volume_size
+    cloud_init                 = [] # empty pool-specific default
+    disable_default_cloud_init = false
+    compartment_id             = var.compartment_id
+    create                     = true
+    drain                      = false
+    image_id                   = var.image_id
+    image_type                 = var.image_type
+    memory                     = local.memory
+    mode                       = var.worker_pool_mode
+    node_labels                = var.node_labels
+    nsg_ids                    = [] # empty pool-specific default
+    ocpus                      = local.ocpus
+    os                         = var.image_os
+    os_version                 = var.image_os_version
+    placement_ads              = var.ad_numbers
+    pod_nsg_ids                = var.pod_nsg_ids
+    pod_subnet_id              = coalesce(var.pod_subnet_id, var.worker_subnet_id, "none")
+    pv_transit_encryption      = var.pv_transit_encryption
+    shape                      = local.shape
+    size                       = var.worker_pool_size
+    subnet_id                  = var.worker_subnet_id
+    volume_kms_key_id          = var.volume_kms_key_id
   }
 
   # Merge desired pool configuration onto default values

--- a/modules/workers/variables.tf
+++ b/modules/workers/variables.tf
@@ -38,6 +38,7 @@ variable "ad_numbers_to_names" { type = map(string) }
 variable "ad_numbers" { type = list(number) }
 variable "block_volume_type" { type = string }
 variable "cloud_init" { type = list(map(string)) }
+variable "disable_default_cloud_init" { type = bool }
 variable "image_id" { type = string }
 variable "image_ids" { type = map(any) }
 variable "image_os_version" { type = string }

--- a/variables-workers.tf
+++ b/variables-workers.tf
@@ -162,6 +162,12 @@ variable "worker_cloud_init" {
   type        = list(map(string))
 }
 
+variable "worker_disable_default_cloud_init" {
+  default = false
+  description = "Whether to disable the default OKE cloud init and only use the cloud init explicitly passed to the worker pool in 'worker_cloud_init'."
+  type = bool
+}
+
 variable "worker_volume_kms_key_id" {
   default     = null
   description = "The ID of the OCI KMS key to be used as the master encryption key for Boot Volume and Block Volume encryption by default when unspecified on a pool."


### PR DESCRIPTION
Added a variable named `disable_default_cloud_init` so users can prevent the default OKE cloud-init from being merged to the user-provided cloud-init if desired. If `disable_default_cloud_init` is set to true, the worker pools will be created using only the cloud-init explicitly provided in `worker_cloud_init`. If `disable_default_cloud_init` is set to false (default), the workers module will continue using the existing behavior of merging a default OKE cloud-init with the cloud-init provided by the user. 