### PR TITLE
fix: 5.x Add missing resources tags, materialize early

### DIFF
--- a/module-bastion.tf
+++ b/module-bastion.tf
@@ -43,11 +43,18 @@ module "bastion" {
   upgrade             = var.bastion_upgrade
   user                = var.bastion_user
 
-  # Tagging
-  defined_tags     = try(lookup(var.defined_tags, "bastion", {}), {})
-  freeform_tags    = try(lookup(var.freeform_tags, "bastion", {}), {})
+  # Standard tags as defined if enabled for use, or freeform
+  # User-provided tags are merged last and take precedence
   use_defined_tags = var.use_defined_tags
   tag_namespace    = var.tag_namespace
+  defined_tags = merge(var.use_defined_tags ? {
+    "${var.tag_namespace}.state_id" = var.state_id,
+    "${var.tag_namespace}.role"     = "bastion",
+  } : {}, local.bastion_defined_tags)
+  freeform_tags = merge(var.use_defined_tags ? {} : {
+    "state_id" = var.state_id,
+    "role"     = "bastion",
+  }, local.bastion_freeform_tags)
 
   providers = {
     oci.home = oci.home

--- a/module-cluster.tf
+++ b/module-cluster.tf
@@ -66,8 +66,51 @@ module "cluster" {
   # Tags
   use_defined_tags = var.use_defined_tags
   tag_namespace    = var.tag_namespace
-  defined_tags     = try(lookup(var.defined_tags, "cluster", {}), {})
-  freeform_tags    = try(lookup(var.freeform_tags, "cluster", {}), {})
+
+  # Standard tags as defined if enabled for use, or freeform
+  # User-provided tags are merged last and take precedence
+  cluster_defined_tags = var.use_defined_tags ? merge(
+    {
+      "${var.tag_namespace}.state_id" = var.state_id,
+      "${var.tag_namespace}.role"     = "cluster",
+    },
+    local.cluster_defined_tags,
+  ) : {}
+  cluster_freeform_tags = var.use_defined_tags ? {} : merge(
+    {
+      "state_id" = var.state_id,
+      "role"     = "cluster",
+    },
+    local.cluster_freeform_tags,
+  )
+  persistent_volume_defined_tags = var.use_defined_tags ? merge(
+    {
+      "${var.tag_namespace}.state_id" = var.state_id,
+      "${var.tag_namespace}.role"     = "persistent_volume",
+    },
+    local.persistent_volume_defined_tags,
+  ) : {}
+  persistent_volume_freeform_tags = var.use_defined_tags ? {} : merge(
+    {
+      "state_id" = var.state_id,
+      "role"     = "persistent_volume",
+    },
+    local.persistent_volume_freeform_tags,
+  )
+  service_lb_defined_tags = var.use_defined_tags ? merge(
+    {
+      "${var.tag_namespace}.state_id" = var.state_id,
+      "${var.tag_namespace}.role"     = "service_lb"
+    },
+    local.service_lb_defined_tags,
+  ) : {}
+  service_lb_freeform_tags = var.use_defined_tags ? {} : merge(
+    {
+      "state_id" = var.state_id,
+      "role"     = "service_lb"
+    },
+    local.service_lb_freeform_tags,
+  )
 
   providers = {
     oci.home = oci.home

--- a/module-iam.tf
+++ b/module-iam.tf
@@ -65,8 +65,8 @@ module "iam" {
 
   create_iam_tag_namespace = var.create_iam_tag_namespace
   create_iam_defined_tags  = var.create_iam_defined_tags
-  defined_tags             = try(lookup(var.defined_tags, "policy", {}), {})
-  freeform_tags            = try(lookup(var.freeform_tags, "policy", {}), {})
+  defined_tags             = local.iam_defined_tags
+  freeform_tags            = local.iam_freeform_tags
   tag_namespace            = var.tag_namespace
   use_defined_tags         = var.use_defined_tags
 

--- a/module-operator.tf
+++ b/module-operator.tf
@@ -63,9 +63,16 @@ module "operator" {
   user                  = var.operator_user
   volume_kms_key_id     = var.operator_volume_kms_key_id
 
-  # Tagging
-  defined_tags     = try(lookup(var.defined_tags, "operator", {}), {})
-  freeform_tags    = try(lookup(var.freeform_tags, "operator", {}), {})
+  # Standard tags as defined if enabled for use, or freeform
+  # User-provided tags are merged last and take precedence
+  defined_tags = merge(var.use_defined_tags ? {
+    "${var.tag_namespace}.state_id" = var.state_id,
+    "${var.tag_namespace}.role"     = "operator",
+  } : {}, local.operator_defined_tags)
+  freeform_tags = merge(var.use_defined_tags ? {} : {
+    "state_id" = var.state_id,
+    "role"     = "operator",
+  }, local.operator_freeform_tags)
   use_defined_tags = var.use_defined_tags
   tag_namespace    = var.tag_namespace
 

--- a/module-workers.tf
+++ b/module-workers.tf
@@ -80,8 +80,8 @@ module "workers" {
 
   # Tagging
   tag_namespace    = var.tag_namespace
-  defined_tags     = try(lookup(var.defined_tags, "workers", {}), {})
-  freeform_tags    = try(lookup(var.freeform_tags, "workers", {}), {})
+  defined_tags     = local.workers_defined_tags
+  freeform_tags    = local.workers_freeform_tags
   use_defined_tags = var.use_defined_tags
 
   providers = {

--- a/modules/bastion/compute.tf
+++ b/modules/bastion/compute.tf
@@ -6,16 +6,6 @@ locals {
   memory           = tonumber(lookup(var.shape, "memory", 4))
   ocpus            = max(1, tonumber(lookup(var.shape, "ocpus", 1)))
   shape            = lookup(var.shape, "shape", "VM.Standard.E4.Flex")
-
-  defined_tags = merge(var.defined_tags, var.use_defined_tags ? {
-    "${var.tag_namespace}.state_id" = var.state_id,
-    "${var.tag_namespace}.role"     = "bastion",
-  } : {})
-
-  freeform_tags = merge(var.freeform_tags, !var.use_defined_tags ? {
-    "state_id" = var.state_id,
-    "role"     = "bastion",
-  } : {})
 }
 
 output "id" {
@@ -29,9 +19,9 @@ output "public_ip" {
 resource "oci_core_instance" "bastion" {
   availability_domain = var.availability_domain
   compartment_id      = var.compartment_id
-  defined_tags        = local.defined_tags
   display_name        = "bastion-${var.state_id}"
-  freeform_tags       = local.freeform_tags
+  defined_tags        = var.defined_tags
+  freeform_tags       = var.freeform_tags
   shape               = lookup(var.shape, "shape")
 
   agent_config {

--- a/modules/cluster/variables.tf
+++ b/modules/cluster/variables.tf
@@ -13,8 +13,6 @@ variable "cni_type" { type = string }
 variable "control_plane_is_public" { type = bool }
 variable "control_plane_nsg_ids" { type = set(string) }
 variable "control_plane_subnet_id" { type = string }
-variable "defined_tags" { type = map(any) }
-variable "freeform_tags" { type = map(any) }
 variable "image_signing_keys" { type = set(string) }
 variable "kubernetes_version" { type = string }
 variable "pods_cidr" { type = string }
@@ -24,3 +22,11 @@ variable "tag_namespace" { type = string }
 variable "use_defined_tags" { type = string }
 variable "use_signed_images" { type = bool }
 variable "vcn_id" { type = string }
+
+# Tagging
+variable "cluster_defined_tags" { type = map(string) }
+variable "cluster_freeform_tags" { type = map(string) }
+variable "persistent_volume_defined_tags" { type = map(string) }
+variable "persistent_volume_freeform_tags" { type = map(string) }
+variable "service_lb_defined_tags" { type = map(string) }
+variable "service_lb_freeform_tags" { type = map(string) }

--- a/modules/iam/tagging.tf
+++ b/modules/iam/tagging.tf
@@ -45,14 +45,14 @@ locals {
   # Standard tags as freeform if defined tags are disabled
   freeform_tags = merge(var.freeform_tags, !var.use_defined_tags ? {
     "state_id" = var.state_id,
-    "role"     = "policy",
+    "role"     = "iam",
     } : {},
   )
 
   # Standard tags as defined if enabled for use
   defined_tags = merge(var.defined_tags, var.use_defined_tags ? {
     "${var.tag_namespace}.state_id" = var.state_id,
-    "${var.tag_namespace}.role"     = "policy",
+    "${var.tag_namespace}.role"     = "iam",
     } : {},
   )
 }
@@ -63,7 +63,7 @@ resource "oci_identity_tag_namespace" "oke" {
   compartment_id = var.compartment_id
   description    = "Tag namespace for OKE resources"
   name           = var.tag_namespace
-  defined_tags   = var.defined_tags
+  defined_tags   = local.defined_tags
   freeform_tags  = local.freeform_tags
   lifecycle {
     ignore_changes = [defined_tags, freeform_tags]
@@ -75,7 +75,7 @@ resource "oci_identity_tag" "oke" {
   for_each         = local.create_iam_tag_namespace ? local.tags : {} #{ for k, v in oci_identity_tag_namespace.oke : k => local.tags } # local.create_iam_tag_namespace ? local.tags : {}
   description      = each.value
   name             = each.key
-  defined_tags     = var.defined_tags
+  defined_tags     = local.defined_tags
   freeform_tags    = local.freeform_tags
   tag_namespace_id = one(oci_identity_tag_namespace.oke[*].id)
 

--- a/modules/network/drgs.tf
+++ b/modules/network/drgs.tf
@@ -12,8 +12,8 @@ resource "oci_core_drg" "oke" {
   count          = length(local.drg_attachments) > 0 ? 1 : 0
   compartment_id = var.compartment_id
   display_name   = "oke-${var.state_id}"
-  defined_tags   = local.defined_tags
-  freeform_tags  = local.freeform_tags
+  defined_tags   = var.defined_tags
+  freeform_tags  = var.freeform_tags
   lifecycle {
     ignore_changes = [freeform_tags, defined_tags]
   }
@@ -24,8 +24,8 @@ resource "oci_core_drg_attachment" "oke" {
   count         = length(local.drg_attachments) > 0 && length(oci_core_drg.oke[*]) > 0 ? 1 : 0
   drg_id        = one(oci_core_drg.oke[*].id)
   display_name  = "drg-oke-${var.state_id}"
-  defined_tags  = local.defined_tags
-  freeform_tags = local.freeform_tags
+  defined_tags  = var.defined_tags
+  freeform_tags = var.freeform_tags
 
   network_details {
     id   = var.vcn_id
@@ -42,8 +42,8 @@ resource "oci_core_drg_attachment" "extra" {
   for_each      = local.drg_attachments
   drg_id        = one(oci_core_drg.oke[*].id)
   display_name  = format("%v-%v", each.key, var.state_id)
-  defined_tags  = local.defined_tags
-  freeform_tags = local.freeform_tags
+  defined_tags  = var.defined_tags
+  freeform_tags = var.freeform_tags
 
   network_details {
     id   = lookup(each.value, "vcn_id")

--- a/modules/network/locals.tf
+++ b/modules/network/locals.tf
@@ -29,16 +29,4 @@ locals {
 
   # Oracle Services Network (OSN)
   osn = one(data.oci_core_services.all_oci_services.services[*].cidr_block)
-
-  defined_tags = merge(var.defined_tags, var.use_defined_tags ? {
-    "${var.tag_namespace}.state_id" = var.state_id,
-    "${var.tag_namespace}.role"     = "network",
-    } : {},
-  )
-
-  freeform_tags = merge(var.freeform_tags, !var.use_defined_tags ? {
-    "state_id" = var.state_id,
-    "role"     = "network",
-    } : {},
-  )
 }

--- a/modules/network/nsg-bastion.tf
+++ b/modules/network/nsg-bastion.tf
@@ -42,8 +42,8 @@ resource "oci_core_network_security_group" "bastion" {
   compartment_id = var.compartment_id
   display_name   = "bastion-${var.state_id}"
   vcn_id         = var.vcn_id
-  defined_tags   = local.defined_tags
-  freeform_tags  = local.freeform_tags
+  defined_tags   = var.defined_tags
+  freeform_tags  = var.freeform_tags
   lifecycle {
     ignore_changes = [defined_tags, freeform_tags, display_name]
   }

--- a/modules/network/nsg-controlplane.tf
+++ b/modules/network/nsg-controlplane.tf
@@ -84,8 +84,8 @@ resource "oci_core_network_security_group" "cp" {
   compartment_id = var.compartment_id
   display_name   = "cp-${var.state_id}"
   vcn_id         = var.vcn_id
-  defined_tags   = local.defined_tags
-  freeform_tags  = local.freeform_tags
+  defined_tags   = var.defined_tags
+  freeform_tags  = var.freeform_tags
   lifecycle {
     ignore_changes = [defined_tags, freeform_tags, display_name]
   }

--- a/modules/network/nsg-fss.tf
+++ b/modules/network/nsg-fss.tf
@@ -47,8 +47,8 @@ resource "oci_core_network_security_group" "fss" {
   compartment_id = var.compartment_id
   display_name   = "fss-${var.state_id}"
   vcn_id         = var.vcn_id
-  defined_tags   = local.defined_tags
-  freeform_tags  = local.freeform_tags
+  defined_tags   = var.defined_tags
+  freeform_tags  = var.freeform_tags
   lifecycle {
     ignore_changes = [defined_tags, freeform_tags, display_name]
   }

--- a/modules/network/nsg-loadbalancers-int.tf
+++ b/modules/network/nsg-loadbalancers-int.tf
@@ -35,8 +35,8 @@ resource "oci_core_network_security_group" "int_lb" {
   compartment_id = var.compartment_id
   display_name   = "int_lb-${var.state_id}"
   vcn_id         = var.vcn_id
-  defined_tags   = local.defined_tags
-  freeform_tags  = local.freeform_tags
+  defined_tags   = var.defined_tags
+  freeform_tags  = var.freeform_tags
   lifecycle {
     ignore_changes = [defined_tags, freeform_tags, display_name]
   }

--- a/modules/network/nsg-loadbalancers-pub.tf
+++ b/modules/network/nsg-loadbalancers-pub.tf
@@ -35,8 +35,8 @@ resource "oci_core_network_security_group" "pub_lb" {
   compartment_id = var.compartment_id
   display_name   = "pub_lb-${var.state_id}"
   vcn_id         = var.vcn_id
-  defined_tags   = local.defined_tags
-  freeform_tags  = local.freeform_tags
+  defined_tags   = var.defined_tags
+  freeform_tags  = var.freeform_tags
   lifecycle {
     ignore_changes = [defined_tags, freeform_tags, display_name]
   }

--- a/modules/network/nsg-operator.tf
+++ b/modules/network/nsg-operator.tf
@@ -42,8 +42,8 @@ resource "oci_core_network_security_group" "operator" {
   compartment_id = var.compartment_id
   display_name   = "operator-${var.state_id}"
   vcn_id         = var.vcn_id
-  defined_tags   = local.defined_tags
-  freeform_tags  = local.freeform_tags
+  defined_tags   = var.defined_tags
+  freeform_tags  = var.freeform_tags
   lifecycle {
     ignore_changes = [defined_tags, freeform_tags, display_name]
   }

--- a/modules/network/nsg-pods.tf
+++ b/modules/network/nsg-pods.tf
@@ -60,8 +60,8 @@ resource "oci_core_network_security_group" "pods" {
   compartment_id = var.compartment_id
   display_name   = "pods-${var.state_id}"
   vcn_id         = var.vcn_id
-  defined_tags   = local.defined_tags
-  freeform_tags  = local.freeform_tags
+  defined_tags   = var.defined_tags
+  freeform_tags  = var.freeform_tags
   lifecycle {
     ignore_changes = [defined_tags, freeform_tags, display_name]
   }

--- a/modules/network/nsg-workers.tf
+++ b/modules/network/nsg-workers.tf
@@ -119,8 +119,8 @@ resource "oci_core_network_security_group" "workers" {
   compartment_id = var.compartment_id
   display_name   = "workers-${var.state_id}"
   vcn_id         = var.vcn_id
-  defined_tags   = local.defined_tags
-  freeform_tags  = local.freeform_tags
+  defined_tags   = var.defined_tags
+  freeform_tags  = var.freeform_tags
   lifecycle {
     ignore_changes = [defined_tags, freeform_tags, display_name]
   }

--- a/modules/network/subnets.tf
+++ b/modules/network/subnets.tf
@@ -120,8 +120,8 @@ resource "oci_core_subnet" "oke" {
   prohibit_public_ip_on_vnic = !tobool(lookup(each.value, "is_public", false))
   route_table_id             = !tobool(lookup(each.value, "is_public", false)) ? var.nat_route_table_id : var.ig_route_table_id
   security_list_ids          = compact([lookup(lookup(oci_core_security_list.oke, each.key, {}), "id", null)])
-  defined_tags               = local.defined_tags
-  freeform_tags              = local.freeform_tags
+  defined_tags               = var.defined_tags
+  freeform_tags              = var.freeform_tags
 
   lifecycle {
     # TODO reflect default security_list_id instead of ignore
@@ -140,8 +140,8 @@ resource "oci_core_security_list" "oke" {
   compartment_id = var.compartment_id
   display_name   = format("%v-%v", each.key, var.state_id)
   vcn_id         = var.vcn_id
-  defined_tags   = local.defined_tags
-  freeform_tags  = local.freeform_tags
+  defined_tags   = var.defined_tags
+  freeform_tags  = var.freeform_tags
 
   lifecycle {
     ignore_changes = [

--- a/modules/operator/compute.tf
+++ b/modules/operator/compute.tf
@@ -6,16 +6,6 @@ locals {
   memory           = lookup(var.shape, "memory", 4)
   ocpus            = max(1, lookup(var.shape, "ocpus", 1))
   shape            = lookup(var.shape, "shape", "VM.Standard.E4.Flex")
-
-  defined_tags = merge(var.defined_tags, var.use_defined_tags ? {
-    "${var.tag_namespace}.state_id" = var.state_id,
-    "${var.tag_namespace}.role"     = "operator",
-  } : {})
-
-  freeform_tags = merge(var.freeform_tags, !var.use_defined_tags ? {
-    "state_id" = var.state_id,
-    "role"     = "operator",
-  } : {})
 }
 
 output "id" {
@@ -29,9 +19,9 @@ output "private_ip" {
 resource "oci_core_instance" "operator" {
   availability_domain                 = var.availability_domain
   compartment_id                      = var.compartment_id
-  defined_tags                        = local.defined_tags
   display_name                        = "operator-${var.state_id}"
-  freeform_tags                       = local.freeform_tags
+  defined_tags                        = var.defined_tags
+  freeform_tags                       = var.freeform_tags
   is_pv_encryption_in_transit_enabled = var.pv_transit_encryption
   shape                               = local.shape
 

--- a/modules/workers/locals.tf
+++ b/modules/workers/locals.tf
@@ -104,7 +104,7 @@ locals {
       # Standard tags as freeform if defined tags are disabled
       # User-provided freeform tags are merged and take precedence
       freeform_tags = merge(
-        !var.use_defined_tags ? merge(
+        var.use_defined_tags ? {} : merge(
           {
             "state_id"           = var.state_id,
             "role"               = "worker",
@@ -112,7 +112,7 @@ locals {
             "cluster_autoscaler" = pool.allow_autoscaler ? "allowed" : "disabled",
           },
           pool.autoscale ? { "cluster_autoscaler" = "managed" } : {},
-        ) : {},
+        ),
         var.freeform_tags,
         lookup(pool, "freeform_tags", {})
       )

--- a/variables-iam.tf
+++ b/variables-iam.tf
@@ -15,6 +15,26 @@ locals {
     ? file(var.api_private_key_path)
     : null
   )
+
+  # Merge freeform tags from map & individual inputs better suited to Resource Manager
+  bastion_freeform_tags           = merge(lookup(var.freeform_tags, "bastion", {}), var.bastion_freeform_tags)
+  cluster_freeform_tags           = merge(lookup(var.freeform_tags, "cluster", {}), var.cluster_freeform_tags)
+  iam_freeform_tags               = merge(lookup(var.freeform_tags, "iam", {}), var.iam_freeform_tags)
+  network_freeform_tags           = merge(lookup(var.freeform_tags, "network", {}), var.network_freeform_tags)
+  operator_freeform_tags          = merge(lookup(var.freeform_tags, "operator", {}), var.operator_freeform_tags)
+  persistent_volume_freeform_tags = merge(lookup(var.freeform_tags, "persistent_volume", {}), var.persistent_volume_freeform_tags)
+  service_lb_freeform_tags        = merge(lookup(var.freeform_tags, "service_lb", {}), var.service_lb_freeform_tags)
+  workers_freeform_tags           = merge(lookup(var.freeform_tags, "workers", {}), var.workers_freeform_tags)
+
+  # Merge defined tags from map & individual inputs better suited to Resource Manager
+  bastion_defined_tags           = merge(lookup(var.defined_tags, "bastion", {}), var.bastion_defined_tags)
+  cluster_defined_tags           = merge(lookup(var.defined_tags, "cluster", {}), var.cluster_defined_tags)
+  iam_defined_tags               = merge(lookup(var.defined_tags, "iam", {}), var.iam_defined_tags)
+  network_defined_tags           = merge(lookup(var.defined_tags, "network", {}), var.network_defined_tags)
+  operator_defined_tags          = merge(lookup(var.defined_tags, "operator", {}), var.operator_defined_tags)
+  persistent_volume_defined_tags = merge(lookup(var.defined_tags, "persistent_volume", {}), var.persistent_volume_defined_tags)
+  service_lb_defined_tags        = merge(lookup(var.defined_tags, "service_lb", {}), var.service_lb_defined_tags)
+  workers_defined_tags           = merge(lookup(var.defined_tags, "workers", {}), var.workers_defined_tags)
 }
 
 # Overrides Resource Manager
@@ -164,6 +184,8 @@ variable "create_iam_worker_policy" {
   }
 }
 
+# Tagging
+
 variable "create_iam_tag_namespace" {
   default     = false
   description = "Whether to create a namespace for defined tags used for IAM policy and tracking. Ignored when 'create_iam_resources' is false."
@@ -190,13 +212,14 @@ variable "tag_namespace" {
 
 variable "freeform_tags" {
   default = {
+    bastion           = {}
     cluster           = {}
+    iam               = {}
+    network           = {}
+    operator          = {}
     persistent_volume = {}
     service_lb        = {}
     workers           = {}
-    bastion           = {}
-    operator          = {}
-    vcn               = {}
   }
   description = "Freeform tags to be applied to created resources."
   type        = any
@@ -204,14 +227,98 @@ variable "freeform_tags" {
 
 variable "defined_tags" {
   default = {
+    bastion           = {}
     cluster           = {}
+    iam               = {}
+    network           = {}
+    operator          = {}
     persistent_volume = {}
     service_lb        = {}
     workers           = {}
-    bastion           = {}
-    operator          = {}
-    vcn               = {}
   }
   description = "Defined tags to be applied to created resources. Must already exist in the tenancy."
   type        = any
+}
+
+# Individual inputs better suited to Resource Manager are merged in locals
+
+variable "bastion_defined_tags" {
+  type        = map(string)
+  description = "Defined tags applied to created resources."
+  default     = {}
+}
+variable "bastion_freeform_tags" {
+  type        = map(string)
+  description = "Freeform tags applied to created resources."
+  default     = {}
+}
+variable "cluster_defined_tags" {
+  type        = map(string)
+  description = "Defined tags applied to created resources."
+  default     = {}
+}
+variable "cluster_freeform_tags" {
+  type        = map(string)
+  description = "Freeform tags applied to created resources."
+  default     = {}
+}
+variable "iam_defined_tags" {
+  type        = map(string)
+  description = "Defined tags applied to created resources."
+  default     = {}
+}
+variable "iam_freeform_tags" {
+  type        = map(string)
+  description = "Freeform tags applied to created resources."
+  default     = {}
+}
+variable "network_defined_tags" {
+  type        = map(string)
+  description = "Defined tags applied to created resources."
+  default     = {}
+}
+variable "network_freeform_tags" {
+  type        = map(string)
+  description = "Freeform tags applied to created resources."
+  default     = {}
+}
+variable "operator_defined_tags" {
+  type        = map(string)
+  description = "Defined tags applied to created resources."
+  default     = {}
+}
+variable "operator_freeform_tags" {
+  type        = map(string)
+  description = "Freeform tags applied to created resources."
+  default     = {}
+}
+variable "persistent_volume_defined_tags" {
+  type        = map(string)
+  description = "Defined tags applied to created resources."
+  default     = {}
+}
+variable "persistent_volume_freeform_tags" {
+  type        = map(string)
+  description = "Freeform tags applied to created resources."
+  default     = {}
+}
+variable "service_lb_defined_tags" {
+  type        = map(string)
+  description = "Defined tags applied to created resources."
+  default     = {}
+}
+variable "service_lb_freeform_tags" {
+  type        = map(string)
+  description = "Freeform tags applied to created resources."
+  default     = {}
+}
+variable "workers_defined_tags" {
+  type        = map(string)
+  description = "Defined tags applied to created resources."
+  default     = {}
+}
+variable "workers_freeform_tags" {
+  type        = map(string)
+  description = "Freeform tags applied to created resources."
+  default     = {}
 }


### PR DESCRIPTION
* Add resource tagging consistently, fix issues merging inputs.
* Merge common tag attributes outside of submodules to materialize earlier, i.e. visible in plan vs. "(known after apply)".
* Workers may still be known after apply due to merge with pool-level configuration, but should have tags applied correctly after.