### PR TITLE
fix: 5.x Use correct state_id var in resource tags

### DIFF
--- a/module-bastion.tf
+++ b/module-bastion.tf
@@ -56,11 +56,11 @@ module "bastion" {
   use_defined_tags = var.use_defined_tags
   tag_namespace    = var.tag_namespace
   defined_tags = merge(var.use_defined_tags ? {
-    "${var.tag_namespace}.state_id" = var.state_id,
+    "${var.tag_namespace}.state_id" = local.state_id,
     "${var.tag_namespace}.role"     = "bastion",
   } : {}, local.bastion_defined_tags)
   freeform_tags = merge(var.use_defined_tags ? {} : {
-    "state_id" = var.state_id,
+    "state_id" = local.state_id,
     "role"     = "bastion",
   }, local.bastion_freeform_tags)
 }

--- a/module-cluster.tf
+++ b/module-cluster.tf
@@ -71,42 +71,42 @@ module "cluster" {
   # User-provided tags are merged last and take precedence
   cluster_defined_tags = var.use_defined_tags ? merge(
     {
-      "${var.tag_namespace}.state_id" = var.state_id,
+      "${var.tag_namespace}.state_id" = local.state_id,
       "${var.tag_namespace}.role"     = "cluster",
     },
     local.cluster_defined_tags,
   ) : {}
   cluster_freeform_tags = var.use_defined_tags ? {} : merge(
     {
-      "state_id" = var.state_id,
+      "state_id" = local.state_id,
       "role"     = "cluster",
     },
     local.cluster_freeform_tags,
   )
   persistent_volume_defined_tags = var.use_defined_tags ? merge(
     {
-      "${var.tag_namespace}.state_id" = var.state_id,
+      "${var.tag_namespace}.state_id" = local.state_id,
       "${var.tag_namespace}.role"     = "persistent_volume",
     },
     local.persistent_volume_defined_tags,
   ) : {}
   persistent_volume_freeform_tags = var.use_defined_tags ? {} : merge(
     {
-      "state_id" = var.state_id,
+      "state_id" = local.state_id,
       "role"     = "persistent_volume",
     },
     local.persistent_volume_freeform_tags,
   )
   service_lb_defined_tags = var.use_defined_tags ? merge(
     {
-      "${var.tag_namespace}.state_id" = var.state_id,
+      "${var.tag_namespace}.state_id" = local.state_id,
       "${var.tag_namespace}.role"     = "service_lb"
     },
     local.service_lb_defined_tags,
   ) : {}
   service_lb_freeform_tags = var.use_defined_tags ? {} : merge(
     {
-      "state_id" = var.state_id,
+      "state_id" = local.state_id,
       "role"     = "service_lb"
     },
     local.service_lb_freeform_tags,

--- a/module-network.tf
+++ b/module-network.tf
@@ -31,13 +31,13 @@ module "vcn" {
   # Standard tags as defined if enabled for use, or freeform
   # User-provided tags are merged last and take precedence
   defined_tags = merge(var.use_defined_tags ? {
-    "${var.tag_namespace}.state_id" = var.state_id,
+    "${var.tag_namespace}.state_id" = local.state_id,
     "${var.tag_namespace}.role"     = "network",
     } : {},
     local.network_defined_tags,
   )
   freeform_tags = merge(var.use_defined_tags ? {} : {
-    "state_id" = var.state_id,
+    "state_id" = local.state_id,
     "role"     = "network",
     },
     local.network_freeform_tags,

--- a/module-operator.tf
+++ b/module-operator.tf
@@ -73,11 +73,11 @@ module "operator" {
   # Standard tags as defined if enabled for use, or freeform
   # User-provided tags are merged last and take precedence
   defined_tags = merge(var.use_defined_tags ? {
-    "${var.tag_namespace}.state_id" = var.state_id,
+    "${var.tag_namespace}.state_id" = local.state_id,
     "${var.tag_namespace}.role"     = "operator",
   } : {}, local.operator_defined_tags)
   freeform_tags = merge(var.use_defined_tags ? {} : {
-    "state_id" = var.state_id,
+    "state_id" = local.state_id,
     "role"     = "operator",
   }, local.operator_freeform_tags)
   use_defined_tags = var.use_defined_tags


### PR DESCRIPTION
Change `var.state_id` -> `local.state_id` in resource tags for proper [fallback to generated value](https://github.com/oracle-terraform-modules/terraform-oci-oke/blob/5.x/data-common.tf#L5) when `use_defined_tags = true`.