### PR TITLE
fix: 5.x Remove unrequired home provider for bastion submodule

### DIFF
--- a/module-bastion.tf
+++ b/module-bastion.tf
@@ -55,10 +55,6 @@ module "bastion" {
     "state_id" = var.state_id,
     "role"     = "bastion",
   }, local.bastion_freeform_tags)
-
-  providers = {
-    oci.home = oci.home
-  }
 }
 
 output "bastion_id" {


### PR DESCRIPTION
Home provider is no longer used and should not be passed into submodule:
```
│ Error: Reference to undefined provider
│ 
│   on .terraform/modules/cluster/module-bastion.tf line 60, in module "bastion":
│   60:     oci.home = oci.home
│ 
│ The child module does not declare any provider requirement with the local name "oci.home".
│ 
│ If you also control the child module, you can add a required_providers entry named "oci.home" with the source address "oracle/oci" to accept this provider
│ configuration.
╵
```