### PR TITLE
feat: Add ability to override default cloud-init set by OKE in worker pools

### DIFF
--- a/module-workers.tf
+++ b/module-workers.tf
@@ -42,30 +42,31 @@ module "workers" {
   worker_pools     = var.worker_pools
 
   # Workers
-  assign_dns            = var.assign_dns
-  assign_public_ip      = var.worker_is_public
-  block_volume_type     = var.worker_block_volume_type
-  cloud_init            = var.worker_cloud_init
-  cni_type              = var.cni_type
-  image_id              = var.worker_image_id
-  image_ids             = local.image_ids
-  image_os              = var.worker_image_os
-  image_os_version      = var.worker_image_os_version
-  image_type            = var.worker_image_type
-  kubeproxy_mode        = var.kubeproxy_mode
-  max_pods_per_node     = var.max_pods_per_node
-  node_labels           = var.worker_node_labels
-  node_metadata         = var.worker_node_metadata
-  pod_nsg_ids           = concat(var.pod_nsg_ids, var.cni_type == "npn" ? [module.network.pod_nsg_id] : [])
-  pod_subnet_id         = lookup(module.network.subnet_ids, "pods", "")
-  pv_transit_encryption = var.worker_pv_transit_encryption
-  shape                 = var.worker_shape
-  ssh_public_key        = local.ssh_public_key
-  timezone              = var.timezone
-  volume_kms_key_id     = var.worker_volume_kms_key_id
-  worker_nsg_ids        = concat(var.worker_nsg_ids, [module.network.worker_nsg_id])
-  worker_subnet_id      = lookup(module.network.subnet_ids, "workers", "")
-  preemptible_config    = var.worker_preemptible_config
+  assign_dns                 = var.assign_dns
+  assign_public_ip           = var.worker_is_public
+  block_volume_type          = var.worker_block_volume_type
+  cloud_init                 = var.worker_cloud_init
+  disable_default_cloud_init = var.worker_disable_default_cloud_init
+  cni_type                   = var.cni_type
+  image_id                   = var.worker_image_id
+  image_ids                  = local.image_ids
+  image_os                   = var.worker_image_os
+  image_os_version           = var.worker_image_os_version
+  image_type                 = var.worker_image_type
+  kubeproxy_mode             = var.kubeproxy_mode
+  max_pods_per_node          = var.max_pods_per_node
+  node_labels                = var.worker_node_labels
+  node_metadata              = var.worker_node_metadata
+  pod_nsg_ids                = concat(var.pod_nsg_ids, var.cni_type == "npn" ? [module.network.pod_nsg_id] : [])
+  pod_subnet_id              = lookup(module.network.subnet_ids, "pods", "")
+  pv_transit_encryption      = var.worker_pv_transit_encryption
+  shape                      = var.worker_shape
+  ssh_public_key             = local.ssh_public_key
+  timezone                   = var.timezone
+  volume_kms_key_id          = var.worker_volume_kms_key_id
+  worker_nsg_ids             = concat(var.worker_nsg_ids, [module.network.worker_nsg_id])
+  worker_subnet_id           = lookup(module.network.subnet_ids, "workers", "")
+  preemptible_config         = var.worker_preemptible_config
 
   # FSS
   create_fss              = var.create_fss

--- a/modules/workers/locals.tf
+++ b/modules/workers/locals.tf
@@ -9,33 +9,34 @@ locals {
   preemptible_config = { enable = false, is_preserve_boot_volume = false }
 
   worker_pool_defaults = {
-    preemptible_config    = local.preemptible_config
-    allow_autoscaler      = false
-    assign_public_ip      = var.assign_public_ip
-    autoscale             = false
-    block_volume_type     = var.block_volume_type
-    boot_volume_size      = local.boot_volume_size
-    cloud_init            = [] # empty pool-specific default
-    compartment_id        = var.compartment_id
-    create                = true
-    drain                 = false
-    image_id              = var.image_id
-    image_type            = var.image_type
-    memory                = local.memory
-    mode                  = var.worker_pool_mode
-    node_labels           = var.node_labels
-    nsg_ids               = [] # empty pool-specific default
-    ocpus                 = local.ocpus
-    os                    = var.image_os
-    os_version            = var.image_os_version
-    placement_ads         = var.ad_numbers
-    pod_nsg_ids           = var.pod_nsg_ids
-    pod_subnet_id         = coalesce(var.pod_subnet_id, var.worker_subnet_id, "none")
-    pv_transit_encryption = var.pv_transit_encryption
-    shape                 = local.shape
-    size                  = var.worker_pool_size
-    subnet_id             = var.worker_subnet_id
-    volume_kms_key_id     = var.volume_kms_key_id
+    preemptible_config         = local.preemptible_config
+    allow_autoscaler           = false
+    assign_public_ip           = var.assign_public_ip
+    autoscale                  = false
+    block_volume_type          = var.block_volume_type
+    boot_volume_size           = local.boot_volume_size
+    cloud_init                 = [] # empty pool-specific default
+    disable_default_cloud_init = false
+    compartment_id             = var.compartment_id
+    create                     = true
+    drain                      = false
+    image_id                   = var.image_id
+    image_type                 = var.image_type
+    memory                     = local.memory
+    mode                       = var.worker_pool_mode
+    node_labels                = var.node_labels
+    nsg_ids                    = [] # empty pool-specific default
+    ocpus                      = local.ocpus
+    os                         = var.image_os
+    os_version                 = var.image_os_version
+    placement_ads              = var.ad_numbers
+    pod_nsg_ids                = var.pod_nsg_ids
+    pod_subnet_id              = coalesce(var.pod_subnet_id, var.worker_subnet_id, "none")
+    pv_transit_encryption      = var.pv_transit_encryption
+    shape                      = local.shape
+    size                       = var.worker_pool_size
+    subnet_id                  = var.worker_subnet_id
+    volume_kms_key_id          = var.volume_kms_key_id
   }
 
   # Merge desired pool configuration onto default values

--- a/modules/workers/variables.tf
+++ b/modules/workers/variables.tf
@@ -38,6 +38,7 @@ variable "ad_numbers_to_names" { type = map(string) }
 variable "ad_numbers" { type = list(number) }
 variable "block_volume_type" { type = string }
 variable "cloud_init" { type = list(map(string)) }
+variable "disable_default_cloud_init" { type = bool }
 variable "image_id" { type = string }
 variable "image_ids" { type = map(any) }
 variable "image_os_version" { type = string }

--- a/variables-workers.tf
+++ b/variables-workers.tf
@@ -162,6 +162,12 @@ variable "worker_cloud_init" {
   type        = list(map(string))
 }
 
+variable "worker_disable_default_cloud_init" {
+  default = false
+  description = "Whether to disable the default OKE cloud init and only use the cloud init explicitly passed to the worker pool in 'worker_cloud_init'."
+  type = bool
+}
+
 variable "worker_volume_kms_key_id" {
   default     = null
   description = "The ID of the OCI KMS key to be used as the master encryption key for Boot Volume and Block Volume encryption by default when unspecified on a pool."


### PR DESCRIPTION
Added a variable named `disable_default_cloud_init` so users can prevent the default OKE cloud-init from being merged to the user-provided cloud-init if desired. If `disable_default_cloud_init` is set to true, the worker pools will be created using only the cloud-init explicitly provided in `worker_cloud_init`. If `disable_default_cloud_init` is set to false (default), the workers module will continue using the existing behavior of merging a default OKE cloud-init with the cloud-init provided by the user.

Sample plan with `disable_default_cloud_init` set to true:
```
 # module.workers.module.workers[0].oci_core_instance_configuration.workers["ip_enhanced_cloudinit_misconfigured"] will be created
  + resource "oci_core_instance_configuration" "workers" {
      + compartment_id  = "ocid1.compartment.oc1..aaaaaaaacurnu3oxtnm42pdgsj4gnmtn4qjdf47k74g7e7lz54uov5k5mq5q"
      + deferred_fields = (known after apply)
      + defined_tags    = {
          + "tfoke.cluster_autoscaler" = "disabled"
          + "tfoke.pool"               = "ip_enhanced_cloudinit_misconfigured"
          + "tfoke.role"               = "worker"
          + "tfoke.state_id"           = "nvfegu"
        }
      + display_name    = "ip_enhanced_cloudinit_misconfigured"
      + freeform_tags   = (known after apply)
      + id              = (known after apply)
      + instance_id     = (known after apply)
      + source          = (known after apply)
      + time_created    = (known after apply)

      + instance_details {
          + instance_type = "compute"

          + block_volumes {
              + volume_id = (known after apply)

              + attach_details {
                  + device                              = (known after apply)
                  + display_name                        = (known after apply)
                  + is_pv_encryption_in_transit_enabled = false
                  + is_read_only                        = (known after apply)
                  + is_shareable                        = (known after apply)
                  + type                                = "paravirtualized"
                  + use_chap                            = (known after apply)
                }

              + create_details {
                  + availability_domain = (known after apply)
                  + backup_policy_id    = (known after apply)
                  + compartment_id      = "ocid1.compartment.oc1..aaaaaaaacurnu3oxtnm42pdgsj4gnmtn4qjdf47k74g7e7lz54uov5k5mq5q"
                  + defined_tags        = (known after apply)
                  + display_name        = "ip_enhanced_cloudinit_misconfigured"
                  + freeform_tags       = (known after apply)
                  + kms_key_id          = (known after apply)
                  + size_in_gbs         = (known after apply)
                  + vpus_per_gb         = (known after apply)

                  + autotune_policies {
                      + autotune_type   = (known after apply)
                      + max_vpus_per_gb = (known after apply)
                    }

                  + source_details {
                      + id   = (known after apply)
                      + type = (known after apply)
                    }
                }
            }

          + launch_details {
              + availability_domain                 = "zkJl:PHX-AD-2"
              + capacity_reservation_id             = (known after apply)
              + compartment_id                      = "ocid1.compartment.oc1..aaaaaaaacurnu3oxtnm42pdgsj4gnmtn4qjdf47k74g7e7lz54uov5k5mq5q"
              + dedicated_vm_host_id                = (known after apply)
              + defined_tags                        = {
                  + "tfoke.cluster_autoscaler" = "disabled"
                  + "tfoke.pool"               = "ip_enhanced_cloudinit_misconfigured"
                  + "tfoke.role"               = "worker"
                  + "tfoke.state_id"           = "nvfegu"
                }
              + display_name                        = (known after apply)
              + extended_metadata                   = (known after apply)
              + fault_domain                        = (known after apply)
              + freeform_tags                       = (known after apply)
              + ipxe_script                         = (known after apply)
              + is_pv_encryption_in_transit_enabled = false
              + launch_mode                         = (known after apply)
              + metadata                            = {
                  + "apiserver_host"           = "10.2.2.143"
                  + "cluster_ca_cert"          = "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURpRENDQW5DZ0F3SUJBZ0lRU2FYcmhoaEpGTmVRL2ZYQTJVSzV3ekFOQmdrcWhraUc5dzBCQVFzRkFEQmUKTVE4d0RRWURWUVFEREFaTE9ITWdRMEV4Q3pBSkJnTlZCQVlUQWxWVE1ROHdEUVlEVlFRSERBWkJkWE4wYVc0eApEekFOQmdOVkJBb01Cazl5WVdOc1pURU1NQW9HQTFVRUN3d0RUMk5wTVE0d0RBWURWUVFJREFWVVpYaGhjekFlCkZ3MHlNekExTURnd01ESXdNamhhRncweU9EQTFNRGd3TURJd01qaGFNRjR4RHpBTkJnTlZCQU1NQmtzNGN5QkQKUVRFTE1Ba0dBMVVFQmhNQ1ZWTXhEekFOQmdOVkJBY01Ca0YxYzNScGJqRVBNQTBHQTFVRUNnd0dUM0poWTJ4bApNUXd3Q2dZRFZRUUxEQU5QWTJreERqQU1CZ05WQkFnTUJWUmxlR0Z6TUlJQklqQU5CZ2txaGtpRzl3MEJBUUVGCkFBT0NBUThBTUlJQkNnS0NBUUVBNUJ4NUlGV0hkY051V2ZjdGVoeG96eldCTTE5ZHZlMlNTbDVLQ3dxUU5DQU4KYStOVVBGbFhQdkUxODNvMGh5V0Rqd3g0MUxHMUtUb2g4b3ByU0gxdUVYcjhDYStDUkZXRDA1NDBmMGY5ZXo3WApjTGM3SkRGeDVhang5Wm5tMnZDMlh5TkM4NllzTWpkU1VpR0FzM0s5S1lpYlNpM3F3MjJIYzZGczFQMTU3N2lLCkNaaWRaYjFmeUhNUThISUxsaTNDS1BLeis2OEE5bGlJdEVzcU54OTYyV1VmMDNNSWh5Qi9mZm1TcjhwSHQ1dnEKNnV1OVRHSFFaeTAraEM2MEo3dnFEd01vSnNWMldzRWkvVVdXaDhCQnRtcDRNbEJHaEREb3JxUU9kSGJzc2FBQwpEd3gyS3VkR3RsbENaYjFsYVVJT29mT3FWWWJsbTM4Rzl4TmJRejMzS3dJREFRQUJvMEl3UURBUEJnTlZIUk1CCkFmOEVCVEFEQVFIL01BNEdBMVVkRHdFQi93UUVBd0lCQmpBZEJnTlZIUTRFRmdRVXFIaEdpNGtYWGt1aStZVlcKdlZnSTBHZW5aREV3RFFZSktvWklodmNOQVFFTEJRQURnZ0VCQUhhTUcySW9DdXlmaC9TR1ZkTXhVKzZwcS9wQwpuTDRqS2ZxMnBQOHZ2NnF6dFJPZ2M5S1NCNGtwVFRLbTUyUmJrZDR6dXNYRExtTko0dXloSGZNSVd6eHhQeGI0CkFmRUF4ZVUzYVhpZkF0Mm9uMzdqdkptV2xQVFV5QXB5N0dkUk5DYjZqNnlzVWNDZkptb1VWSkh0OUozZlpDczIKM00rblpnRVAvWDFsVTRwK3BIUTBXOW5FeWdPRzhFYUQxUnh4NllURGg3aFhzU1BuQVJScE1vNUNac1pJdmRKVAp0MHBGcURPcW1CRklxQ3FaaWo1ekVkWExlTVY3TGdWL0wzTE5LVUhPVURLUzBLTFBzdGZnTUszeEpYbThFTTlpCmMzNUl2a09pLzZQVjJuSUZ6TnlHY0tOWHB1aFJGM1g1TnpkdFg3K0xFVk5qYVVDb2J1cStkSERWZ3AwPQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg=="
                  + "oke-initial-node-labels"  = "oke.oraclecloud.com/cluster_autoscaler=disabled,oke.oraclecloud.com/pool.mode=instance-pool,oke.oraclecloud.com/pool.name=ip_enhanced_cloudinit_misconfigured,oke.oraclecloud.com/tf.module=terraform-oci-oke,oke.oraclecloud.com/tf.state_id=nvfegu,oke.oraclecloud.com/tf.workspace=default"
                  + "oke-k8version"            = "v1.25.4"
                  + "oke-kubeproxy-proxy-mode" = "iptables"
                  + "oke-tenancy-id"           = "ocid1.tenancy.oc1..aaaaaaaat37ab62ltpvzgyoydasbfig3gcmccxwzvbi6yoh6ewqiiswps6sq"
                  + "secondary_vnics"          = jsonencode({})
                  + "ssh_authorized_keys"      = <<-EOT
                        ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC07ybO1OfwsfoVwEi95aelL7j3/Eiyzh28sqCeihN0HHtBTw8UrHSsl5lV7MerhUH7iH4hfY91vcby0K2tpoMl1FWjf26s6rDtzjawJA8Q2wSV3NUI0GP+r7VoH+YbxrfXXDhbDlYcBYjOIDhH5GL0/3vRL7kGnUmXV9RzWmfVbz/24u/uA/pK0GUvKWwXAXBYqDle6GtWBDngocSbEF0nc+SJBONH0oqPlCUxt1LpmxxOtBsA1UvxsTzrZIuP2Wf4vigVqAogqMc5g13G/flSE5dCXqLDacOyobrNhSc6GgAWF+ZnEEF2dX/aR5d08Zwh9xymmdPNFKftr4Jzb8UPh4Ha3NUZT7TJipKOz8uj2ezGYXx+ltfg55Kapx4tOP0xU7u07vu1favfd/pn7QKJWp3QYO2tKIZk5euIBR+5MZPQnAItfQbRXA1EvTRY39J7hmwBfeArs6LHKWeRjBri11UJX5wzM44orY23HeCb4hsF0QH7/Y3vQOon3q/OeCTJNJbwiVJwaw0SevbDRGCZkLxy0wLtoNdv4I+dEXF/Dbevv73gdsDbk7tCMk5I/nlV6q1oM9aMrvtwjsYysKrkCSCY3eu/d10sAfbzJzaf1htUj07OkHEgRaG3oQ3+Rn+MgEyIsOPJjeoYiHZRSZbf+F8Y/qboBKvcPQ63evbRKQ== e2e_user@oracle.com
                    EOT
                  + "user_data"                = "H4sIAAAAAAAA/1yPz0oDMRCH74F9h1gvLTWNnoQtHvzTg4dVEBU9lWx27A5mJ2EyC9u3l4iW0sMMDHwz3/zuIwmQmNd9gloPYxBMjsUOOEG31m0cqXO8v5k1j83m7vnt6eH25XOmymTegTNGqvXV6rJSlTLmGKrU4TY7yl/AZkM+dki7Wl+3KEfAr1xgEjuZ3EMI2TMmqVSDA5x4PkwDvIO/pYBZ5i4loG6x7NDLnOKWIQXn4YLBj5xhW6DFMgv/k+Xb8zPbItnW5X6tS9cWxNv4DaUMUhYXwir3p8GMqdRPAAAA///h7OXENwEAAA=="
                }
              + preferred_maintenance_action        = (known after apply)
              + shape                               = "VM.Standard2.1"

              + agent_config {
                  + are_all_plugins_disabled = (known after apply)
                  + is_management_disabled   = (known after apply)
                  + is_monitoring_disabled   = (known after apply)

                  + plugins_config {
                      + desired_state = (known after apply)
                      + name          = (known after apply)
                    }
                }

              + availability_config {
                  + recovery_action = (known after apply)
                }

              + create_vnic_details {
                  + assign_private_dns_record = true
                  + assign_public_ip          = false
                  + defined_tags              = {
                      + "tfoke.cluster_autoscaler" = "disabled"
                      + "tfoke.pool"               = "ip_enhanced_cloudinit_misconfigured"
                      + "tfoke.role"               = "worker"
                      + "tfoke.state_id"           = "nvfegu"
                    }
                  + display_name              = (known after apply)
                  + freeform_tags             = (known after apply)
                  + hostname_label            = (known after apply)
                  + nsg_ids                   = [
                      + "ocid1.networksecuritygroup.oc1.phx.aaaaaaaaxrdilymr6wmi2mermmzge7zq36stu3gr2cwuoutjakb3jjctuzta",
                    ]
                  + private_ip                = (known after apply)
                  + skip_source_dest_check    = (known after apply)
                  + subnet_id                 = "ocid1.subnet.oc1.phx.aaaaaaaa7yvrsg5e5kct4jeyaytiw2mfoio4ol27msuqbh53ovhs63beswaq"
                }

              + instance_options {
                  + are_legacy_imds_endpoints_disabled = false
                }

              + launch_options {
                  + boot_volume_type                    = (known after apply)
                  + firmware                            = (known after apply)
                  + is_consistent_volume_naming_enabled = (known after apply)
                  + is_pv_encryption_in_transit_enabled = (known after apply)
                  + network_type                        = (known after apply)
                  + remote_data_volume_type             = (known after apply)
                }

              + platform_config {
                  + are_virtual_instructions_enabled               = (known after apply)
                  + is_access_control_service_enabled              = (known after apply)
                  + is_input_output_memory_management_unit_enabled = (known after apply)
                  + is_measured_boot_enabled                       = (known after apply)
                  + is_memory_encryption_enabled                   = (known after apply)
                  + is_secure_boot_enabled                         = (known after apply)
                  + is_symmetric_multi_threading_enabled           = (known after apply)
                  + is_trusted_platform_module_enabled             = (known after apply)
                  + numa_nodes_per_socket                          = (known after apply)
                  + percentage_of_cores_enabled                    = (known after apply)
                  + type                                           = (known after apply)
                }

              + preemptible_instance_config {
                  + preemption_action {
                      + preserve_boot_volume = (known after apply)
                      + type                 = (known after apply)
                    }
                }

              + shape_config {
                  + baseline_ocpu_utilization = (known after apply)
                  + memory_in_gbs             = (known after apply)
                  + nvmes                     = (known after apply)
                  + ocpus                     = (known after apply)
                }

              + source_details {
                  + boot_volume_id          = (known after apply)
                  + boot_volume_size_in_gbs = "50"
                  + boot_volume_vpus_per_gb = (known after apply)
                  + image_id                = "ocid1.image.oc1.iad.aaaaaaaagtmoghpvppmc5qmd2e7kui4mpdkcnbdrnkyzuh3x62mqzjdy6xnq"
                  + source_type             = "image"
                }
            }

          + secondary_vnics {
              + display_name = (known after apply)
              + nic_index    = (known after apply)

              + create_vnic_details {
                  + assign_private_dns_record = (known after apply)
                  + assign_public_ip          = (known after apply)
                  + defined_tags              = (known after apply)
                  + display_name              = (known after apply)
                  + freeform_tags             = (known after apply)
                  + hostname_label            = (known after apply)
                  + nsg_ids                   = (known after apply)
                  + private_ip                = (known after apply)
                  + skip_source_dest_check    = (known after apply)
                  + subnet_id                 = (known after apply)
                }
            }
        }
    }
```

Sample plan with `disable_default_cloud_init` set to false:
```
  # module.workers.module.workers[0].oci_core_instance_configuration.workers["ip_enhanced_cloudinit_misconfigured"] will be created
  + resource "oci_core_instance_configuration" "workers" {
      + compartment_id  = "ocid1.compartment.oc1..aaaaaaaacurnu3oxtnm42pdgsj4gnmtn4qjdf47k74g7e7lz54uov5k5mq5q"
      + deferred_fields = (known after apply)
      + defined_tags    = {
          + "tfoke.cluster_autoscaler" = "disabled"
          + "tfoke.pool"               = "ip_enhanced_cloudinit_misconfigured"
          + "tfoke.role"               = "worker"
          + "tfoke.state_id"           = "nvfegu"
        }
      + display_name    = "ip_enhanced_cloudinit_misconfigured"
      + freeform_tags   = (known after apply)
      + id              = (known after apply)
      + instance_id     = (known after apply)
      + source          = (known after apply)
      + time_created    = (known after apply)

      + instance_details {
          + instance_type = "compute"

          + block_volumes {
              + volume_id = (known after apply)

              + attach_details {
                  + device                              = (known after apply)
                  + display_name                        = (known after apply)
                  + is_pv_encryption_in_transit_enabled = false
                  + is_read_only                        = (known after apply)
                  + is_shareable                        = (known after apply)
                  + type                                = "paravirtualized"
                  + use_chap                            = (known after apply)
                }

              + create_details {
                  + availability_domain = (known after apply)
                  + backup_policy_id    = (known after apply)
                  + compartment_id      = "ocid1.compartment.oc1..aaaaaaaacurnu3oxtnm42pdgsj4gnmtn4qjdf47k74g7e7lz54uov5k5mq5q"
                  + defined_tags        = (known after apply)
                  + display_name        = "ip_enhanced_cloudinit_misconfigured"
                  + freeform_tags       = (known after apply)
                  + kms_key_id          = (known after apply)
                  + size_in_gbs         = (known after apply)
                  + vpus_per_gb         = (known after apply)

                  + autotune_policies {
                      + autotune_type   = (known after apply)
                      + max_vpus_per_gb = (known after apply)
                    }

                  + source_details {
                      + id   = (known after apply)
                      + type = (known after apply)
                    }
                }
            }

          + launch_details {
              + availability_domain                 = "zkJl:PHX-AD-2"
              + capacity_reservation_id             = (known after apply)
              + compartment_id                      = "ocid1.compartment.oc1..aaaaaaaacurnu3oxtnm42pdgsj4gnmtn4qjdf47k74g7e7lz54uov5k5mq5q"
              + dedicated_vm_host_id                = (known after apply)
              + defined_tags                        = {
                  + "tfoke.cluster_autoscaler" = "disabled"
                  + "tfoke.pool"               = "ip_enhanced_cloudinit_misconfigured"
                  + "tfoke.role"               = "worker"
                  + "tfoke.state_id"           = "nvfegu"
                }
              + display_name                        = (known after apply)
              + extended_metadata                   = (known after apply)
              + fault_domain                        = (known after apply)
              + freeform_tags                       = (known after apply)
              + ipxe_script                         = (known after apply)
              + is_pv_encryption_in_transit_enabled = false
              + launch_mode                         = (known after apply)
              + metadata                            = {
                  + "apiserver_host"           = "10.2.2.143"
                  + "cluster_ca_cert"          = "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURpRENDQW5DZ0F3SUJBZ0lRU2FYcmhoaEpGTmVRL2ZYQTJVSzV3ekFOQmdrcWhraUc5dzBCQVFzRkFEQmUKTVE4d0RRWURWUVFEREFaTE9ITWdRMEV4Q3pBSkJnTlZCQVlUQWxWVE1ROHdEUVlEVlFRSERBWkJkWE4wYVc0eApEekFOQmdOVkJBb01Cazl5WVdOc1pURU1NQW9HQTFVRUN3d0RUMk5wTVE0d0RBWURWUVFJREFWVVpYaGhjekFlCkZ3MHlNekExTURnd01ESXdNamhhRncweU9EQTFNRGd3TURJd01qaGFNRjR4RHpBTkJnTlZCQU1NQmtzNGN5QkQKUVRFTE1Ba0dBMVVFQmhNQ1ZWTXhEekFOQmdOVkJBY01Ca0YxYzNScGJqRVBNQTBHQTFVRUNnd0dUM0poWTJ4bApNUXd3Q2dZRFZRUUxEQU5QWTJreERqQU1CZ05WQkFnTUJWUmxlR0Z6TUlJQklqQU5CZ2txaGtpRzl3MEJBUUVGCkFBT0NBUThBTUlJQkNnS0NBUUVBNUJ4NUlGV0hkY051V2ZjdGVoeG96eldCTTE5ZHZlMlNTbDVLQ3dxUU5DQU4KYStOVVBGbFhQdkUxODNvMGh5V0Rqd3g0MUxHMUtUb2g4b3ByU0gxdUVYcjhDYStDUkZXRDA1NDBmMGY5ZXo3WApjTGM3SkRGeDVhang5Wm5tMnZDMlh5TkM4NllzTWpkU1VpR0FzM0s5S1lpYlNpM3F3MjJIYzZGczFQMTU3N2lLCkNaaWRaYjFmeUhNUThISUxsaTNDS1BLeis2OEE5bGlJdEVzcU54OTYyV1VmMDNNSWh5Qi9mZm1TcjhwSHQ1dnEKNnV1OVRHSFFaeTAraEM2MEo3dnFEd01vSnNWMldzRWkvVVdXaDhCQnRtcDRNbEJHaEREb3JxUU9kSGJzc2FBQwpEd3gyS3VkR3RsbENaYjFsYVVJT29mT3FWWWJsbTM4Rzl4TmJRejMzS3dJREFRQUJvMEl3UURBUEJnTlZIUk1CCkFmOEVCVEFEQVFIL01BNEdBMVVkRHdFQi93UUVBd0lCQmpBZEJnTlZIUTRFRmdRVXFIaEdpNGtYWGt1aStZVlcKdlZnSTBHZW5aREV3RFFZSktvWklodmNOQVFFTEJRQURnZ0VCQUhhTUcySW9DdXlmaC9TR1ZkTXhVKzZwcS9wQwpuTDRqS2ZxMnBQOHZ2NnF6dFJPZ2M5S1NCNGtwVFRLbTUyUmJrZDR6dXNYRExtTko0dXloSGZNSVd6eHhQeGI0CkFmRUF4ZVUzYVhpZkF0Mm9uMzdqdkptV2xQVFV5QXB5N0dkUk5DYjZqNnlzVWNDZkptb1VWSkh0OUozZlpDczIKM00rblpnRVAvWDFsVTRwK3BIUTBXOW5FeWdPRzhFYUQxUnh4NllURGg3aFhzU1BuQVJScE1vNUNac1pJdmRKVAp0MHBGcURPcW1CRklxQ3FaaWo1ekVkWExlTVY3TGdWL0wzTE5LVUhPVURLUzBLTFBzdGZnTUszeEpYbThFTTlpCmMzNUl2a09pLzZQVjJuSUZ6TnlHY0tOWHB1aFJGM1g1TnpkdFg3K0xFVk5qYVVDb2J1cStkSERWZ3AwPQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg=="
                  + "oke-initial-node-labels"  = "oke.oraclecloud.com/cluster_autoscaler=disabled,oke.oraclecloud.com/pool.mode=instance-pool,oke.oraclecloud.com/pool.name=ip_enhanced_cloudinit_misconfigured,oke.oraclecloud.com/tf.module=terraform-oci-oke,oke.oraclecloud.com/tf.state_id=nvfegu,oke.oraclecloud.com/tf.workspace=default"
                  + "oke-k8version"            = "v1.25.4"
                  + "oke-kubeproxy-proxy-mode" = "iptables"
                  + "oke-tenancy-id"           = "ocid1.tenancy.oc1..aaaaaaaat37ab62ltpvzgyoydasbfig3gcmccxwzvbi6yoh6ewqiiswps6sq"
                  + "secondary_vnics"          = jsonencode({})
                  + "ssh_authorized_keys"      = <<-EOT
                        ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC07ybO1OfwsfoVwEi95aelL7j3/Eiyzh28sqCeihN0HHtBTw8UrHSsl5lV7MerhUH7iH4hfY91vcby0K2tpoMl1FWjf26s6rDtzjawJA8Q2wSV3NUI0GP+r7VoH+YbxrfXXDhbDlYcBYjOIDhH5GL0/3vRL7kGnUmXV9RzWmfVbz/24u/uA/pK0GUvKWwXAXBYqDle6GtWBDngocSbEF0nc+SJBONH0oqPlCUxt1LpmxxOtBsA1UvxsTzrZIuP2Wf4vigVqAogqMc5g13G/flSE5dCXqLDacOyobrNhSc6GgAWF+ZnEEF2dX/aR5d08Zwh9xymmdPNFKftr4Jzb8UPh4Ha3NUZT7TJipKOz8uj2ezGYXx+ltfg55Kapx4tOP0xU7u07vu1favfd/pn7QKJWp3QYO2tKIZk5euIBR+5MZPQnAItfQbRXA1EvTRY39J7hmwBfeArs6LHKWeRjBri11UJX5wzM44orY23HeCb4hsF0QH7/Y3vQOon3q/OeCTJNJbwiVJwaw0SevbDRGCZkLxy0wLtoNdv4I+dEXF/Dbevv73gdsDbk7tCMk5I/nlV6q1oM9aMrvtwjsYysKrkCSCY3eu/d10sAfbzJzaf1htUj07OkHEgRaG3oQ3+Rn+MgEyIsOPJjeoYiHZRSZbf+F8Y/qboBKvcPQ63evbRKQ== e2e_user@oracle.com
                    EOT
                  + "user_data"                = "H4sIAAAAAAAA/9RXbXObOpT+7pn+By29c9vOjW0wdnaSTu9MsMEOMbgIJGLudjwyUgxBCALyS2j733dwkrbpy3649+7O7AebAZ2X5znn6OhoXAjJhOwG9yU7B/mWy7Qklezn6YHRt2BdbAUl1f07xbl0TGOB3MkFXCqd9q2LWVWnhTgHWk990XnR6Xa/FXrR+WK7IqK+YVXXFHFBU7E5B/+5TuU3Akfnkh1k/9CtE8Z5HVdpKV90nDRn3/m57jqs2rBHJZ7W8jUpSybomz9oGsvXolhVrOQkZicVi7dVzVat0Js/alk9SbZoX/5Hf52K/prUyVvQ/oM+k3G/yFj766ailoTzXp38mtgkrcuiTuURHJGSxEnOhHwLblLOBMnZO0VTuzLNWVMI1rvPufL3ohLzYku7cSFu0s1Pg/Ki81F58qOcK6aM+ygYK5//KfZNVezbevjfxP5vJfSjsi4KGedUOf9LSW/AX3+B7g3ob+uqz9M1O7C4X8TpkdJNDT58eAtkwsQvBbr3bSyUDyfKUxCU848KZbs0ZnXrot+upRtRVGzVilRFIVc0rcmaM6qc3xBesxMlL2ibEbKVhfL5RKlYnTZs1cre1Mq5rLbsnyVppHbbcn2I7/+PNO2rVLJVS6GN40clfkCjnCua2hv0Bj1tqCsnSklkopwrz3YlKdOaVTtWKZ9PvlWc+6qc+9oYImoHqTGB2EY+imxPtRA8rqlynGm2j2AJTXfihaNJpFq6j2wjUjlEA2sZ50lBzHIa5BjOB9HSC2zsN1hnmbXwclrFYVIRFI9oY4w9bDUws0wvR1cBNodUhTBEMETYMqFpkcA8uwxCCh0TDz29NPzMFgGPxh7myAsPITY1uJhRE2FuYm5B34RGmNlZaA73Sxyr7KI0H/0ucGYba1Ubk4aPQkwXsVYiiDTXC89mXmBhiFydqhA52WgfYFOlKjQesdjQtEKMyyWZJrcss/g4i3Rnxl2WmYcAQUFVzfSvqUvyJIEi3jN0ZnqB5cIp1QMEbapqd2RqufAWDuGsNIInHq3/XDbu1B15mXeFMLQCUzOISg0HY8vLE9fTojC4Tp7xWLY81OVh2bh+PLXvIDZcLzCeeAiqUuSoZREG9nB9UbromuregEbQiiBCB9NDIy8M7IqZ8M5D2jhSR6GXWSJAdojyA4dqdBogbnsZv/PQaBwN5IFMZQkbrjumbSCEp+PMMgLVNVCQGA+yrvDbd4QNF9lDF/EpVpNsqY40PIhu6RQXbHp2yjgdB4E5imYRd7gbrCd47un0gNBo4qHh1dKXC4yN6dpKPJqhw2Li7pxpMsIqvKP6RnXQYeYgidaDzXCtG/dI3Rwowsv4NpksfTlBWXQNJxeaOzFyZ7ocRdeFHl6Ut8HU0f0MTtkEJ0RsRmE+ko6IJg5PRkHmDF3OmyAsM6ThEqpW46j1yNd4ueRu6eiW7tzal8smmsaN5TkB0t0Bn48zl5AQkuWtlTOUuChILn10qEngTnzNmLO0HixMc7SecpuauInRaLgIlvdYw7kzcV0/TEZeepZHuRbEt8nen3kaFeaVK7C2wHDmWxZhwUVFTGfgmIVOhWVSVdv5wg0dThsYZjuM6TWZJGNPQBlPoLs27RkxobnW7QNCZ5k/tZt4YBnevjSpvrn3dZxBHdZr021x10uM7WBwlge6FYahXa8DZwgbPgxyG7Jbp/F12tY/9JC9c0yuIwQNZB7r9xJl2nicWfnCxGNsWqaHrcu5qhmueazfDM6o5aVnelsTVOVjLy+N6Ek3gBbMKcTX1iUxaelO5TKcSo34MsI8vqI8En5gzKJwRKCJdWhZkZ/JXZjxgubuwsOWFZg29BAUkYrHHkqSAMX3fng2odc8J+OzAGpRFlwn+KqJ9rF/tvf25TaYwDt/EB0cYXiLWTRwhXVKLft9NHBGvuaO3ancYwvO1wG6R7ldRRN4Sq/dJTQPMsgKlV7zwp9Gro/pKZslHpteqm0MILKGEUbNEidllFmqk59tnYbe0ayUeHDwsIVH3rUxclWaoWw0Wd5Gd67gDQ7dSZSVcq3h0M8SdYGKJuLlJG4urxxVrda8FBBf7MKJVeMA7q904xIFxvUiHFkspO9hk1hL5B2QSNoaRnC60YmVNEgzth62/djUdi5ySayVNs3hFb4oVWdmTGME38ehNoYZP3i6RUhYaCzDWWgeeICXejCl4VzdN4E5mmOUvMcIzlFjzAPLaOg0EgGqG2aWy3WQWEHAy3HuNC7iA6KelfMm8vCtvfVRdBoIPluqchHODI1Y9tTRNlogyoxaG/1KPVg4G90tMZ6sB7YW+zLzTRhG+sX+vVccz5s5wgs4/sVZtHn3TjlR2OO5rJwra1Kz0+F3x162XbNKMMnqfkx6cSWVzx/+jXGhVyd/c0z4P53P28msndGZ2B0n9M5LMC7K+yrdJBK8jt+AgToYnLT/OlhUJOYMjIuqLCrShgAQQftFBVJZA3Jzk/KUSFb3Oi/BPI2ZqBkFW0FZ1Y6BAIl0x6qacPCeVXla1+mOPcmBXcsMkBrUSbEXgEiQSFnW5/1+Ude94ui5Fxd5nz8o1P1tyTsvwTFUccLiDDzOhe/8saaeaeAluDwOjmArKlYXfMfoMUmgzT4oK1YzIUEhWtoMpDnZsLpTMwm6BSjTkt2QlHc6N1sRH5lWW7EqMrZKRSpfvwEfW/silSnhacPA4soE+6LKWAVEQVkHgK/TcVtl9X0tWU4fn4+3n1T22kkrjdmXUbkDAAAPQrHkoNsVRXfNizgDTLTkjl/24Hv9DgCMP/f4NM49Eah7dQI+fAC///4zqa9Xse+gFNsqZr+2eBTiRUw4+DI3rpKilm+/e3/32+sNk6vnH98c1R9xN0D57ePz9c/KczTg50bTnNarnElCiSTgE7i9A90qdsCr3nPxVw/+btLO8RnzbS1ZtYrJo522FXAmVzFPmZCrmPyI76vOj9h+sPdrXF9FVzGrvgf2P92UwX89eut+HdS7TNCySIX8aQS/Kjzy68ak23r9ns+xiGoGXgLIZJWyHQMPHbN77KGMgoeWBB7vBOCmKvLjNj0BrLfpgSNKETPwxPmb6njaOqttxd+9apXO+33t9Kw3GA17j89+Ucb93aD/ZKf/ZKf/RfsBwauH/G2rdoe0+xR0Z0C52MqkqNKGPDRng5GKVY9NSwHdudoS/hbHN8H59EgVdLuUtWTBn/0dqfrVVnyzWZN29zxk5yeLnWMGP3c6Ms3Zs34BPn0CHwGLkwIoZlW1DVMcW0YtSSW3pQK0P38fvAXskEqgvQU/nD/d7ovOfwcAAP///BSXOkcSAAA="
                }
              + preferred_maintenance_action        = (known after apply)
              + shape                               = "VM.Standard2.1"

              + agent_config {
                  + are_all_plugins_disabled = (known after apply)
                  + is_management_disabled   = (known after apply)
                  + is_monitoring_disabled   = (known after apply)

                  + plugins_config {
                      + desired_state = (known after apply)
                      + name          = (known after apply)
                    }
                }

              + availability_config {
                  + recovery_action = (known after apply)
                }

              + create_vnic_details {
                  + assign_private_dns_record = true
                  + assign_public_ip          = false
                  + defined_tags              = {
                      + "tfoke.cluster_autoscaler" = "disabled"
                      + "tfoke.pool"               = "ip_enhanced_cloudinit_misconfigured"
                      + "tfoke.role"               = "worker"
                      + "tfoke.state_id"           = "nvfegu"
                    }
                  + display_name              = (known after apply)
                  + freeform_tags             = (known after apply)
                  + hostname_label            = (known after apply)
                  + nsg_ids                   = [
                      + "ocid1.networksecuritygroup.oc1.phx.aaaaaaaaxrdilymr6wmi2mermmzge7zq36stu3gr2cwuoutjakb3jjctuzta",
                    ]
                  + private_ip                = (known after apply)
                  + skip_source_dest_check    = (known after apply)
                  + subnet_id                 = "ocid1.subnet.oc1.phx.aaaaaaaa7yvrsg5e5kct4jeyaytiw2mfoio4ol27msuqbh53ovhs63beswaq"
                }

              + instance_options {
                  + are_legacy_imds_endpoints_disabled = false
                }

              + launch_options {
                  + boot_volume_type                    = (known after apply)
                  + firmware                            = (known after apply)
                  + is_consistent_volume_naming_enabled = (known after apply)
                  + is_pv_encryption_in_transit_enabled = (known after apply)
                  + network_type                        = (known after apply)
                  + remote_data_volume_type             = (known after apply)
                }

              + platform_config {
                  + are_virtual_instructions_enabled               = (known after apply)
                  + is_access_control_service_enabled              = (known after apply)
                  + is_input_output_memory_management_unit_enabled = (known after apply)
                  + is_measured_boot_enabled                       = (known after apply)
                  + is_memory_encryption_enabled                   = (known after apply)
                  + is_secure_boot_enabled                         = (known after apply)
                  + is_symmetric_multi_threading_enabled           = (known after apply)
                  + is_trusted_platform_module_enabled             = (known after apply)
                  + numa_nodes_per_socket                          = (known after apply)
                  + percentage_of_cores_enabled                    = (known after apply)
                  + type                                           = (known after apply)
                }

              + preemptible_instance_config {
                  + preemption_action {
                      + preserve_boot_volume = (known after apply)
                      + type                 = (known after apply)
                    }
                }

              + shape_config {
                  + baseline_ocpu_utilization = (known after apply)
                  + memory_in_gbs             = (known after apply)
                  + nvmes                     = (known after apply)
                  + ocpus                     = (known after apply)
                }

              + source_details {
                  + boot_volume_id          = (known after apply)
                  + boot_volume_size_in_gbs = "50"
                  + boot_volume_vpus_per_gb = (known after apply)
                  + image_id                = "ocid1.image.oc1.iad.aaaaaaaagtmoghpvppmc5qmd2e7kui4mpdkcnbdrnkyzuh3x62mqzjdy6xnq"
                  + source_type             = "image"
                }
            }

          + secondary_vnics {
              + display_name = (known after apply)
              + nic_index    = (known after apply)

              + create_vnic_details {
                  + assign_private_dns_record = (known after apply)
                  + assign_public_ip          = (known after apply)
                  + defined_tags              = (known after apply)
                  + display_name              = (known after apply)
                  + freeform_tags             = (known after apply)
                  + hostname_label            = (known after apply)
                  + nsg_ids                   = (known after apply)
                  + private_ip                = (known after apply)
                  + skip_source_dest_check    = (known after apply)
                  + subnet_id                 = (known after apply)
                }
            }
        }
    }
```