### PR TITLE
fix: ssh_to_operator output use long form

### DIFF
--- a/module-operator.tf
+++ b/module-operator.tf
@@ -101,6 +101,6 @@ output "operator_private_ip" {
 output "ssh_to_operator" {
   description = "SSH command for operator host"
   value = (local.operator_enabled || coalesce(var.operator_private_ip, "none") != "none"
-    ? "ssh${local.ssh_key_arg} -J ${var.bastion_user}@${local.bastion_public_ip} ${var.operator_user}@${local.operator_private_ip}" : null
+    ? "ssh${local.ssh_key_arg} -o ProxyCommand='ssh ${local.ssh_key_arg} -W %h:%p ${var.bastion_user}@${local.bastion_public_ip}' ${var.operator_user}@${local.operator_private_ip}" : null
   )
 }


### PR DESCRIPTION
This commit Updates the terraform output for `ssh_to_operator` so that you can use a private key that is anywhere on the filesystem. Currently the short form (`-J`) does not allow you to pass any arguments like `-i`, therefore if your ssh key is not in a default location that openssh knows about it will fail to connect.

This ports https://github.com/oracle-terraform-modules/terraform-oci-oke/pull/700 submitted by @cwiggs to the [5.x branch](https://github.com/oracle-terraform-modules/terraform-oci-oke/tree/5.x) 

Resolves #246