### PR TITLE
5.x: OKE provisioning on sub-compartment with support of custom identity domain.

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -8,6 +8,7 @@
   - [Identity](./guide/identity.md)
     - [Policies](./guide/identity_policies.md)
     - [Tags](./guide/identity_tags.md)
+    - [Identity Domain](./guide/identity_domain.md)
   - [Network](./guide/network.md)
     - [Subnets](./guide/network_subnets.md)
     - [Network Security Groups](./guide/network_nsgs.md)    

--- a/docs/src/guide/identity.md
+++ b/docs/src/guide/identity.md
@@ -1,3 +1,5 @@
 # Identity
 
-Optional creation of Identity Dynamic Groups, Policies, and Tags.
+## IAM without Identity Domains
+
+Optional creation of Identity [Dynamic Groups](https://docs.oracle.com/en-us/iaas/Content/Identity/Tasks/managingdynamicgroups.htm), [Policies](https://docs.oracle.com/en-us/iaas/Content/Identity/Tasks/managingpolicies.htm), and Tags.

--- a/docs/src/guide/identity_domain.md
+++ b/docs/src/guide/identity_domain.md
@@ -1,0 +1,16 @@
+# IAM with Identity Domains
+
+Creation of Identity [Dynamic Groups](https://docs.oracle.com/en-us/iaas/Content/Identity/dynamicgroups/managingdynamicgroups.htm), [Policies](https://docs.oracle.com/en-us/iaas/Content/Identity/Tasks/managingpolicies.htm), and Tags.
+
+
+## Context
+
+While you might not have the necessary policy permissions to provision OKE clusters directly at Tenancy level (ROOT compartment) and you have full control only under a sub-compartment, the following parameters will allow you to reference an existing and custom `identity domain` at this sub-compartment level. The `Dynamic Groups` will be then created in this Identity Domain while the policies will be created at the sub-compartment level and their statements using the `dynamic group` in your `identity domain`
+
+Moreover, You can use this Identity Domain, to create service account users for your Kubernetes/OKE controllers or operators.
+
+## Usage
+
+```javascript
+{{#include ../../../examples/iam/vars-subcompartment-iam-identitydomain.auto.tfvars:4:}}
+```

--- a/module-iam.tf
+++ b/module-iam.tf
@@ -55,7 +55,8 @@ module "iam" {
   source                       = "./modules/iam"
   compartment_id               = local.compartment_id
   state_id                     = local.state_id
-  tenancy_id                   = local.tenancy_id
+  tenancy_id                   = local.iam_compartment_id
+  identity_domain_name         = local.identity_domain_name
   cluster_id                   = local.cluster_id
   create_iam_resources         = var.create_iam_resources
   create_iam_autoscaler_policy = local.create_iam_autoscaler_policy

--- a/modules/iam/data-common.tf
+++ b/modules/iam/data-common.tf
@@ -1,0 +1,26 @@
+# Copyright (c) 2022, 2023 Oracle Corporation and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl
+
+locals {
+  identity_domain_name = coalesce(var.identity_domain_name, "Default" )
+  isDefaultIdentityDomain = local.identity_domain_name == "Default" ? true : false
+}
+
+data "oci_identity_domains" "domains" {
+  count = local.isDefaultIdentityDomain ? 0 : 1
+
+  #Required
+  compartment_id = var.tenancy_id # dynamic groups exist in the parent compartment.
+
+  #Optional
+  display_name = var.identity_domain_name
+  #home_region_url = var.domain_home_region_url  ## TODO: provide the home region
+  #is_hidden_on_login = var.domain_is_hidden_on_login
+  #license_type = var.domain_license_type
+  #name = var.domain_name
+  #state = var.domain_state
+  #type = var.domain_type
+  #url = var.domain_url
+
+  provider = oci.home
+}

--- a/modules/iam/group-workers.tf
+++ b/modules/iam/group-workers.tf
@@ -18,15 +18,15 @@ locals {
   ])))
 
   cluster_join_statements = formatlist(
-    "Allow dynamic-group %v to {CLUSTER_JOIN} in compartment id %v where %v",
-    local.worker_group_name, local.worker_compartments, local.cluster_join_where_clause
+    "Allow dynamic-group '%v'/'%v' to {CLUSTER_JOIN} in compartment id %v where %v",
+    local.identity_domain_name, local.worker_group_name, local.worker_compartments, local.cluster_join_where_clause
   )
 
   # TODO support keys defined at worker group level
   worker_kms_volume_templates = tolist([
     "Allow service oke to USE key-delegates in compartment id %v where target.key.id = '%v'",
     "Allow service blockstorage to USE keys in compartment id %v where target.key.id = '%v'",
-    "Allow dynamic-group ${local.worker_group_name} to USE key-delegates in compartment id %v where target.key.id = '%v'"
+    "Allow dynamic-group '${local.identity_domain_name}'/'${local.worker_group_name}' to USE key-delegates in compartment id %v where target.key.id = '%v'"
   ])
 
   # Block volume encryption using OCI Key Management System (KMS)
