### PR TITLE
fix: 5.x Use correct suffix numbering for pools with mode=instance

### DIFF
--- a/modules/workers/locals.tf
+++ b/modules/workers/locals.tf
@@ -156,11 +156,11 @@ locals {
   }
 
   # Enabled worker_pool map entries for individual instances
-  enabled_instances = { for k, v in concat([], [
+  enabled_instances = { for e in concat([], [
     for k, v in local.enabled_worker_pools : [
       for i in range(0, lookup(v, "size", 0)) : merge(v, { "key" = k, "index" = i })
     ] if lookup(v, "mode", "") == "instance"
-  ]...) : "${lookup(v, "key")}-${k}" => v }
+  ]...) : "${lookup(e, "key")}-${lookup(e, "index")}" => e }
 
   # Enabled worker_pool map entries for cluster networks
   enabled_cluster_networks = {

--- a/modules/workers/locals.tf
+++ b/modules/workers/locals.tf
@@ -182,7 +182,8 @@ locals {
   worker_node_pools       = { for k, v in oci_containerengine_node_pool.workers : k => merge(v, lookup(local.worker_pools_final, k, {})) }
   worker_instance_pools   = { for k, v in oci_core_instance_pool.workers : k => merge(v, lookup(local.worker_pools_final, k, {})) }
   worker_cluster_networks = { for k, v in oci_core_cluster_network.workers : k => merge(v, lookup(local.worker_pools_final, k, {})) }
-  worker_pools_output     = merge(local.worker_node_pools, local.worker_instance_pools, local.worker_cluster_networks)
+  worker_instances        = { for k, v in oci_core_instance.workers : k => merge(v, lookup(local.worker_pools_final, k, {})) }
+  worker_pools_output     = merge(local.worker_node_pools, local.worker_instance_pools, local.worker_cluster_networks, local.worker_instances)
   worker_pool_ids         = { for k, v in local.worker_pools_output : k => v.id }
   worker_instance_ids     = { for k, v in local.enabled_instances : k => lookup(lookup(oci_core_instance.workers, k, {}), "id", "") }
 }


### PR DESCRIPTION
* Include `mode: instance` pools in detailed `worker_pools` output.
* Each pool with `mode: instance` should be numbered independently rather than in a group as before.

Before:
```
poolA-0
poolA-1
poolA-2
poolB-3
poolB-4
poolB-5
```

After:
```
poolA-0
poolA-1
poolA-2
poolB-0
poolB-1
poolB-2
```