### PR TITLE
adding capacity reservation support for workers

### DIFF
--- a/module-workers.tf
+++ b/module-workers.tf
@@ -45,6 +45,7 @@ module "workers" {
   assign_dns                 = var.assign_dns
   assign_public_ip           = var.worker_is_public
   block_volume_type          = var.worker_block_volume_type
+  capacity_reservation_id    = var.worker_capacity_reservation_id
   cloud_init                 = var.worker_cloud_init
   disable_default_cloud_init = var.worker_disable_default_cloud_init
   cni_type                   = var.cni_type

--- a/modules/workers/instance.tf
+++ b/modules/workers/instance.tf
@@ -6,9 +6,10 @@ resource "oci_core_instance" "workers" {
   preserve_boot_volume = false
   shape                = each.value.shape
 
-  defined_tags      = each.value.defined_tags
-  freeform_tags     = each.value.freeform_tags
-  extended_metadata = each.value.extended_metadata
+  defined_tags            = each.value.defined_tags
+  freeform_tags           = each.value.freeform_tags
+  extended_metadata       = each.value.extended_metadata
+  capacity_reservation_id = each.value.capacity_reservation_id
 
   dynamic "shape_config" {
     for_each = length(regexall("Flex", each.value.shape)) > 0 ? [1] : []

--- a/modules/workers/instanceconfig.tf
+++ b/modules/workers/instanceconfig.tf
@@ -13,11 +13,12 @@ resource "oci_core_instance_configuration" "workers" {
     instance_type = "compute"
 
     launch_details {
-      availability_domain = element(each.value.availability_domains, 1)
-      compartment_id      = each.value.compartment_id
-      defined_tags        = each.value.defined_tags
-      freeform_tags       = each.value.freeform_tags
-      extended_metadata   = each.value.extended_metadata
+      availability_domain     = element(each.value.availability_domains, 1)
+      compartment_id          = each.value.compartment_id
+      defined_tags            = each.value.defined_tags
+      freeform_tags           = each.value.freeform_tags
+      extended_metadata       = each.value.extended_metadata
+      capacity_reservation_id = each.value.capacity_reservation_id
 
       instance_options {
         are_legacy_imds_endpoints_disabled = false

--- a/modules/workers/locals.tf
+++ b/modules/workers/locals.tf
@@ -15,6 +15,7 @@ locals {
     autoscale                  = false
     block_volume_type          = var.block_volume_type
     boot_volume_size           = local.boot_volume_size
+    capacity_reservation_id    = var.capacity_reservation_id
     cloud_init                 = [] # empty pool-specific default
     disable_default_cloud_init = false
     compartment_id             = var.compartment_id

--- a/modules/workers/variables.tf
+++ b/modules/workers/variables.tf
@@ -37,6 +37,7 @@ variable "worker_pools" { type = any }
 variable "ad_numbers_to_names" { type = map(string) }
 variable "ad_numbers" { type = list(number) }
 variable "block_volume_type" { type = string }
+variable "capacity_reservation_id" { type = string }
 variable "cloud_init" { type = list(map(string)) }
 variable "disable_default_cloud_init" { type = bool }
 variable "image_id" { type = string }

--- a/variables-workers.tf
+++ b/variables-workers.tf
@@ -147,6 +147,12 @@ variable "worker_shape" {
   type        = map(any)
 }
 
+variable "worker_capacity_reservation_id" {
+  default     = null
+  description = "The ID of the Compute capacity reservation the worker node will be launched under. See <a href=https://docs.oracle.com/en-us/iaas/Content/Compute/Tasks/reserve-capacity.htm>Capacity Reservations</a> for more information."
+  type        = string
+}
+
 variable "worker_preemptible_config" {
   default = {
     enable                  = false,


### PR DESCRIPTION
Resolves https://github.com/oracle-terraform-modules/terraform-oci-oke/issues/740 to add support for capacity reservation for worker nodes

Sample usage for different types of worker pools:
```
worker_pools = {
    np_enhanced = {
      mode = "node-pool", size = 1,
      capacity_reservation_id = "ocid1.capacityreservation...",
      placement_ads = [1]
    },
    ip_enhanced = {
      mode = "instance-pool", size = 1,
      capacity_reservation_id = "ocid1.capacityreservation..."
    },
    instance_enhanced = {
      mode = "instance", size = 1,
      capacity_reservation_id = "ocid1.capacityreservation..."
    }
  }
```
Note: setting a capacity reservation for a node-pool is only allowed if a single AD is specified for the node-pool. You may have to set placement_ads = [<AD number>] when using capacity reservation with standalone instances or instance pools because capacity reservations are tied to specific ADs

Capacity reservations are now included in pool metadata:
```
output pools {
  value = {
    for k, v in module.cluster.worker_pools : k => v.capacity_reservation_id
  }
}

Outputs:

pools = {
  "instance_enhanced-0" = "ocid1.capacityreservation..."
  "ip_enhanced" = "ocid1.capacityreservation..."
  "np_enhanced" = "ocid1.capacityreservation..."
}
```

Example of precondition failing when multiple ADs are passed to node-pool when using capacity reservation:
```
╷
│ Error: Resource precondition failed
│ 
│   on .terraform/modules/cluster/modules/workers/nodepools.tf line 122, in resource "oci_containerengine_node_pool" "workers":
│  122:       condition = coalesce(each.value.capacity_reservation_id, "none") == "none" || length(each.value.availability_domains) == 1
│     ├────────────────
│     │ each.value.availability_domains is list of string with 3 elements
│     │ each.value.capacity_reservation_id is "ocid1.capacityreservation..."
│ 
│ A single availability domain must be specified when using a capacity reservation with mode=node-pool

```

instance, instance-pool and node-pool worker pools were successfully able to be created with capacity reservations after making the changes in this PR:
instance:
![image](https://github.com/oracle-terraform-modules/terraform-oci-oke/assets/8781285/9c7bff0e-6323-4f82-9ad5-748fb7281da9)
node-pool:
![image](https://github.com/oracle-terraform-modules/terraform-oci-oke/assets/8781285/c1031c50-0346-4fc8-baaf-feab251a5508)
instance configuration for instance pool:
<img width="1439" alt="image" src="https://github.com/oracle-terraform-modules/terraform-oci-oke/assets/8781285/72ef4cfd-6461-4c06-8ea0-0d4d1ccef7b7">


