### PR TITLE
fix: 5.x Disable unused datasources, create NSGs with auto defaults

### DIFF
--- a/modules/extensions/versions.tf
+++ b/modules/extensions/versions.tf
@@ -7,17 +7,17 @@ terraform {
   required_providers {
     helm = {
       source  = "hashicorp/helm"
-      version = "~> 2.9.0"
+      version = ">= 2.9.0"
     }
 
     http = {
       source  = "hashicorp/http"
-      version = "~> 3.2.1"
+      version = ">= 3.2.1"
     }
 
     null = {
       source  = "hashicorp/null"
-      version = "~> 3.2.1"
+      version = ">= 3.2.1"
     }
   }
 }

--- a/modules/network/nsg-bastion.tf
+++ b/modules/network/nsg-bastion.tf
@@ -7,7 +7,7 @@ locals {
     lookup(local.bastion_nsg_config, "create", "auto") == "always",
     alltrue([
       lookup(local.bastion_nsg_config, "create", "auto") == "auto",
-      !contains(keys(local.bastion_nsg_config), "id"),
+      coalesce(lookup(local.bastion_nsg_config, "id", null), "none") == "none",
       var.create_cluster, var.create_bastion,
     ]),
   ])

--- a/modules/network/nsg-controlplane.tf
+++ b/modules/network/nsg-controlplane.tf
@@ -7,7 +7,7 @@ locals {
     lookup(local.control_plane_nsg_config, "create", "auto") == "always",
     alltrue([
       lookup(local.control_plane_nsg_config, "create", "auto") == "auto",
-      !contains(keys(local.control_plane_nsg_config), "id"),
+      coalesce(lookup(local.control_plane_nsg_config, "id", null), "none") == "none",
       var.create_cluster,
     ]),
   ])

--- a/modules/network/nsg-fss.tf
+++ b/modules/network/nsg-fss.tf
@@ -4,11 +4,10 @@
 locals {
   fss_nsg_config = try(var.nsgs.fss, { create = "never" })
   fss_nsg_enabled = anytrue([
-    lookup(local.operator_nsg_config, "create", "auto") == "always",
+    lookup(local.fss_nsg_config, "create", "auto") == "always",
     alltrue([
-      lookup(local.operator_nsg_config, "create", "auto") == "auto",
-      !contains(keys(local.operator_nsg_config), "id"),
-      contains(keys(var.nsgs), "fss"),
+      lookup(local.fss_nsg_config, "create", "auto") == "auto",
+      coalesce(lookup(local.fss_nsg_config, "id", null), "none") == "none",
       var.create_cluster,
     ]),
   ])

--- a/modules/network/nsg-loadbalancers-int.tf
+++ b/modules/network/nsg-loadbalancers-int.tf
@@ -7,7 +7,7 @@ locals {
     lookup(local.int_lb_nsg_config, "create", "auto") == "always",
     alltrue([
       lookup(local.int_lb_nsg_config, "create", "auto") == "auto",
-      !contains(keys(local.int_lb_nsg_config), "id"),
+      coalesce(lookup(local.int_lb_nsg_config, "id", null), "none") == "none",
       var.create_cluster, var.load_balancers == "internal" || var.load_balancers == "both",
     ]),
   ])

--- a/modules/network/nsg-loadbalancers-pub.tf
+++ b/modules/network/nsg-loadbalancers-pub.tf
@@ -7,7 +7,7 @@ locals {
     lookup(local.pub_lb_nsg_config, "create", "auto") == "always",
     alltrue([
       lookup(local.pub_lb_nsg_config, "create", "auto") == "auto",
-      !contains(keys(local.pub_lb_nsg_config), "id"),
+      coalesce(lookup(local.pub_lb_nsg_config, "id", null), "none") == "none",
       var.create_cluster, var.load_balancers == "public" || var.load_balancers == "both",
     ]),
   ])

--- a/modules/network/nsg-operator.tf
+++ b/modules/network/nsg-operator.tf
@@ -7,7 +7,7 @@ locals {
     lookup(local.operator_nsg_config, "create", "auto") == "always",
     alltrue([
       lookup(local.operator_nsg_config, "create", "auto") == "auto",
-      !contains(keys(local.operator_nsg_config), "id"),
+      coalesce(lookup(local.operator_nsg_config, "id", null), "none") == "none",
       var.create_cluster, var.create_operator,
     ]),
   ])

--- a/modules/network/nsg-pods.tf
+++ b/modules/network/nsg-pods.tf
@@ -7,7 +7,7 @@ locals {
     lookup(local.pod_nsg_config, "create", "auto") == "always",
     alltrue([
       lookup(local.pod_nsg_config, "create", "auto") == "auto",
-      !contains(keys(local.pod_nsg_config), "id"),
+      coalesce(lookup(local.pod_nsg_config, "id", null), "none") == "none",
       var.create_cluster, var.cni_type == "npn",
     ]),
   ])

--- a/modules/network/nsg-workers.tf
+++ b/modules/network/nsg-workers.tf
@@ -7,7 +7,7 @@ locals {
     lookup(local.worker_nsg_config, "create", "auto") == "always",
     alltrue([
       lookup(local.worker_nsg_config, "create", "auto") == "auto",
-      !contains(keys(local.worker_nsg_config), "id"),
+      coalesce(lookup(local.worker_nsg_config, "id", null), "none") == "none",
       var.create_cluster,
     ]),
   ])


### PR DESCRIPTION
- Disable bastion/operator/worker image datasources when unused, handle empty result
- Fix evaluation of `create = auto` (default) for NSGs
- Relax version constraints for extensions submodule

Resolves #745 