### PR TITLE
docs: Add clarifying examples for operator instance principal

### DIFF
--- a/docs/src/guide/operator_identity.md
+++ b/docs/src/guide/operator_identity.md
@@ -1,8 +1,12 @@
 # Operator: Identity
 
-## Authorizing the operator `instance_principal`
+## `instance_principal`
 
 [Instance_principal](https://docs.cloud.oracle.com/iaas/Content/Identity/Tasks/callingservicesfrominstances.htm) is an IAM service feature that enables instances to be authorized actors (or principals) to perform actions on service resources. Each compute instance has its own identity, and it authenticates using the certificates that are added to it. These certificates are automatically created, assigned to instances and rotated, preventing the need for you to distribute credentials to your hosts and rotate them.
+
+[Dynamic Groups](https://docs.oracle.com/en-us/iaas/Content/Identity/Tasks/callingservicesfrominstances.htm) group OCI instances as principal actors, similar to user groups.  IAM policies can then
+be created to allow instances in these groups to make calls against OCI infrastructure services.  For example, on the operator host,
+this permits kubectl to access the OKE cluster.
 
 Any user who has access to the instance (who can SSH to the instance), automatically inherits the privileges granted to the instance. Before you enable this feature, ensure that you know who can access it, and that they should be authorized with the permissions you are granting to the instance.
 
@@ -10,4 +14,20 @@ By default, this feature is **disabled**. However, it is **required** at the tim
 
 When you enable this feature, by default, the operator host will have privileges to all resources in the compartment. If you are enabling it for [KMS Integration](), the operator host will also have rights to create policies in the root tenancy. 
 
-You can also turn on and off the feature at any time without impact on the operator or the cluster.
+## Enabling `instance_principal` for the operator instance
+
+`instance_principal` for the operator instance can be enabled or disabled at any time without impact on the operator or the cluster.
+
+To enable this feature, specify the following to create of the necessary IAM policies,
+[Dynamic Groups](https://docs.oracle.com/en-us/iaas/Content/Identity/Tasks/callingservicesfrominstances.htm), and [Matching Rules](https://docs.oracle.com/en-us/iaas/Content/Identity/Tasks/callingservicesfrominstances.htm):
+
+```properties
+create_iam_resources = true
+create_iam_operator_policy = "always"
+```
+
+To disable this feature, specify:
+
+```properties
+create_iam_operator_policy = "never"
+```


### PR DESCRIPTION
Added some clarifying text on operator instance principal, based on
discussion in https://github.com/oracle-terraform-modules/terraform-oci-oke/issues/776