### PR TITLE
fix: 5.x Merge redundant shape results for `platform_config` `type` lookup

### DIFF
--- a/modules/workers/data-shapes.tf
+++ b/modules/workers/data-shapes.tf
@@ -7,12 +7,14 @@ data "oci_core_shapes" "oke" {
 
 locals {
   shapes_by_name = {
+    # Group by shape name, yielding a list of objects for each
     for shape in data.oci_core_shapes.oke.shapes :
-    lookup(shape, "name") => shape if contains(keys(shape), "name")
+    lookup(shape, "name") => shape... if contains(keys(shape), "name")
   }
 
   platform_config_by_shape = {
+    # Merge objects for each shape; we only need the consistent 'type'
     for k, v in local.shapes_by_name :
-    k => merge(lookup(v, "platform_config_options", [])...)
+    k => merge(lookup(merge(v...), "platform_config_options", [])...)
   }
 }

--- a/modules/workers/instance.tf
+++ b/modules/workers/instance.tf
@@ -6,8 +6,9 @@ resource "oci_core_instance" "workers" {
   preserve_boot_volume = false
   shape                = each.value.shape
 
-  defined_tags  = each.value.defined_tags
-  freeform_tags = each.value.freeform_tags
+  defined_tags      = each.value.defined_tags
+  freeform_tags     = each.value.freeform_tags
+  extended_metadata = each.value.extended_metadata
 
   dynamic "shape_config" {
     for_each = length(regexall("Flex", each.value.shape)) > 0 ? [1] : []
@@ -100,7 +101,7 @@ resource "oci_core_instance" "workers" {
     }
 
     ignore_changes = [
-      defined_tags, freeform_tags, display_name, extended_metadata,
+      defined_tags, freeform_tags, display_name,
       metadata["cluster_ca_cert"], metadata["user_data"],
       create_vnic_details[0].defined_tags,
       create_vnic_details[0].freeform_tags,

--- a/modules/workers/instanceconfig.tf
+++ b/modules/workers/instanceconfig.tf
@@ -17,6 +17,7 @@ resource "oci_core_instance_configuration" "workers" {
       compartment_id      = each.value.compartment_id
       defined_tags        = each.value.defined_tags
       freeform_tags       = each.value.freeform_tags
+      extended_metadata   = each.value.extended_metadata
 
       instance_options {
         are_legacy_imds_endpoints_disabled = false
@@ -142,7 +143,6 @@ resource "oci_core_instance_configuration" "workers" {
     ignore_changes = [
       defined_tags, freeform_tags, display_name,
       instance_details[0].launch_details[0].metadata,
-      instance_details[0].launch_details[0].extended_metadata,
       instance_details[0].launch_details[0].defined_tags,
       instance_details[0].launch_details[0].freeform_tags,
       instance_details[0].launch_details[0].create_vnic_details[0].defined_tags,


### PR DESCRIPTION
* Resolve errors caused by multiple results for a given shape, e.g. in multi-AD regions. The fields that might differ between these aren't used for our purpose.
* Remove previously added lifecycle ignore for `extended_metadata` in favor of `{}` default or optional pool configuration, to mitigate cosmetic differences reported on subsequent apply.
```
 Error: Duplicate object key
│
│   on .terraform/modules/oci_workers/modules/workers/data-shapes.tf line 11, in locals:
│    9:   shapes_by_name = {
│   10:     for shape in data.oci_core_shapes.oke.shapes :
│   11:     lookup(shape, "name") => shape if contains(keys(shape), "name")
│   12:   }
│
│ Two different items produced the key "VM.Standard.x86.Generic" in this 'for' expression. If duplicates are expected, use the ellipsis
│ (...) after the value expression to enable grouping by key.
```