### PR TITLE
docs: improve formatting by putting more variables different lines

### DIFF
--- a/examples/network/vars-network-subnets-create-force.auto.tfvars
+++ b/examples/network/vars-network-subnets-create-force.auto.tfvars
@@ -2,10 +2,39 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl
 
 subnets = {
-  bastion  = { create = "always", netnum = 0, newbits = 13 }
-  operator = { create = "always", netnum = 1, newbits = 13 }
-  cp       = { create = "always", netnum = 2, newbits = 13 }
-  int_lb   = { create = "always", netnum = 16, newbits = 11 }
-  pub_lb   = { create = "always", netnum = 17, newbits = 11 }
-  workers  = { create = "always", netnum = 1, newbits = 2 }
+  bastion = {
+    create  = "always",
+    netnum  = 0,
+    newbits = 13
+  }
+
+  operator = {
+    create  = "always",
+    netnum  = 1,
+    newbits = 13
+  }
+
+  cp = {
+    create  = "always",
+    netnum  = 2,
+    newbits = 13
+  }
+
+  int_lb = {
+    create  = "always",
+    netnum  = 16,
+    newbits = 11
+  }
+
+  pub_lb = {
+    create  = "always",
+    netnum  = 17,
+    newbits = 11
+  }
+
+  workers = {
+    create  = "always",
+    netnum  = 1,
+    newbits = 2
+  }
 }

--- a/examples/profiles/network-only/main.tf
+++ b/examples/profiles/network-only/main.tf
@@ -30,12 +30,39 @@ module "network_only" {
 
   # Force creation of subnets with associated components disabled
   subnets = {
-    bastion  = { create = "always", newbits = 13 }
-    operator = { create = "always", newbits = 13 }
-    cp       = { create = "always", newbits = 13 }
-    int_lb   = { create = "always", newbits = 11 }
-    pub_lb   = { create = "always", newbits = 11 }
-    workers  = { create = "always", newbits = 4 }
-    pods     = { create = "always", newbits = 2 }
+    bastion = {
+      create  = "always",
+      newbits = 13
+    }
+
+    operator = {
+      create  = "always",
+      newbits = 13
+    }
+
+    cp = {
+      create  = "always",
+      newbits = 13
+    }
+
+    int_lb = {
+      create  = "always",
+      newbits = 11
+    }
+
+    pub_lb = {
+      create  = "always",
+      newbits = 11
+    }
+
+    workers = {
+      create  = "always",
+      newbits = 4
+    }
+
+    pods = {
+      create  = "always",
+      newbits = 2
+    }
   }
 }

--- a/examples/rms/oke-network-only/main.tf
+++ b/examples/rms/oke-network-only/main.tf
@@ -32,13 +32,47 @@ module "oke" {
   drg_display_name            = var.drg_display_name
 
   subnets = {
-    bastion  = { create = var.bastion_subnet_create ? "always" : "never", newbits = var.bastion_subnet_newbits, id = var.bastion_subnet_id }
-    operator = { create = var.operator_subnet_create ? "always" : "never", newbits = var.operator_subnet_newbits, id = var.operator_subnet_id }
-    cp       = { create = var.control_plane_subnet_create ? "always" : "never", newbits = var.control_plane_subnet_newbits, id = var.control_plane_subnet_id }
-    int_lb   = { create = var.int_lb_subnet_create ? "always" : "never", newbits = var.int_lb_subnet_newbits, id = var.int_lb_subnet_id }
-    pub_lb   = { create = var.pub_lb_subnet_create ? "always" : "never", newbits = var.pub_lb_subnet_newbits, id = var.pub_lb_subnet_id }
-    workers  = { create = var.worker_subnet_create ? "always" : "never", newbits = var.worker_subnet_newbits, id = var.worker_subnet_id }
-    pods     = { create = var.pod_subnet_create ? "always" : "never", newbits = var.pod_subnet_newbits, id = var.pod_subnet_id }
+    bastion = {
+      create  = var.bastion_subnet_create ? "always" : "never",
+      newbits = var.bastion_subnet_newbits,
+      id      = var.bastion_subnet_id
+    }
+
+    operator = {
+      create  = var.operator_subnet_create ? "always" : "never",
+      newbits = var.operator_subnet_newbits,
+      id      = var.operator_subnet_id
+    }
+
+    cp = {
+      create  = var.control_plane_subnet_create ? "always" : "never",
+      newbits = var.control_plane_subnet_newbits,
+      id      = var.control_plane_subnet_id
+    }
+
+    int_lb = {
+      create  = var.int_lb_subnet_create ? "always" : "never",
+      newbits = var.int_lb_subnet_newbits,
+      id      = var.int_lb_subnet_id
+    }
+
+    pub_lb = {
+      create  = var.pub_lb_subnet_create ? "always" : "never",
+      newbits = var.pub_lb_subnet_newbits,
+      id      = var.pub_lb_subnet_id
+    }
+
+    workers = {
+      create  = var.worker_subnet_create ? "always" : "never",
+      newbits = var.worker_subnet_newbits,
+      id      = var.worker_subnet_id
+    }
+
+    pods = {
+      create  = var.pod_subnet_create ? "always" : "never",
+      newbits = var.pod_subnet_newbits,
+      id      = var.pod_subnet_id
+    }
   }
 
   # Network Security


### PR DESCRIPTION
I personally find things a bit easier to understand in the examples
when the variables are specified on multiple lines.