### PR TITLE
fix: 5.x Safe handling of null values in strings on missing/destroy

### DIFF
--- a/data-images.tf
+++ b/data-images.tf
@@ -40,6 +40,6 @@ locals {
     }, {
     # Include groups for OS name and major version
     # https://developer.hashicorp.com/terraform/language/expressions/for#grouping-results
-    for k, v in local.parsed_images : "${v.os} ${split(".", v.os_version)[0]}" => k...
+    for k, v in local.parsed_images : format("%v %v", v.os, split(".", v.os_version)[0]) => k...
   })
 }

--- a/examples/oke-workers/main.tf
+++ b/examples/oke-workers/main.tf
@@ -75,7 +75,7 @@ module "oke" {
   }
 
   worker_pools = {
-    "${var.worker_pool_name}" = {
+    format("%v", var.worker_pool_name) = {
       description = lookup({
         "Node Pool"       = "OKE-managed Node Pool"
         "Instances"       = "Self-managed Instances"

--- a/module-bastion.tf
+++ b/module-bastion.tf
@@ -33,12 +33,12 @@ module "bastion" {
   assign_dns          = var.assign_dns
   availability_domain = coalesce(var.bastion_availability_domain, lookup(local.ad_numbers_to_names, local.ad_numbers[0]))
   image_id            = local.bastion_image_id
-  nsg_ids             = compact(flatten([var.bastion_nsg_ids, [module.network.bastion_nsg_id]]))
+  nsg_ids             = compact(flatten([var.bastion_nsg_ids, [try(module.network.bastion_nsg_id, null)]]))
   is_public           = var.bastion_is_public
   shape               = var.bastion_shape
   ssh_private_key     = sensitive(local.ssh_private_key) # to await cloud-init completion
   ssh_public_key      = local.ssh_public_key
-  subnet_id           = module.network.bastion_subnet_id
+  subnet_id           = try(module.network.bastion_subnet_id, "") # safe destroy; validated in submodule
   timezone            = var.timezone
   upgrade             = var.bastion_upgrade
   user                = var.bastion_user

--- a/module-cluster.tf
+++ b/module-cluster.tf
@@ -41,13 +41,13 @@ module "cluster" {
   vcn_id                  = local.vcn_id
   cni_type                = var.cni_type
   control_plane_is_public = var.control_plane_is_public
-  control_plane_nsg_ids   = compact(flatten([var.control_plane_nsg_ids, module.network.control_plane_nsg_id]))
-  control_plane_subnet_id = module.network.control_plane_subnet_id
+  control_plane_nsg_ids   = compact(flatten([var.control_plane_nsg_ids, try(module.network.control_plane_nsg_id, null)]))
+  control_plane_subnet_id = try(module.network.control_plane_subnet_id, "") # safe destroy; validated in submodule
   pods_cidr               = var.pods_cidr
   services_cidr           = var.services_cidr
   service_lb_subnet_id = (var.preferred_load_balancer == "public"
-    ? module.network.pub_lb_subnet_id
-    : module.network.int_lb_subnet_id
+    ? try(module.network.pub_lb_subnet_id, "") # safe destroy; validated in submodule
+    : try(module.network.int_lb_subnet_id, "")
   )
 
   # Cluster

--- a/module-network.tf
+++ b/module-network.tf
@@ -120,107 +120,107 @@ module "network" {
 # VCN
 output "vcn_id" {
   description = "VCN ID"
-  value       = local.vcn_id
+  value       = try(local.vcn_id, null)
 }
 output "ig_route_table_id" {
   description = "Internet gateway route table ID"
-  value       = local.ig_route_table_id
+  value       = try(local.ig_route_table_id, null)
 }
 output "nat_route_table_id" {
   description = "NAT gateway route table ID"
-  value       = local.nat_route_table_id
+  value       = try(local.nat_route_table_id, null)
 }
 
 # Subnets
 output "bastion_subnet_id" {
-  value = module.network.bastion_subnet_id
+  value = try(module.network.bastion_subnet_id, null)
 }
 output "bastion_subnet_cidr" {
-  value = module.network.bastion_subnet_cidr
+  value = try(module.network.bastion_subnet_cidr, null)
 }
 output "operator_subnet_id" {
-  value = module.network.operator_subnet_id
+  value = try(module.network.operator_subnet_id, null)
 }
 output "operator_subnet_cidr" {
-  value = module.network.operator_subnet_cidr
+  value = try(module.network.operator_subnet_cidr, null)
 }
 output "control_plane_subnet_id" {
-  value = module.network.control_plane_subnet_id
+  value = try(module.network.control_plane_subnet_id, null)
 }
 output "control_plane_subnet_cidr" {
-  value = module.network.control_plane_subnet_cidr
+  value = try(module.network.control_plane_subnet_cidr, null)
 }
 output "worker_subnet_id" {
-  value = module.network.worker_subnet_id
+  value = try(module.network.worker_subnet_id, null)
 }
 output "worker_subnet_cidr" {
-  value = module.network.worker_subnet_cidr
+  value = try(module.network.worker_subnet_cidr, null)
 }
 output "pod_subnet_id" {
-  value = module.network.pod_subnet_id
+  value = try(module.network.pod_subnet_id, null)
 }
 output "pod_subnet_cidr" {
-  value = module.network.pod_subnet_cidr
+  value = try(module.network.pod_subnet_cidr, null)
 }
 output "int_lb_subnet_id" {
-  value = module.network.int_lb_subnet_id
+  value = try(module.network.int_lb_subnet_id, null)
 }
 output "int_lb_subnet_cidr" {
-  value = module.network.int_lb_subnet_cidr
+  value = try(module.network.int_lb_subnet_cidr, null)
 }
 output "pub_lb_subnet_id" {
-  value = module.network.pub_lb_subnet_id
+  value = try(module.network.pub_lb_subnet_id, null)
 }
 output "pub_lb_subnet_cidr" {
-  value = module.network.pub_lb_subnet_cidr
+  value = try(module.network.pub_lb_subnet_cidr, null)
 }
 output "fss_subnet_id" {
-  value = module.network.fss_subnet_id
+  value = try(module.network.fss_subnet_id, null)
 }
 output "fss_subnet_cidr" {
-  value = module.network.fss_subnet_cidr
+  value = try(module.network.fss_subnet_cidr, null)
 }
 
 # NSGs
 output "bastion_nsg_id" {
   description = "Network Security Group for bastion host(s)."
-  value       = module.network.bastion_nsg_id
+  value       = try(module.network.bastion_nsg_id, null)
 }
 output "operator_nsg_id" {
   description = "Network Security Group for operator host(s)."
-  value       = module.network.operator_nsg_id
+  value       = try(module.network.operator_nsg_id, null)
 }
 output "control_plane_nsg_id" {
   description = "Network Security Group for Kubernetes control plane(s)."
-  value       = module.network.control_plane_nsg_id
+  value       = try(module.network.control_plane_nsg_id, null)
 }
 output "int_lb_nsg_id" {
   description = "Network Security Group for internal load balancers."
-  value       = module.network.int_lb_nsg_id
+  value       = try(module.network.int_lb_nsg_id, null)
 }
 output "pub_lb_nsg_id" {
   description = "Network Security Group for public load balancers."
-  value       = module.network.pub_lb_nsg_id
+  value       = try(module.network.pub_lb_nsg_id, null)
 }
 output "worker_nsg_id" {
   description = "Network Security Group for worker nodes."
-  value       = module.network.worker_nsg_id
+  value       = try(module.network.worker_nsg_id, null)
 }
 output "pod_nsg_id" {
   description = "Network Security Group for pods."
-  value       = module.network.pod_nsg_id
+  value       = try(module.network.pod_nsg_id, null)
 }
 output "fss_nsg_id" {
   description = "Network Security Group for File Storage Service resources."
-  value       = module.network.fss_nsg_id
+  value       = try(module.network.fss_nsg_id, null)
 }
 
 output "network_security_rules" {
-  value = var.output_detail ? module.network.network_security_rules : null
+  value = var.output_detail ? try(module.network.network_security_rules, null) : null
 }
 
 # DRG
 output "drg_id" {
   description = "Dynamic routing gateway ID"
-  value       = one(module.drg[*].drg_id)
+  value       = try(one(module.drg[*].drg_id), null)
 }

--- a/module-operator.tf
+++ b/module-operator.tf
@@ -52,12 +52,12 @@ module "operator" {
   install_kubectx       = var.operator_install_kubectx
   kubeconfig            = yamlencode(local.kubeconfig_private)
   kubernetes_version    = var.kubernetes_version
-  nsg_ids               = compact(flatten([var.operator_nsg_ids, module.network.operator_nsg_id]))
+  nsg_ids               = compact(flatten([var.operator_nsg_ids, try(module.network.operator_nsg_id, null)]))
   pv_transit_encryption = var.operator_pv_transit_encryption
   shape                 = var.operator_shape
   ssh_private_key       = sensitive(local.ssh_private_key) # to await cloud-init completion
   ssh_public_key        = local.ssh_public_key
-  subnet_id             = module.network.operator_subnet_id
+  subnet_id             = try(module.network.operator_subnet_id, "") # safe destroy; validated in submodule
   timezone              = var.timezone
   upgrade               = var.operator_upgrade
   user                  = var.operator_user

--- a/module-workers.tf
+++ b/module-workers.tf
@@ -58,21 +58,21 @@ module "workers" {
   node_labels                = var.worker_node_labels
   node_metadata              = var.worker_node_metadata
   platform_config            = var.platform_config
-  pod_nsg_ids                = concat(var.pod_nsg_ids, var.cni_type == "npn" ? [module.network.pod_nsg_id] : [])
-  pod_subnet_id              = module.network.pod_subnet_id
+  pod_nsg_ids                = concat(var.pod_nsg_ids, var.cni_type == "npn" ? [try(module.network.pod_nsg_id, null)] : [])
+  pod_subnet_id              = try(module.network.pod_subnet_id, "") # safe destroy; validated in submodule
   pv_transit_encryption      = var.worker_pv_transit_encryption
   shape                      = var.worker_shape
   ssh_public_key             = local.ssh_public_key
   timezone                   = var.timezone
   volume_kms_key_id          = var.worker_volume_kms_key_id
-  worker_nsg_ids             = concat(var.worker_nsg_ids, [module.network.worker_nsg_id])
-  worker_subnet_id           = module.network.worker_subnet_id
+  worker_nsg_ids             = concat(var.worker_nsg_ids, [try(module.network.worker_nsg_id, null)])
+  worker_subnet_id           = try(module.network.worker_subnet_id, "") # safe destroy; validated in submodule
   preemptible_config         = var.worker_preemptible_config
 
   # FSS
   create_fss              = var.create_fss
   fss_availability_domain = coalesce(var.fss_availability_domain, local.ad_numbers_to_names[1])
-  fss_subnet_id           = module.network.fss_subnet_id
+  fss_subnet_id           = try(module.network.fss_subnet_id, "") # safe destroy; validated in submodule
   fss_nsg_ids             = var.fss_nsg_ids
   fss_mount_path          = var.fss_mount_path
   fss_max_fs_stat_bytes   = var.fss_max_fs_stat_bytes

--- a/modules/iam/group-autoscaling.tf
+++ b/modules/iam/group-autoscaling.tf
@@ -2,27 +2,27 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl
 
 locals {
-  autoscaler_group_name          = "oke-autoscaler-${var.state_id}"
+  autoscaler_group_name          = format("oke-autoscaler-%v", var.state_id)
   autoscaler_compartments        = coalescelist(var.autoscaler_compartments, [var.compartment_id])
-  autoscaler_compartment_matches = formatlist("instance.compartment.id = '%s'", local.autoscaler_compartments)
-  autoscaler_compartment_rule    = format("ANY {%s}", join(", ", local.autoscaler_compartment_matches))
+  autoscaler_compartment_matches = formatlist("instance.compartment.id = '%v'", local.autoscaler_compartments)
+  autoscaler_compartment_rule    = format("ANY {%v}", join(", ", local.autoscaler_compartment_matches))
 
-  autoscaler_group_rules = var.use_defined_tags ? format("ALL {%s}", join(", ", [
-    "tag.${var.tag_namespace}.role.value='worker'",
-    "tag.${var.tag_namespace}.cluster_autoscaler.value='allowed'",
+  autoscaler_group_rules = var.use_defined_tags ? format("ALL {%v}", join(", ", [
+    format("tag.%v.role.value='worker'", var.tag_namespace),
+    format("tag.%v.cluster_autoscaler.value='allowed'", var.tag_namespace),
     local.autoscaler_compartment_rule,
     # "tag.${var.tag_namespace}.state_id.value='${var.state_id}'", # TODO optional use w/ config
   ])) : local.autoscaler_compartment_rule
 
   autoscaler_templates = [
-    "Allow dynamic-group %s to manage cluster-node-pools in compartment id %s",
-    "Allow dynamic-group %s to manage compute-management-family in compartment id %s",
-    "Allow dynamic-group %s to manage instance-family in compartment id %s",
-    "Allow dynamic-group %s to manage volume-family in compartment id %s",
-    "Allow dynamic-group %s to use subnets in compartment id %s",
-    "Allow dynamic-group %s to read virtual-network-family in compartment id %s",
-    "Allow dynamic-group %s to use vnics in compartment id %s",
-    "Allow dynamic-group %s to inspect compartments in compartment id %s",
+    "Allow dynamic-group %v to manage cluster-node-pools in compartment id %v",
+    "Allow dynamic-group %v to manage compute-management-family in compartment id %v",
+    "Allow dynamic-group %v to manage instance-family in compartment id %v",
+    "Allow dynamic-group %v to manage volume-family in compartment id %v",
+    "Allow dynamic-group %v to use subnets in compartment id %v",
+    "Allow dynamic-group %v to read virtual-network-family in compartment id %v",
+    "Allow dynamic-group %v to use vnics in compartment id %v",
+    "Allow dynamic-group %v to inspect compartments in compartment id %v",
   ]
 
   autoscaler_policy_statements = var.create_iam_autoscaler_policy ? tolist([
@@ -36,7 +36,7 @@ resource "oci_identity_dynamic_group" "autoscaling" {
   provider       = oci.home
   count          = var.create_iam_resources && var.create_iam_autoscaler_policy ? 1 : 0
   compartment_id = var.tenancy_id # dynamic groups exist in root compartment (tenancy)
-  description    = "Dynamic group of cluster autoscaler-capable worker nodes for OKE Terraform state ${var.state_id}"
+  description    = format("Dynamic group of cluster autoscaler-capable worker nodes for OKE Terraform state %v", var.state_id)
   matching_rule  = local.autoscaler_group_rules
   name           = local.autoscaler_group_name
   defined_tags   = local.defined_tags

--- a/modules/iam/group-cluster.tf
+++ b/modules/iam/group-cluster.tf
@@ -2,16 +2,17 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl
 
 locals {
-  cluster_group_name = "oke-cluster-${var.state_id}"
-  cluster_rule = format("ALL {%s}", join(", ", compact([
+  cluster_group_name = format("oke-cluster-%v", var.state_id)
+  cluster_rule = format("ALL {%v}", join(", ", compact([
     "resource.type = 'cluster'",
-    "resource.compartment.id = '${var.compartment_id}'",
-    var.use_defined_tags ? "tag.${var.tag_namespace}.state_id.value='${var.state_id}'" : null,
+    format("resource.compartment.id = '%v'", var.compartment_id),
+    var.use_defined_tags ? format("tag.%v.state_id.value='%v'",
+    var.tag_namespace, var.state_id) : null,
   ])))
 
   # Cluster secrets encryption using OCI Key Management System (KMS)
   cluster_policy_statements = coalesce(var.cluster_kms_key_id, "none") != "none" ? tolist([format(
-    "Allow dynamic-group %s to use keys in compartment id %s where target.key.id = '%s'",
+    "Allow dynamic-group %v to use keys in compartment id %v where target.key.id = '%v'",
     local.cluster_group_name, var.compartment_id, var.cluster_kms_key_id,
   )]) : []
 }
@@ -20,7 +21,7 @@ resource "oci_identity_dynamic_group" "cluster" {
   provider       = oci.home
   count          = var.create_iam_resources && var.create_iam_kms_policy ? 1 : 0
   compartment_id = var.tenancy_id # dynamic groups exist in root compartment (tenancy)
-  description    = "Dynamic group with cluster for OKE Terraform state ${var.state_id}"
+  description    = format("Dynamic group with cluster for OKE Terraform state %v", var.state_id)
   matching_rule  = local.cluster_rule
   name           = local.cluster_group_name
   defined_tags   = local.defined_tags

--- a/modules/iam/group-operator.tf
+++ b/modules/iam/group-operator.tf
@@ -2,22 +2,21 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl
 
 locals {
-  operator_group_name = "oke-operator-${var.state_id}"
-
-  operator_group_rules = var.use_defined_tags ? format("ALL {%s}", join(", ", [
-    "tag.${var.tag_namespace}.role.value='operator'",
-    "tag.${var.tag_namespace}.state_id.value='${var.state_id}'",
+  operator_group_name = format("oke-operator-%v", var.state_id)
+  operator_group_rules = var.use_defined_tags ? format("ALL {%v}", join(", ", [
+    format("tag.%v.role.value='operator'", var.tag_namespace),
+    format("tag.%v.state_id.value='%v'", var.tag_namespace, var.state_id),
   ])) : "ALL {instance.compartment.id = '${var.compartment_id}'}"
 
   cluster_manage_statement = format(
-    "Allow dynamic-group %s to MANAGE clusters in compartment id %s",
+    "Allow dynamic-group %v to MANAGE clusters in compartment id %v",
     local.operator_group_name, var.compartment_id,
   )
 
   # TODO support keys defined at worker group level
   operator_kms_volume_templates = [
-    "Allow service blockstorage to USE keys in compartment id %s where target.key.id = '%s'",
-    "Allow dynamic-group ${local.operator_group_name} to USE key-delegates in compartment id %s where target.key.id = '%s'"
+    "Allow service blockstorage to USE keys in compartment id %v where target.key.id = '%v'",
+    "Allow dynamic-group ${local.operator_group_name} to USE key-delegates in compartment id %v where target.key.id = '%v'"
   ]
 
   # Block volume encryption using OCI Key Management System (KMS)
@@ -36,7 +35,7 @@ resource "oci_identity_dynamic_group" "operator" {
   provider       = oci.home
   count          = var.create_iam_resources && var.create_iam_operator_policy ? 1 : 0
   compartment_id = var.tenancy_id # dynamic groups exist in root compartment (tenancy)
-  description    = "Dynamic group of operator instance(s) for OKE Terraform state ${var.state_id}"
+  description    = format("Dynamic group of operator instance(s) for OKE Terraform state %v", var.state_id)
   matching_rule  = local.operator_group_rules
   name           = local.operator_group_name
   defined_tags   = local.defined_tags

--- a/modules/iam/policy.tf
+++ b/modules/iam/policy.tf
@@ -21,7 +21,7 @@ resource "oci_identity_policy" "cluster" {
   provider       = oci.home
   count          = local.has_policy_statements ? 1 : 0
   compartment_id = var.compartment_id
-  description    = "Policies for OKE Terraform state ${var.state_id}"
+  description    = format("Policies for OKE Terraform state %v", var.state_id)
   name           = local.cluster_group_name
   statements     = local.policy_statements
   defined_tags   = local.defined_tags

--- a/modules/network/drgs.tf
+++ b/modules/network/drgs.tf
@@ -41,7 +41,7 @@ resource "oci_core_drg_attachment" "oke" {
 resource "oci_core_drg_attachment" "extra" {
   for_each      = local.drg_attachments
   drg_id        = one(oci_core_drg.oke[*].id)
-  display_name  = "${each.key}-${var.state_id}"
+  display_name  = format("%v-%v", each.key, var.state_id)
   defined_tags  = local.defined_tags
   freeform_tags = local.freeform_tags
 

--- a/modules/network/subnets.tf
+++ b/modules/network/subnets.tf
@@ -115,7 +115,7 @@ resource "oci_core_subnet" "oke" {
   compartment_id             = var.compartment_id
   vcn_id                     = var.vcn_id
   cidr_block                 = lookup(local.subnet_cidrs_all, each.key)
-  display_name               = "${each.key}-${var.state_id}"
+  display_name               = format("%v-%v", each.key, var.state_id)
   dns_label                  = var.assign_dns ? lookup(try(lookup(var.subnets, each.key), {}), "dns_label", substr(each.key, 0, 2)) : null
   prohibit_public_ip_on_vnic = !tobool(lookup(each.value, "is_public", false))
   route_table_id             = !tobool(lookup(each.value, "is_public", false)) ? var.nat_route_table_id : var.ig_route_table_id
@@ -138,7 +138,7 @@ resource "oci_core_security_list" "oke" {
   }
 
   compartment_id = var.compartment_id
-  display_name   = "${each.key}-${var.state_id}"
+  display_name   = format("%v-%v", each.key, var.state_id)
   vcn_id         = var.vcn_id
   defined_tags   = local.defined_tags
   freeform_tags  = local.freeform_tags

--- a/modules/workers/instance.tf
+++ b/modules/workers/instance.tf
@@ -69,7 +69,7 @@ resource "oci_core_instance" "workers" {
       oke-k8version            = var.kubernetes_version
       oke-kubeproxy-proxy-mode = var.kubeproxy_mode
       oke-tenancy-id           = var.tenancy_id
-      oke-initial-node-labels  = join(",", [for k, v in each.value.node_labels : "${k}=${v}"])
+      oke-initial-node-labels  = join(",", [for k, v in each.value.node_labels : format("%v=%v", k, v)])
       secondary_vnics          = jsonencode(lookup(each.value, "secondary_vnics", {}))
       ssh_authorized_keys      = var.ssh_public_key
       user_data                = lookup(lookup(data.cloudinit_config.workers, lookup(each.value, "key", ""), {}), "rendered", "")

--- a/modules/workers/instanceconfig.tf
+++ b/modules/workers/instanceconfig.tf
@@ -39,7 +39,7 @@ resource "oci_core_instance_configuration" "workers" {
           oke-k8version            = var.kubernetes_version
           oke-kubeproxy-proxy-mode = var.kubeproxy_mode
           oke-tenancy-id           = var.tenancy_id
-          oke-initial-node-labels  = join(",", [for k, v in each.value.node_labels : "${k}=${v}"])
+          oke-initial-node-labels  = join(",", [for k, v in each.value.node_labels : format("%v=%v", k, v)])
           secondary_vnics          = jsonencode(lookup(each.value, "secondary_vnics", {}))
           ssh_authorized_keys      = var.ssh_public_key
           user_data                = lookup(lookup(data.cloudinit_config.workers, each.key, {}), "rendered", "")

--- a/modules/workers/locals.tf
+++ b/modules/workers/locals.tf
@@ -82,7 +82,7 @@ locals {
         lookup(var.image_ids, pool.image_type, null),
         length(regexall("GPU", pool.shape)) > 0 ? var.image_ids.gpu : var.image_ids.nongpu,
         length(regexall("A1", pool.shape)) > 0 ? var.image_ids.aarch64 : var.image_ids.x86_64,
-        lookup(var.image_ids, "${pool.os} ${split(".", pool.os_version)[0]}", null),
+        lookup(var.image_ids, format("%v %v", pool.os, split(".", pool.os_version)[0]), null),
       ]...)), 0))
 
       # Standard tags as defined if enabled for use
@@ -162,7 +162,7 @@ locals {
     for k, v in local.enabled_worker_pools : [
       for i in range(0, lookup(v, "size", 0)) : merge(v, { "key" = k, "index" = i })
     ] if lookup(v, "mode", "") == "instance"
-  ]...) : "${lookup(e, "key")}-${lookup(e, "index")}" => e }
+  ]...) : format("%v-%v", lookup(e, "key"), lookup(e, "index")) => e }
 
   # Enabled worker_pool map entries for cluster networks
   enabled_cluster_networks = {


### PR DESCRIPTION
* Add error handling for missing `subnet_id` values, e.g. when unused or with `terraform destroy`. Inputs are better validated by the resources that use them and their preconditions.
* Improve null handling with string interpolation. The `%v` format verb yields "null" in a string instead of an error - e.g. when unused/destroying.

Example failure for missing subnet/NSG with `terraform destroy`:
```
module.oke.module.workers[0].oci_core_instance_pool.workers["wp1"]: Refreshing state... [id=...]
╷
│ Error: Unsupported attribute
│
│   on .terraform/modules/oke/module-workers.tf line 62, in module "workers":
│   62:   pod_subnet_id              = module.network.pod_subnet_id
│     ├────────────────
│     │ module.network is object with 17 attributes
│
│ This object does not have an attribute named "pod_subnet_id".
```
```
module.oke.module.bastion[0].null_resource.await_cloudinit: Refreshing state... [id=...]
╷
│ Error: Unsupported attribute
│ 
│   on .terraform/modules/oke/module-workers.tf line 68, in module "workers":
│   68:   worker_nsg_ids             = concat(var.worker_nsg_ids, [module.network.worker_nsg_id])
│     ├────────────────
│     │ module.network is object with 14 attributes
│ 
│ This object does not have an attribute named "worker_nsg_id".
```

Example failure for null string interpolation with `terraform destroy` after interrupted `apply`:
```
module.oke.data.oci_containerengine_node_pool_option.oke: Read complete after 1s [id=ContainerengineNodePoolOptionDataSource-...]

Error: Invalid template interpolation value

  on .terraform/modules/oke/modules/iam/group-workers.tf line 17, in locals:
  17:     var.create_iam_worker_policy ? "target.cluster.id = '${var.cluster_id}'" : null,
    ├────────────────
    │ var.cluster_id is null

The expression result is null. Cannot include a null value in a string
template.
```