### PR TITLE
fix: 5.x Use pool-level node_labels

### DIFF
--- a/modules/workers/locals.tf
+++ b/modules/workers/locals.tf
@@ -129,7 +129,7 @@ locals {
           "oke.oraclecloud.com/cluster_autoscaler" = pool.allow_autoscaler ? "allowed" : "disabled"
         },
         pool.autoscale ? { "oke.oraclecloud.com/cluster_autoscaler" = "managed" } : {},
-        var.node_labels,
+        pool.node_labels,
       )
     }) if tobool(pool.create)
   }


### PR DESCRIPTION
- Fix incorrect `node_labels` reference to use pool-level configuration when present.