### PR TITLE
docs: improve formatting of examples/workers tfvars

### DIFF
--- a/examples/workers/vars-workers-advanced.auto.tfvars
+++ b/examples/workers/vars-workers-advanced.auto.tfvars
@@ -18,22 +18,46 @@ worker_pool_mode = "node-pool"
 worker_pool_size = 1
 
 worker_pools = {
-  np1 = { mode = "node-pool", size = 1, shape = "VM.Standard.E4.Flex", create = false },
+  np1 = {
+    mode   = "node-pool",
+    size   = 1,
+    shape  = "VM.Standard.E4.Flex",
+    create = false
+  },
   wg_np-vm-ol7 = {
-    description = "OKE-managed Node Pool with OKE Oracle Linux 7 image", create = false,
-    mode        = "node-pool", size = 1, size_max = 2, os = "Oracle Linux", os_version = "7", autoscale = true,
+    description = "OKE-managed Node Pool with OKE Oracle Linux 7 image",
+    create      = false,
+    mode        = "node-pool",
+    size        = 1,
+    size_max    = 2,
+    os          = "Oracle Linux",
+    os_version  = "7",
+    autoscale   = true,
   },
   wg_np-vm-ol8 = {
-    description = "OKE-managed Node Pool with OKE Oracle Linux 8 image", create = false,
-    mode        = "node-pool", size = 1, size_max = 3, os = "Oracle Linux", os_version = "8", autoscale = true,
+    description = "OKE-managed Node Pool with OKE Oracle Linux 8 image",
+    create      = false,
+    mode        = "node-pool",
+    size        = 1,
+    size_max    = 3,
+    os          = "Oracle Linux",
+    os_version  = "8",
+    autoscale   = true,
   },
   wg_np-vm-custom = {
-    description = "OKE-managed Node Pool with custom image", create = true,
-    mode        = "node-pool", image_type = "custom", size = 1, allow_autoscaler = true,
+    description      = "OKE-managed Node Pool with custom image",
+    create           = true,
+    mode             = "node-pool",
+    image_type       = "custom",
+    size             = 1,
+    allow_autoscaler = true,
   },
   shielded_instances = {
-    description = "Self-managed Shielded VM Instance", create = false,
-    size        = 1, mode = "instance", shape = "VM.Standard2.4",
+    description = "Self-managed Shielded VM Instance",
+    create      = false,
+    size        = 1,
+    mode        = "instance",
+    shape       = "VM.Standard2.4",
     platform_config = {
       is_measured_boot_enabled           = true,
       is_secure_boot_enabled             = true,

--- a/examples/workers/vars-workers-autoscaling.auto.tfvars
+++ b/examples/workers/vars-workers-autoscaling.auto.tfvars
@@ -6,10 +6,13 @@
 worker_pools = {
   np-autoscaled = {
     description = "Node pool managed by cluster autoscaler",
-    size        = 1, size_max = 2, autoscale = true,
+    size        = 1,
+    size_max    = 2,
+    autoscale   = true,
   },
   np-autoscaler = {
-    description = "Node pool with cluster autoscaler scheduling allowed",
-    size        = 1, allow_autoscaler = true,
+    description      = "Node pool with cluster autoscaler scheduling allowed",
+    size             = 1,
+    allow_autoscaler = true,
   },
 }

--- a/examples/workers/vars-workers-basic.auto.tfvars
+++ b/examples/workers/vars-workers-basic.auto.tfvars
@@ -8,9 +8,13 @@ worker_pools = {
   oke-vm-standard = {},
 
   oke-vm-standard-large = {
-    description = "OKE-managed Node Pool with OKE Oracle Linux 8 image",
-    shape       = "VM.Standard.E4.Flex", create = true,
-    ocpus       = 8, memory = 128, boot_volume_size = 200,
-    os          = "Oracle Linux", os_version = "8",
+    description      = "OKE-managed Node Pool with OKE Oracle Linux 8 image",
+    shape            = "VM.Standard.E4.Flex",
+    create           = true,
+    ocpus            = 8,
+    memory           = 128,
+    boot_volume_size = 200,
+    os               = "Oracle Linux",
+    os_version       = "8",
   },
 }

--- a/examples/workers/vars-workers-clusternetwork.auto.tfvars
+++ b/examples/workers/vars-workers-clusternetwork.auto.tfvars
@@ -3,15 +3,22 @@
 
 worker_pools = {
   oke-vm-standard = {
-    description = "Managed node pool for operational workloads without GPU toleration"
-    mode        = "node-pool", size = 1, shape = "VM.Standard.E4.Flex",
-    ocpus       = 2, memory = 16, boot_volume_size = 50,
+    description      = "Managed node pool for operational workloads without GPU toleration"
+    mode             = "node-pool",
+    size             = 1,
+    shape            = "VM.Standard.E4.Flex",
+    ocpus            = 2,
+    memory           = 16,
+    boot_volume_size = 50,
   },
 
   oke-bm-gpu-rdma = {
     description   = "Self-managed nodes in a Cluster Network with RDMA networking",
-    mode          = "cluster-network", size = 1, shape = "BM.GPU.B4.8",
-    placement_ads = [1], image_id = "ocid1.image..."
+    mode          = "cluster-network",
+    size          = 1,
+    shape         = "BM.GPU.B4.8",
+    placement_ads = [1],
+    image_id      = "ocid1.image..."
     cloud_init = [
       {
         content = <<-EOT
@@ -21,7 +28,10 @@ worker_pools = {
       },
     ],
     secondary_vnics = {
-      "vnic-display-name" = { nic_index = 1, subnet_id = "ocid1.subnet..." },
+      "vnic-display-name" = {
+        nic_index = 1,
+        subnet_id = "ocid1.subnet..."
+      },
     },
   }
 }

--- a/examples/workers/vars-workers-drain.auto.tfvars
+++ b/examples/workers/vars-workers-drain.auto.tfvars
@@ -6,7 +6,8 @@ worker_pool_size = 1
 
 worker_pools = {
   oke-vm-active = {
-    description = "Node pool with active workers", size = 2,
+    description = "Node pool with active workers",
+    size        = 2,
   },
   oke-vm-draining = {
     description = "Node pool with scheduling disabled and draining",

--- a/examples/workers/vars-workers-instance.auto.tfvars
+++ b/examples/workers/vars-workers-instance.auto.tfvars
@@ -4,8 +4,12 @@
 worker_pools = {
   oke-vm-instance = {
     description = "Self-managed Instances",
-    mode        = "instance", size = 1,
-    node_labels = { "keya" : "valuea", "keyb" : "valueb" },
+    mode        = "instance",
+    size        = 1,
+    node_labels = {
+      "keya" = "valuea",
+      "keyb" = "valueb"
+    },
     secondary_vnics = {
       "vnic-display-name" = {},
     },

--- a/examples/workers/vars-workers-instancepool.auto.tfvars
+++ b/examples/workers/vars-workers-instancepool.auto.tfvars
@@ -4,8 +4,12 @@
 worker_pools = {
   oke-vm-instance-pool = {
     description = "Self-managed Instance Pool with custom image",
-    mode        = "instance-pool", size = 1,
-    node_labels = { "keya" : "valuea", "keyb" : "valueb" },
+    mode        = "instance-pool",
+    size        = 1,
+    node_labels = {
+      "keya" = "valuea",
+      "keyb" = "valueb"
+    },
     secondary_vnics = {
       "vnic-display-name" = {},
     },

--- a/examples/workers/vars-workers-network-vnics.auto.tfvars
+++ b/examples/workers/vars-workers-network-vnics.auto.tfvars
@@ -14,13 +14,15 @@ pod_nsg_ids       = [] // when cni_type = "npn"
 
 worker_pools = {
   oke-vm-custom-network-flannel = {
-    assign_public_ip = false, create = false,
+    assign_public_ip = false,
+    create           = false,
     subnet_id        = "ocid1.subnet..."
     nsg_ids          = ["ocid1.networksecuritygroup..."]
   },
 
   oke-vm-custom-network-npn = {
-    assign_public_ip = false, create = false,
+    assign_public_ip = false,
+    create           = false,
     subnet_id        = "ocid1.subnet..."
     pod_subnet_id    = "ocid1.subnet..."
     nsg_ids          = ["ocid1.networksecuritygroup..."]
@@ -28,19 +30,36 @@ worker_pools = {
   },
 
   oke-vm-vnics = {
-    mode = "instance-pool", size = 1, create = false,
+    mode   = "instance-pool",
+    size   = 1,
+    create = false,
     secondary_vnics = {
-      vnic0 = { nic_index = 0, subnet_id = "ocid1.subnet..." },
-      vnic1 = { nic_index = 1, subnet_id = "ocid1.subnet..." },
+      vnic0 = {
+        nic_index = 0,
+        subnet_id = "ocid1.subnet..."
+      },
+      vnic1 = {
+        nic_index = 1,
+        subnet_id = "ocid1.subnet..."
+      },
     },
   },
 
   oke-bm-vnics = {
-    mode          = "cluster-network", size = 2, shape = "BM.GPU.B4.8",
-    placement_ads = [1], create = false,
+    mode          = "cluster-network",
+    size          = 2,
+    shape         = "BM.GPU.B4.8",
+    placement_ads = [1],
+    create        = false,
     secondary_vnics = {
-      gpu0 = { nic_index = 0, subnet_id = "ocid1.subnet..." },
-      gpu1 = { nic_index = 1, subnet_id = "ocid1.subnet..." },
+      gpu0 = {
+        nic_index = 0,
+        subnet_id = "ocid1.subnet..."
+      },
+      gpu1 = {
+        nic_index = 1,
+        subnet_id = "ocid1.subnet..."
+      },
     },
   },
 }

--- a/examples/workers/vars-workers-nodepool.auto.tfvars
+++ b/examples/workers/vars-workers-nodepool.auto.tfvars
@@ -8,25 +8,34 @@ worker_pools = {
   oke-vm-standard = {},
 
   oke-vm-standard-large = {
-    size   = 1, shape = "VM.Standard.E4.Flex",
-    ocpus  = 8, memory = 128, boot_volume_size = 200,
-    create = false,
+    size             = 1,
+    shape            = "VM.Standard.E4.Flex",
+    ocpus            = 8,
+    memory           = 128,
+    boot_volume_size = 200,
+    create           = false,
   },
 
   oke-vm-standard-ol7 = {
     description = "OKE-managed Node Pool with OKE Oracle Linux 7 image",
-    size        = 1, os = "Oracle Linux", os_version = "7",
+    size        = 1,
+    os          = "Oracle Linux",
+    os_version  = "7",
     create      = false,
   },
 
   oke-vm-standard-ol8 = {
     description = "OKE-managed Node Pool with OKE Oracle Linux 8 image",
-    size        = 1, os = "Oracle Linux", os_version = "8",
+    size        = 1,
+    os          = "Oracle Linux",
+    os_version  = "8",
   },
 
   oke-vm-standard-custom = {
     description = "OKE-managed Node Pool with custom image",
-    image_type  = "custom", image_id = "ocid1.image...", size = 1,
+    image_type  = "custom",
+    image_id    = "ocid1.image...",
+    size        = 1,
     create      = false,
   },
 }


### PR DESCRIPTION
Instead of putting multiple variables on one line, put variables on separate lines.
These examples get rendered into documentation,
so this makes these files more readable.