### PR TITLE
fix: 5.x TF 1.3, subnet/NSG objects, NSG/image preconditions, unrequired VCN

### DIFF
--- a/examples/vars-bastion.auto.tfvars
+++ b/examples/vars-bastion.auto.tfvars
@@ -4,7 +4,7 @@
 # All configuration for bastion sub-module w/ defaults
 
 create_bastion              = true           # *true/false
-bastion_allowed_cidrs       = ["0.0.0.0/0"]  # e.g. "0.0.0.0/0" for all
+bastion_allowed_cidrs       = []             # e.g. ["0.0.0.0/0"] to allow traffic from all sources
 bastion_availability_domain = null           # Defaults to first available
 bastion_image_id            = null           # Ignored when bastion_image_type = "platform"
 bastion_image_os            = "Oracle Linux" # Ignored when bastion_image_type = "custom"

--- a/module-bastion.tf
+++ b/module-bastion.tf
@@ -33,12 +33,12 @@ module "bastion" {
   assign_dns          = var.assign_dns
   availability_domain = coalesce(var.bastion_availability_domain, lookup(local.ad_numbers_to_names, local.ad_numbers[0]))
   image_id            = local.bastion_image_id
-  nsg_ids             = concat(var.bastion_nsg_ids, var.create_nsgs ? [module.network.bastion_nsg_id] : [])
+  nsg_ids             = compact(flatten([var.bastion_nsg_ids, [module.network.bastion_nsg_id]]))
   is_public           = var.bastion_is_public
   shape               = var.bastion_shape
   ssh_private_key     = sensitive(local.ssh_private_key) # to await cloud-init completion
   ssh_public_key      = local.ssh_public_key
-  subnet_id           = lookup(module.network.subnet_ids, "bastion", lookup(module.network.subnet_ids, "pub_lb"))
+  subnet_id           = module.network.bastion_subnet_id
   timezone            = var.timezone
   upgrade             = var.bastion_upgrade
   user                = var.bastion_user

--- a/module-cluster.tf
+++ b/module-cluster.tf
@@ -41,13 +41,13 @@ module "cluster" {
   vcn_id                  = local.vcn_id
   cni_type                = var.cni_type
   control_plane_is_public = var.control_plane_is_public
-  control_plane_nsg_ids   = setunion(var.control_plane_nsg_ids, var.create_nsgs ? [module.network.control_plane_nsg_id] : [])
-  control_plane_subnet_id = lookup(module.network.subnet_ids, "cp")
+  control_plane_nsg_ids   = compact(flatten([var.control_plane_nsg_ids, module.network.control_plane_nsg_id]))
+  control_plane_subnet_id = module.network.control_plane_subnet_id
   pods_cidr               = var.pods_cidr
   services_cidr           = var.services_cidr
   service_lb_subnet_id = (var.preferred_load_balancer == "public"
-    ? lookup(module.network.subnet_ids, "pub_lb")
-    : lookup(module.network.subnet_ids, "int_lb")
+    ? module.network.pub_lb_subnet_id
+    : module.network.int_lb_subnet_id
   )
 
   # Cluster

--- a/module-network.tf
+++ b/module-network.tf
@@ -100,8 +100,7 @@ module "network" {
   create_cluster               = var.create_cluster
   create_bastion               = var.create_bastion
   create_fss                   = var.create_fss
-  create_nsgs                  = var.create_nsgs
-  create_nsgs_always           = var.create_nsgs_always
+  nsgs                         = var.nsgs
   create_operator              = local.operator_enabled
   drg_attachments              = var.drg_attachments
   enable_waf                   = var.enable_waf
@@ -133,54 +132,56 @@ output "nat_route_table_id" {
 }
 
 # Subnets
-output "subnet_ids" {
-  description = "Map of subnet ids by role for the cluster and associated resources."
-  value       = module.network.subnet_ids
-}
-output "subnet_cidrs" {
-  description = "Map of provided/calculated subnet CIDR ranges by role for the cluster."
-  value       = module.network.subnet_cidrs
-}
 output "bastion_subnet_id" {
-  value = lookup(module.network.subnet_ids, "bastion", null)
+  value = module.network.bastion_subnet_id
+}
+output "bastion_subnet_cidr" {
+  value = module.network.bastion_subnet_cidr
 }
 output "operator_subnet_id" {
-  value = lookup(module.network.subnet_ids, "operator", null)
+  value = module.network.operator_subnet_id
+}
+output "operator_subnet_cidr" {
+  value = module.network.operator_subnet_cidr
 }
 output "control_plane_subnet_id" {
-  value = lookup(module.network.subnet_ids, "cp", null)
+  value = module.network.control_plane_subnet_id
+}
+output "control_plane_subnet_cidr" {
+  value = module.network.control_plane_subnet_cidr
 }
 output "worker_subnet_id" {
-  value = lookup(module.network.subnet_ids, "workers", null)
+  value = module.network.worker_subnet_id
+}
+output "worker_subnet_cidr" {
+  value = module.network.worker_subnet_cidr
 }
 output "pod_subnet_id" {
-  value = lookup(module.network.subnet_ids, "pods", null)
+  value = module.network.pod_subnet_id
+}
+output "pod_subnet_cidr" {
+  value = module.network.pod_subnet_cidr
 }
 output "int_lb_subnet_id" {
-  value = lookup(module.network.subnet_ids, "int_lb", null)
+  value = module.network.int_lb_subnet_id
+}
+output "int_lb_subnet_cidr" {
+  value = module.network.int_lb_subnet_cidr
 }
 output "pub_lb_subnet_id" {
-  value = lookup(module.network.subnet_ids, "pub_lb", null)
+  value = module.network.pub_lb_subnet_id
+}
+output "pub_lb_subnet_cidr" {
+  value = module.network.pub_lb_subnet_cidr
 }
 output "fss_subnet_id" {
-  value = lookup(module.network.subnet_ids, "fss", null)
+  value = module.network.fss_subnet_id
+}
+output "fss_subnet_cidr" {
+  value = module.network.fss_subnet_cidr
 }
 
 # NSGs
-output "nsg_ids" {
-  description = "Map of network security group IDs by role for the cluster and associated resources."
-  value = var.create_nsgs ? {
-    "bastion"  = module.network.bastion_nsg_id
-    "operator" = module.network.operator_nsg_id
-    "cp"       = module.network.control_plane_nsg_id
-    "int_lb"   = module.network.int_lb_nsg_id
-    "pub_lb"   = module.network.pub_lb_nsg_id
-    "workers"  = module.network.worker_nsg_id
-    "pods"     = module.network.pod_nsg_id
-    "fss"      = module.network.fss_nsg_id
-  } : null
-}
-
 output "bastion_nsg_id" {
   description = "Network Security Group for bastion host(s)."
   value       = module.network.bastion_nsg_id

--- a/module-operator.tf
+++ b/module-operator.tf
@@ -52,12 +52,12 @@ module "operator" {
   install_kubectx       = var.operator_install_kubectx
   kubeconfig            = yamlencode(local.kubeconfig_private)
   kubernetes_version    = var.kubernetes_version
-  nsg_ids               = concat(var.operator_nsg_ids, var.create_nsgs ? [module.network.operator_nsg_id] : [])
+  nsg_ids               = compact(flatten([var.operator_nsg_ids, module.network.operator_nsg_id]))
   pv_transit_encryption = var.operator_pv_transit_encryption
   shape                 = var.operator_shape
   ssh_private_key       = sensitive(local.ssh_private_key) # to await cloud-init completion
   ssh_public_key        = local.ssh_public_key
-  subnet_id             = lookup(module.network.subnet_ids, "operator", "")
+  subnet_id             = module.network.operator_subnet_id
   timezone              = var.timezone
   upgrade               = var.operator_upgrade
   user                  = var.operator_user

--- a/module-workers.tf
+++ b/module-workers.tf
@@ -58,20 +58,20 @@ module "workers" {
   node_labels                = var.worker_node_labels
   node_metadata              = var.worker_node_metadata
   pod_nsg_ids                = concat(var.pod_nsg_ids, var.cni_type == "npn" ? [module.network.pod_nsg_id] : [])
-  pod_subnet_id              = lookup(module.network.subnet_ids, "pods", "")
+  pod_subnet_id              = module.network.pod_subnet_id
   pv_transit_encryption      = var.worker_pv_transit_encryption
   shape                      = var.worker_shape
   ssh_public_key             = local.ssh_public_key
   timezone                   = var.timezone
   volume_kms_key_id          = var.worker_volume_kms_key_id
   worker_nsg_ids             = concat(var.worker_nsg_ids, [module.network.worker_nsg_id])
-  worker_subnet_id           = lookup(module.network.subnet_ids, "workers", "")
+  worker_subnet_id           = module.network.worker_subnet_id
   preemptible_config         = var.worker_preemptible_config
 
   # FSS
   create_fss              = var.create_fss
   fss_availability_domain = coalesce(var.fss_availability_domain, local.ad_numbers_to_names[1])
-  fss_subnet_id           = lookup(module.network.subnet_ids, "fss", "")
+  fss_subnet_id           = module.network.fss_subnet_id
   fss_nsg_ids             = var.fss_nsg_ids
   fss_mount_path          = var.fss_mount_path
   fss_max_fs_stat_bytes   = var.fss_max_fs_stat_bytes

--- a/modules/network/nsg-bastion.tf
+++ b/modules/network/nsg-bastion.tf
@@ -10,7 +10,8 @@ locals {
       var.create_cluster, var.create_bastion,
     ]),
   ])
-  bastion_nsg_id = one(oci_core_network_security_group.bastion[*].id)
+  # Return provided NSG when configured with an existing ID or created resource ID
+  bastion_nsg_id = one(compact([try(var.nsgs.bastion.id, null), one(oci_core_network_security_group.bastion[*].id)]))
   bastion_rules = local.bastion_nsg_enabled ? merge(
     { for cidr in var.bastion_allowed_cidrs :
       "Allow SSH ingress to bastion from ${cidr}" => {

--- a/modules/network/nsg-bastion.tf
+++ b/modules/network/nsg-bastion.tf
@@ -7,6 +7,7 @@ locals {
     lookup(local.bastion_nsg_config, "create", "auto") == "always",
     alltrue([
       lookup(local.bastion_nsg_config, "create", "auto") == "auto",
+      !contains(keys(local.bastion_nsg_config), "id"),
       var.create_cluster, var.create_bastion,
     ]),
   ])

--- a/modules/network/nsg-bastion.tf
+++ b/modules/network/nsg-bastion.tf
@@ -2,7 +2,7 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl
 
 locals {
-  bastion_nsg_enabled = (var.create_nsgs && var.create_bastion) || var.create_nsgs_always
+  bastion_nsg_enabled = (var.vcn_id != null && var.create_nsgs && var.create_bastion) || var.create_nsgs_always
   bastion_nsg_id      = one(oci_core_network_security_group.bastion[*].id)
   bastion_rules = (var.create_nsgs && var.create_bastion) || var.create_nsgs_always ? merge(
     { for cidr in var.bastion_allowed_cidrs :

--- a/modules/network/nsg-controlplane.tf
+++ b/modules/network/nsg-controlplane.tf
@@ -10,7 +10,8 @@ locals {
       var.create_cluster,
     ]),
   ])
-  control_plane_nsg_id = one(oci_core_network_security_group.cp[*].id)
+  # Return provided NSG when configured with an existing ID or created resource ID
+  control_plane_nsg_id = one(compact([try(var.nsgs.cp.id, null), one(oci_core_network_security_group.cp[*].id)]))
   control_plane_rules = local.control_plane_nsg_enabled ? merge(
     {
       "Allow TCP egress from OKE control plane to OCI services" : {

--- a/modules/network/nsg-controlplane.tf
+++ b/modules/network/nsg-controlplane.tf
@@ -2,9 +2,9 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl
 
 locals {
-  control_plane_nsg_enabled = (var.create_nsgs && var.create_cluster) || var.create_nsgs_always
+  control_plane_nsg_enabled = (var.vcn_id != null && var.create_nsgs && var.create_cluster) || var.create_nsgs_always
   control_plane_nsg_id      = one(oci_core_network_security_group.cp[*].id)
-  control_plane_rules = merge(
+  control_plane_rules = local.control_plane_nsg_enabled ? merge(
     {
       "Allow TCP egress from OKE control plane to OCI services" : {
         protocol = local.tcp_protocol, port = local.all_ports, destination = local.osn, destination_type = local.rule_type_service,
@@ -67,7 +67,7 @@ locals {
         protocol = local.tcp_protocol, port = local.apiserver_port, source = allowed_cidr, source_type = local.rule_type_cidr
       }
     },
-  )
+  ) : {}
 }
 
 resource "oci_core_network_security_group" "cp" {

--- a/modules/network/nsg-controlplane.tf
+++ b/modules/network/nsg-controlplane.tf
@@ -7,6 +7,7 @@ locals {
     lookup(local.control_plane_nsg_config, "create", "auto") == "always",
     alltrue([
       lookup(local.control_plane_nsg_config, "create", "auto") == "auto",
+      !contains(keys(local.control_plane_nsg_config), "id"),
       var.create_cluster,
     ]),
   ])

--- a/modules/network/nsg-fss.tf
+++ b/modules/network/nsg-fss.tf
@@ -2,7 +2,7 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl
 
 locals {
-  fss_nsg_enabled = (var.create_nsgs && var.create_fss) || var.create_nsgs_always
+  fss_nsg_enabled = (var.vcn_id != null && var.create_nsgs && var.create_fss) || var.create_nsgs_always
   fss_nsg_id      = one(oci_core_network_security_group.fss[*].id)
   fss_rules = local.fss_nsg_enabled ? {
     # See https://docs.oracle.com/en-us/iaas/Content/File/Tasks/securitylistsfilestorage.htm

--- a/modules/network/nsg-fss.tf
+++ b/modules/network/nsg-fss.tf
@@ -7,6 +7,7 @@ locals {
     lookup(local.operator_nsg_config, "create", "auto") == "always",
     alltrue([
       lookup(local.operator_nsg_config, "create", "auto") == "auto",
+      !contains(keys(local.operator_nsg_config), "id"),
       var.create_cluster, var.create_fss,
     ]),
   ])

--- a/modules/network/nsg-fss.tf
+++ b/modules/network/nsg-fss.tf
@@ -10,7 +10,8 @@ locals {
       var.create_cluster, var.create_fss,
     ]),
   ])
-  fss_nsg_id = one(oci_core_network_security_group.fss[*].id)
+  # Return provided NSG when configured with an existing ID or created resource ID
+  fss_nsg_id = one(compact([try(var.nsgs.fss.id, null), one(oci_core_network_security_group.fss[*].id)]))
   fss_rules = local.fss_nsg_enabled ? {
     # See https://docs.oracle.com/en-us/iaas/Content/File/Tasks/securitylistsfilestorage.htm
     # Ingress

--- a/modules/network/nsg-loadbalancers-int.tf
+++ b/modules/network/nsg-loadbalancers-int.tf
@@ -3,7 +3,7 @@
 
 locals {
   int_lb_nsg_enabled = alltrue([
-    var.create_cluster, var.create_nsgs,
+    var.vcn_id != null, var.create_cluster, var.create_nsgs,
     var.load_balancers == "internal" || var.load_balancers == "both",
   ]) || var.create_nsgs_always
   int_lb_nsg_id = one(oci_core_network_security_group.int_lb[*].id)

--- a/modules/network/nsg-loadbalancers-int.tf
+++ b/modules/network/nsg-loadbalancers-int.tf
@@ -10,7 +10,8 @@ locals {
       var.create_cluster, var.load_balancers == "internal" || var.load_balancers == "both",
     ]),
   ])
-  int_lb_nsg_id = one(oci_core_network_security_group.int_lb[*].id)
+  # Return provided NSG when configured with an existing ID or created resource ID
+  int_lb_nsg_id = one(compact([try(var.nsgs.int_lb.id, null), one(oci_core_network_security_group.int_lb[*].id)]))
   int_lb_rules = local.int_lb_nsg_enabled ? merge(
     {
       "Allow TCP egress from internal load balancers to workers for Node Ports" : {

--- a/modules/network/nsg-loadbalancers-int.tf
+++ b/modules/network/nsg-loadbalancers-int.tf
@@ -7,6 +7,7 @@ locals {
     lookup(local.int_lb_nsg_config, "create", "auto") == "always",
     alltrue([
       lookup(local.int_lb_nsg_config, "create", "auto") == "auto",
+      !contains(keys(local.int_lb_nsg_config), "id"),
       var.create_cluster, var.load_balancers == "internal" || var.load_balancers == "both",
     ]),
   ])

--- a/modules/network/nsg-loadbalancers-pub.tf
+++ b/modules/network/nsg-loadbalancers-pub.tf
@@ -3,7 +3,7 @@
 
 locals {
   pub_lb_nsg_enabled = alltrue([
-    var.create_cluster, var.create_nsgs,
+    var.vcn_id != null, var.create_cluster, var.create_nsgs,
     var.load_balancers == "public" || var.load_balancers == "both",
   ]) || var.create_nsgs_always
   pub_lb_nsg_id = one(oci_core_network_security_group.pub_lb[*].id)

--- a/modules/network/nsg-loadbalancers-pub.tf
+++ b/modules/network/nsg-loadbalancers-pub.tf
@@ -10,7 +10,8 @@ locals {
       var.create_cluster, var.load_balancers == "public" || var.load_balancers == "both",
     ]),
   ])
-  pub_lb_nsg_id = one(oci_core_network_security_group.pub_lb[*].id)
+  # Return provided NSG when configured with an existing ID or created resource ID
+  pub_lb_nsg_id = one(compact([try(var.nsgs.pub_lb.id, null), one(oci_core_network_security_group.pub_lb[*].id)]))
   pub_lb_rules = local.pub_lb_nsg_enabled ? merge(
     {
       "Allow TCP egress from public load balancers to workers nodes for NodePort traffic" : {

--- a/modules/network/nsg-loadbalancers-pub.tf
+++ b/modules/network/nsg-loadbalancers-pub.tf
@@ -7,6 +7,7 @@ locals {
     lookup(local.pub_lb_nsg_config, "create", "auto") == "always",
     alltrue([
       lookup(local.pub_lb_nsg_config, "create", "auto") == "auto",
+      !contains(keys(local.pub_lb_nsg_config), "id"),
       var.create_cluster, var.load_balancers == "public" || var.load_balancers == "both",
     ]),
   ])

--- a/modules/network/nsg-operator.tf
+++ b/modules/network/nsg-operator.tf
@@ -10,7 +10,8 @@ locals {
       var.create_cluster, var.create_operator,
     ]),
   ])
-  operator_nsg_id = one(oci_core_network_security_group.operator[*].id)
+  # Return provided NSG when configured with an existing ID or created resource ID
+  operator_nsg_id = one(compact([try(var.nsgs.operator.id, null), one(oci_core_network_security_group.operator[*].id)]))
   operator_rules = local.operator_nsg_enabled ? merge(
     {
       "Allow TCP egress from operator to OCI services" : {

--- a/modules/network/nsg-operator.tf
+++ b/modules/network/nsg-operator.tf
@@ -7,6 +7,7 @@ locals {
     lookup(local.operator_nsg_config, "create", "auto") == "always",
     alltrue([
       lookup(local.operator_nsg_config, "create", "auto") == "auto",
+      !contains(keys(local.operator_nsg_config), "id"),
       var.create_cluster, var.create_operator,
     ]),
   ])

--- a/modules/network/nsg-pods.tf
+++ b/modules/network/nsg-pods.tf
@@ -7,6 +7,7 @@ locals {
     lookup(local.pod_nsg_config, "create", "auto") == "always",
     alltrue([
       lookup(local.pod_nsg_config, "create", "auto") == "auto",
+      !contains(keys(local.pod_nsg_config), "id"),
       var.create_cluster, var.cni_type == "npn",
     ]),
   ])

--- a/modules/network/nsg-pods.tf
+++ b/modules/network/nsg-pods.tf
@@ -2,7 +2,7 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl
 
 locals {
-  pod_nsg_enabled = (var.cni_type == "npn" && var.create_nsgs && var.create_cluster) || var.create_nsgs_always
+  pod_nsg_enabled = (var.vcn_id != null && var.cni_type == "npn" && var.create_nsgs && var.create_cluster) || var.create_nsgs_always
   pod_nsg_id      = one(oci_core_network_security_group.pods[*].id)
   pods_rules = local.pod_nsg_enabled ? merge(
     {

--- a/modules/network/nsg-pods.tf
+++ b/modules/network/nsg-pods.tf
@@ -10,7 +10,8 @@ locals {
       var.create_cluster, var.cni_type == "npn",
     ]),
   ])
-  pod_nsg_id = one(oci_core_network_security_group.pods[*].id)
+  # Return provided NSG when configured with an existing ID or created resource ID
+  pod_nsg_id = one(compact([try(var.nsgs.pods.id, null), one(oci_core_network_security_group.pods[*].id)]))
   pods_rules = local.pod_nsg_enabled ? merge(
     {
       "Allow TCP egress from pods to OCI Services" : {

--- a/modules/network/nsg-workers.tf
+++ b/modules/network/nsg-workers.tf
@@ -10,7 +10,8 @@ locals {
       var.create_cluster,
     ]),
   ])
-  worker_nsg_id = one(oci_core_network_security_group.workers[*].id)
+  # Return provided NSG when configured with an existing ID or created resource ID
+  worker_nsg_id = one(compact([try(var.nsgs.workers.id, null), one(oci_core_network_security_group.workers[*].id)]))
   workers_rules = local.worker_nsg_enabled ? merge(
     {
       "Allow TCP egress from workers to OCI Services" : {

--- a/modules/network/nsg-workers.tf
+++ b/modules/network/nsg-workers.tf
@@ -7,6 +7,7 @@ locals {
     lookup(local.worker_nsg_config, "create", "auto") == "always",
     alltrue([
       lookup(local.worker_nsg_config, "create", "auto") == "auto",
+      !contains(keys(local.worker_nsg_config), "id"),
       var.create_cluster,
     ]),
   ])

--- a/modules/network/nsg-workers.tf
+++ b/modules/network/nsg-workers.tf
@@ -2,7 +2,7 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl
 
 locals {
-  worker_nsg_enabled = (var.create_nsgs && var.create_cluster) || var.create_nsgs_always
+  worker_nsg_enabled = (var.vcn_id != null && var.create_nsgs && var.create_cluster) || var.create_nsgs_always
   worker_nsg_id      = one(oci_core_network_security_group.workers[*].id)
   workers_rules = local.worker_nsg_enabled ? merge(
     {

--- a/modules/network/rules.tf
+++ b/modules/network/rules.tf
@@ -27,7 +27,7 @@ locals {
       source_type               = lookup(y, "source_type", null)
       destination               = lookup(y, "destination", null)
       destination_type          = lookup(y, "destination_type", null)
-  }) if var.create_nsgs }
+  }) }
 
   # Dynamic map of all NSG IDs for enabled NSGs
   all_nsg_ids = { for x, y in merge(
@@ -39,7 +39,7 @@ locals {
     local.pod_nsg_enabled ? { "pods" = local.pod_nsg_id } : {},
     local.operator_nsg_enabled ? { "operator" = local.operator_nsg_id } : {},
     local.fss_nsg_enabled ? { "fss" = local.fss_nsg_id } : {},
-  ) : x => y if var.create_nsgs }
+  ) : x => y }
 }
 
 resource "oci_core_network_security_group_security_rule" "oke" {

--- a/modules/network/variables.tf
+++ b/modules/network/variables.tf
@@ -28,15 +28,30 @@ variable "control_plane_is_public" { type = bool }
 variable "create_cluster" { type = bool }
 variable "create_bastion" { type = bool }
 variable "create_fss" { type = bool }
-variable "create_nsgs" { type = bool }
-variable "create_nsgs_always" { type = bool }
 variable "create_operator" { type = bool }
 variable "drg_attachments" { type = any }
 variable "enable_waf" { type = bool }
 variable "ig_route_table_id" { type = string }
 variable "load_balancers" { type = string }
 variable "nat_route_table_id" { type = string }
-variable "subnets" { type = any }
 variable "vcn_cidrs" { type = list(string) }
 variable "vcn_id" { type = string }
 variable "worker_is_public" { type = bool }
+
+variable "subnets" {
+  type = map(object({
+    create    = optional(string)
+    id        = optional(string)
+    newbits   = optional(string)
+    netnum    = optional(string)
+    cidr      = optional(string)
+    dns_label = optional(string)
+  }))
+}
+
+variable "nsgs" {
+  type = map(object({
+    create = optional(string)
+    id     = optional(string)
+  }))
+}

--- a/modules/workers/instance.tf
+++ b/modules/workers/instance.tf
@@ -66,6 +66,16 @@ resource "oci_core_instance" "workers" {
   }
 
   lifecycle {
+    precondition {
+      condition     = coalesce(each.value.image_id, "none") != "none"
+      error_message = <<-EOT
+      Missing image_id; check provided value if image_type is 'custom', or image_os/image_os_version if image_type is 'oke' or 'platform'.
+        pool: ${each.key}
+        image_type: ${coalesce(each.value.image_type, "none")}
+        image_id: ${coalesce(each.value.image_id, "none")}
+      EOT
+    }
+
     ignore_changes = [
       defined_tags, freeform_tags, display_name,
       metadata["cluster_ca_cert"], metadata["user_data"],

--- a/modules/workers/instancepools.tf
+++ b/modules/workers/instancepools.tf
@@ -39,7 +39,12 @@ resource "oci_core_instance_pool" "workers" {
 
     precondition {
       condition     = coalesce(each.value.image_id, "none") != "none"
-      error_message = "Missing image_id for pool ${each.key}. Check provided value for image_id if image_type is 'custom', or image_os/image_os_version if image_type is 'oke' or 'platform'."
+      error_message = <<-EOT
+      Missing image_id; check provided value if image_type is 'custom', or image_os/image_os_version if image_type is 'oke' or 'platform'.
+        pool: ${each.key}
+        image_type: ${coalesce(each.value.image_type, "none")}
+        image_id: ${coalesce(each.value.image_id, "none")}
+      EOT
     }
 
     precondition {

--- a/modules/workers/nodepools.tf
+++ b/modules/workers/nodepools.tf
@@ -102,7 +102,12 @@ resource "oci_containerengine_node_pool" "workers" {
 
     precondition {
       condition     = coalesce(each.value.image_id, "none") != "none"
-      error_message = "Missing image_id for pool ${each.key}. Check provided value for image_id if image_type is 'custom', or image_os/image_os_version if image_type is 'oke' or 'platform'."
+      error_message = <<-EOT
+      Missing image_id; check provided value if image_type is 'custom', or image_os/image_os_version if image_type is 'oke' or 'platform'.
+        pool: ${each.key}
+        image_type: ${coalesce(each.value.image_type, "none")}
+        image_id: ${coalesce(each.value.image_id, "none")}
+      EOT
     }
 
     precondition {

--- a/modules/workers/nodepools.tf
+++ b/modules/workers/nodepools.tf
@@ -53,8 +53,8 @@ resource "oci_containerengine_node_pool" "workers" {
       content { # VCN-Native requires max pods/node, nsg ids, subnet ids
         cni_type          = "OCI_VCN_IP_NATIVE"
         max_pods_per_node = min(max(var.max_pods_per_node, 1), 110)
-        pod_nsg_ids    = compact(tolist(each.value.pod_nsg_ids))
-        pod_subnet_ids = compact(tolist([each.value.pod_subnet_id]))
+        pod_nsg_ids       = compact(tolist(each.value.pod_nsg_ids))
+        pod_subnet_ids    = compact(tolist([each.value.pod_subnet_id]))
       }
     }
   }

--- a/modules/workers/nodepools.tf
+++ b/modules/workers/nodepools.tf
@@ -53,8 +53,7 @@ resource "oci_containerengine_node_pool" "workers" {
       content { # VCN-Native requires max pods/node, nsg ids, subnet ids
         cni_type          = "OCI_VCN_IP_NATIVE"
         max_pods_per_node = min(max(var.max_pods_per_node, 1), 110)
-        # pick the 1st pod nsg here until https://github.com/oracle/terraform-provider-oci/issues/1662 is clarified and resolved
-        pod_nsg_ids    = slice(each.value.pod_nsg_ids, 0, min(1, length(each.value.pod_nsg_ids)))
+        pod_nsg_ids    = compact(tolist(each.value.pod_nsg_ids))
         pod_subnet_ids = compact(tolist([each.value.pod_subnet_id]))
       }
     }

--- a/variables-bastion.tf
+++ b/variables-bastion.tf
@@ -14,8 +14,8 @@ variable "bastion_public_ip" {
 }
 
 variable "bastion_allowed_cidrs" {
-  default     = ["0.0.0.0/0"]
-  description = "A list of CIDR blocks to allow SSH access to the bastion host."
+  default     = []
+  description = "A list of CIDR blocks to allow SSH access to the bastion host. NOTE: Default is empty i.e. no access permitted. Allow access from anywhere with '0.0.0.0/0'."
   type        = list(string)
 }
 

--- a/variables-cluster.tf
+++ b/variables-cluster.tf
@@ -25,7 +25,7 @@ variable "cluster_type" {
 
 variable "control_plane_is_public" {
   default     = false
-  description = "Whether the Kubernetes control plane endpoint should be allocated a public IP address."
+  description = "Whether the Kubernetes control plane endpoint should be allocated a public IP address to enable access over public internet."
   type        = bool
 }
 
@@ -37,7 +37,7 @@ variable "control_plane_nsg_ids" {
 
 variable "cni_type" {
   default     = "flannel"
-  description = "The CNI for the cluster: 'flannel' or 'npn'. See https://docs.oracle.com/en-us/iaas/Content/ContEng/Concepts/contengpodnetworking.htm."
+  description = "The CNI for the cluster: 'flannel' or 'npn'. See <a href=https://docs.oracle.com/en-us/iaas/Content/ContEng/Concepts/contengpodnetworking.htm>Pod Networking</a>."
   type        = string
   validation {
     condition     = contains(["flannel", "npn"], var.cni_type)
@@ -82,7 +82,7 @@ variable "image_signing_keys" {
 }
 
 variable "load_balancers" {
-  default     = "public"
+  default     = "both"
   description = "The type of subnets to create for load balancers."
   type        = string
   validation {
@@ -92,10 +92,8 @@ variable "load_balancers" {
 }
 
 variable "preferred_load_balancer" {
-  # values: public, internal.
-  # When creating an internal load balancer, the internal annotation must still be specified regardless
   default     = "public"
-  description = "The preferred load balancer subnets that OKE will automatically choose when creating a load balancer. valid values are public or internal. if 'public' is chosen, the value for load_balancers must be either 'public' or 'both'. If 'private' is chosen, the value for load_balancers must be either 'internal' or 'both'."
+  description = "The preferred load balancer subnets that OKE will automatically choose when creating a load balancer. Valid values are 'public' or 'internal'. If 'public' is chosen, the value for load_balancers must be either 'public' or 'both'. If 'private' is chosen, the value for load_balancers must be either 'internal' or 'both'. NOTE: Service annotations for internal load balancers must still be specified regardless of this setting. See <a href=https://github.com/oracle/oci-cloud-controller-manager/blob/master/docs/load-balancer-annotations.md>Load Balancer Annotations</a> for more information."
   type        = string
   validation {
     condition     = contains(["public", "internal"], var.preferred_load_balancer)

--- a/variables-cluster.tf
+++ b/variables-cluster.tf
@@ -24,7 +24,7 @@ variable "cluster_type" {
 }
 
 variable "control_plane_is_public" {
-  default     = true
+  default     = false
   description = "Whether the Kubernetes control plane endpoint should be allocated a public IP address."
   type        = bool
 }

--- a/variables-network.tf
+++ b/variables-network.tf
@@ -147,14 +147,14 @@ variable "subnets" {
 
 variable "nsgs" {
   default = {
-    bastion  = { }
-    operator = { }
-    cp       = { }
-    int_lb   = { }
-    pub_lb   = { }
-    workers  = { }
-    pods     = { }
-    fss      = { }
+    bastion  = {}
+    operator = {}
+    cp       = {}
+    int_lb   = {}
+    pub_lb   = {}
+    workers  = {}
+    pods     = {}
+    fss      = {}
   }
   description = "Configuration for standard network security groups (NSGs).  The 'create' parameter of each entry defaults to 'auto', creating NSGs when other enabled components are expected to utilize them, and may be configured with 'never' or 'always' to force disabled/enabled."
   type = map(object({

--- a/variables-workers.tf
+++ b/variables-workers.tf
@@ -163,9 +163,9 @@ variable "worker_cloud_init" {
 }
 
 variable "worker_disable_default_cloud_init" {
-  default = false
+  default     = false
   description = "Whether to disable the default OKE cloud init and only use the cloud init explicitly passed to the worker pool in 'worker_cloud_init'."
-  type = bool
+  type        = bool
 }
 
 variable "worker_volume_kms_key_id" {

--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl
 
 terraform {
-  required_version = ">= 1.2.0"
+  required_version = ">= 1.3.0"
 
   required_providers {
     cloudinit = {


### PR DESCRIPTION
* Add preconditions for better error messaging with image/NSGs configuration issues.
* Support `create_vcn = false` and undefined `vcn_id` for workers with an existing cluster and subnets, where VCN information is not needed.
* Provide `pod_subnet_ids` as list when `var.cni_type == "npn"` - resolves #682.

Example - worker pool with existing subnet and cluster:
```
cluster_id         = "ocid1.cluster..."
create_cluster     = false
create_bastion     = false
create_nsgs        = false
create_vcn         = false
create_operator    = false
create_nsgs_always = false

worker_pools = {
  np1 = { size = 1 },
}

subnets = {
  workers = { id = "ocid1.subnet..." }
}
```

Before:
```
│ Error: Missing required argument
│ 
│   with data.oci_core_vcn.oke[0],
│   on module-network.tf line 6, in data "oci_core_vcn" "oke":
│    6:   vcn_id = var.vcn_id
│ 
│ The argument "vcn_id" is required, but no definition was found.
```

After:
```
Plan: 2 to add, 0 to change, 0 to destroy.

Changes to Outputs:
...
  + state_id               = (known after apply)
  + subnet_ids             = {
      + workers = "ocid1.subnet..."
    }
  + worker_pool_ids        = {
      + np1 = (known after apply)
    }
  + worker_subnet_id       = "ocid1.subnet..."
```