### PR TITLE
fix: Include empty default for pool extended_metadata

### DIFF
--- a/modules/workers/locals.tf
+++ b/modules/workers/locals.tf
@@ -20,6 +20,7 @@ locals {
     compartment_id             = var.compartment_id
     create                     = true
     drain                      = false
+    extended_metadata          = {} # empty pool-specific default
     image_id                   = var.image_id
     image_type                 = var.image_type
     memory                     = local.memory


### PR DESCRIPTION
Add default value for `extended_metadata` used by pools.