### PR TITLE
fix: 5.x Unspecified default placement FDs when mode != virtual-node-pool

### DIFF
--- a/modules/workers/instance.tf
+++ b/modules/workers/instance.tf
@@ -1,6 +1,7 @@
 resource "oci_core_instance" "workers" {
   for_each             = local.enabled_instances
   availability_domain  = element(each.value.availability_domains, 1)
+  fault_domain         = try(each.value.placement_fds[0], null)
   compartment_id       = each.value.compartment_id
   display_name         = each.key
   preserve_boot_volume = false

--- a/modules/workers/instanceconfig.tf
+++ b/modules/workers/instanceconfig.tf
@@ -15,15 +15,8 @@ resource "oci_core_instance_configuration" "workers" {
     launch_details {
       availability_domain = element(each.value.availability_domains, 1)
 
-      # Intersect the list of available and configured FDs for this AD, selecting the first
-      fault_domain = element(tolist(setintersection(
-        each.value.placement_fds,
-        lookup(
-          local.fault_domains_available,
-          element(each.value.availability_domains, 1),
-          each.value.placement_fds
-        )
-      )), 1)
+      # First value specified on pool, or null to select automatically
+      fault_domain = try(each.value.placement_fds[0], null)
 
       compartment_id          = each.value.compartment_id
       defined_tags            = each.value.defined_tags

--- a/modules/workers/instancepools.tf
+++ b/modules/workers/instancepools.tf
@@ -20,11 +20,8 @@ resource "oci_core_instance_pool" "workers" {
       availability_domain = ad.value
       primary_subnet_id   = each.value.subnet_id
 
-      # Intersect the list of available and configured FDs for this AD
-      fault_domains = tolist(setintersection(
-        each.value.placement_fds,
-        lookup(local.fault_domains_available, ad.value, local.fault_domains_default)
-      ))
+      # Value(s) specified on pool, or null to select automatically
+      fault_domains = try(each.value.placement_fds, null)
 
       dynamic "secondary_vnic_subnets" {
         for_each = lookup(each.value, "secondary_vnics", {})

--- a/modules/workers/locals.tf
+++ b/modules/workers/locals.tf
@@ -7,7 +7,8 @@ locals {
   ocpus            = max(1, lookup(var.shape, "ocpus", 1))
   shape            = lookup(var.shape, "shape", "VM.Standard.E4.Flex")
 
-  fault_domains_default = formatlist("FD-%v", [1, 2, 3])
+  # Used for default values of required input for virtual node pools
+  fault_domains_all = formatlist("FD-%v", [1, 2, 3])
   fault_domains_available = {
     for ad, fd in data.oci_identity_fault_domains.all : ad => fd
   }
@@ -35,7 +36,6 @@ locals {
     os                         = var.image_os
     os_version                 = var.image_os_version
     placement_ads              = var.ad_numbers
-    placement_fds              = local.fault_domains_default
     platform_config            = var.platform_config
     pod_nsg_ids                = var.pod_nsg_ids
     pod_subnet_id              = coalesce(var.pod_subnet_id, var.worker_subnet_id, "none")

--- a/modules/workers/nodepools.tf
+++ b/modules/workers/nodepools.tf
@@ -31,11 +31,8 @@ resource "oci_containerengine_node_pool" "workers" {
         capacity_reservation_id = each.value.capacity_reservation_id
         subnet_id               = each.value.subnet_id
 
-        # Intersect the list of available and configured FDs for this AD
-        fault_domains = tolist(setintersection(
-          each.value.placement_fds,
-          lookup(local.fault_domains_available, ad.value, local.fault_domains_default)
-        ))
+        # Value(s) specified on pool, or null to select automatically
+        fault_domains = try(each.value.placement_fds, null)
 
         dynamic "preemptible_node_config" {
           for_each = each.value.preemptible_config.enable ? [1] : []

--- a/modules/workers/virtualnodepools.tf
+++ b/modules/workers/virtualnodepools.tf
@@ -23,8 +23,8 @@ resource "oci_containerengine_virtual_node_pool" "workers" {
 
       # Intersect the list of available and configured FDs for this AD
       fault_domain = tolist(setintersection(
-        each.value.placement_fds,
-        lookup(local.fault_domains_available, ad.value, local.fault_domains_default)
+        try(each.value.placement_fds, local.fault_domains_all),
+        lookup(local.fault_domains_available, ad.value, local.fault_domains_all)
       ))
     }
   }


### PR DESCRIPTION
* Omit placement fault domains unless specified to avoid changes to existing resources, as input is not required when mode != `virtual-node-pool`.