### PR TITLE
fix: 5.x Relax TF provider version constraints

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -7,33 +7,33 @@ terraform {
   required_providers {
     cloudinit = {
       source  = "hashicorp/cloudinit"
-      version = "~> 2.2.0"
+      version = ">= 2.2.0"
     }
 
     helm = {
       source  = "hashicorp/helm"
-      version = "~> 2.9.0"
+      version = ">= 2.9.0"
     }
 
     null = {
       source  = "hashicorp/null"
-      version = "~> 3.2.1"
+      version = ">= 3.2.1"
     }
 
     oci = {
       configuration_aliases = [oci.home]
       source                = "oracle/oci"
-      version               = "~> 4.115.0"
+      version               = ">= 4.115.0"
     }
 
     random = {
       source  = "hashicorp/random"
-      version = "~> 3.4.3"
+      version = ">= 3.4.3"
     }
 
     time = {
       source  = "hashicorp/time"
-      version = "~> 0.9.1"
+      version = ">= 0.9.1"
     }
   }
 }


### PR DESCRIPTION
Fix in main (4.x): https://github.com/oracle-terraform-modules/terraform-oci-oke/commit/eedebc047a4747ba89a443830ed7be80fa9f90e0 and other.