@@ -43,7 +43,7 @@ locals {
 
 resource "oci_identity_dynamic_group" "workers" {
   provider       = oci.home
-  count          = var.create_iam_resources && var.create_iam_worker_policy ? 1 : 0
+  count          = var.create_iam_resources && var.create_iam_worker_policy && local.isDefaultIdentityDomain ? 1 : 0
   compartment_id = var.tenancy_id # dynamic groups exist in root compartment (tenancy)
   description    = format("Dynamic group of self-managed worker nodes for OKE Terraform state %v", var.state_id)
   matching_rule  = local.worker_group_rules
@@ -53,4 +53,19 @@ resource "oci_identity_dynamic_group" "workers" {
   lifecycle {
     ignore_changes = [defined_tags, freeform_tags]
   }
+}
+
+resource "oci_identity_domains_dynamic_resource_group" "workers" {
+  provider      = oci.home
+  count         = var.create_iam_resources && var.create_iam_worker_policy && !local.isDefaultIdentityDomain ? 1 : 0
+  #Optional
+  description   = format("Dynamic group of self-managed worker nodes for OKE Terraform state %v", var.state_id)
+  #Required
+  matching_rule = local.worker_group_rules
+  display_name  = local.worker_group_name
+  idcs_endpoint = data.oci_identity_domains.domains[0].domains[0]["url"]
+  schemas = [
+    "urn:ietf:params:scim:schemas:oracle:idcs:DynamicResourceGroup",
+    "urn:ietf:params:scim:schemas:oracle:idcs:extension:OCITags"
+  ]
 }

--- a/modules/iam/outputs.tf
+++ b/modules/iam/outputs.tf
@@ -3,12 +3,17 @@
 
 output "dynamic_group_ids" {
   description = "Cluster IAM dynamic group IDs"
-  value = local.has_policy_statements ? compact([
-    one(oci_identity_dynamic_group.cluster[*].id),
-    one(oci_identity_dynamic_group.workers[*].id),
-    one(oci_identity_dynamic_group.autoscaling[*].id),
-    one(oci_identity_dynamic_group.operator[*].id),
-  ]) : null
+  value = local.has_policy_statements && local.isDefaultIdentityDomain ? compact([
+      one(oci_identity_dynamic_group.cluster[*].id),
+      one(oci_identity_dynamic_group.workers[*].id),
+      one(oci_identity_dynamic_group.autoscaling[*].id),
+      one(oci_identity_dynamic_group.operator[*].id),
+    ]) : local.has_policy_statements && !local.isDefaultIdentityDomain ? compact([
+      one(oci_identity_domains_dynamic_resource_group.cluster[*].id),
+      one(oci_identity_domains_dynamic_resource_group.workers[*].id),
+      one(oci_identity_domains_dynamic_resource_group.autoscaling[*].id),
+      one(oci_identity_domains_dynamic_resource_group.operator[*].id),
+    ]) : null
 }
 
 output "policy_statements" {

--- a/modules/iam/variables.tf
+++ b/modules/iam/variables.tf
@@ -7,6 +7,7 @@ variable "compartment_id" { type = string }
 variable "state_id" { type = string }
 variable "tenancy_id" { type = string }
 variable "worker_compartments" { type = list(string) }
+variable "identity_domain_name" { type = string }
 
 # Tags
 variable "create_iam_defined_tags" { type = bool }

--- a/variables-iam.tf
+++ b/variables-iam.tf
@@ -3,6 +3,8 @@
 
 locals {
   tenancy_id            = coalesce(var.tenancy_id, var.tenancy_ocid, "unknown")
+  iam_compartment_id    = coalesce(var.iam_compartment_id, local.tenancy_id)
+  identity_domain_name  = coalesce(var.identity_domain_name, "Default")
   compartment_id        = coalesce(var.compartment_id, var.compartment_ocid, var.tenancy_id)
   worker_compartment_id = coalesce(var.worker_compartment_id, var.compartment_id)
   user_id               = var.user_id != "" ? var.user_id : var.current_user_ocid
@@ -47,6 +49,18 @@ variable "tenancy_id" {
 variable "tenancy_ocid" {
   default     = null
   description = "A tenancy OCID automatically populated by Resource Manager."
+  type        = string
+}
+
+variable "iam_compartment_id" {
+  default     = null
+  description = "The comparment id of the parent comparment in which to create the IAM resources."
+  type        = string
+}
+
+variable "identity_domain_name" {
+  default     = null
+  description = "The Identity domain name to use. If not defined, it will use the tenancy default"
   type        = string
 }
 


### PR DESCRIPTION
This PR relates to the issue #768.

OKE provisioning on sub-compartment which has no direct policy permission at the tenancy level.
This also support the case which has a custom identity domain in the sub-compartment instead of using the Default one at the tenancy level.


 