### PR TITLE
feat: 5.x Update outputs for worker pools/ips/ids, eviction grace in seconds

### DIFF
--- a/examples/workers/vars-workers-drain.auto.tfvars
+++ b/examples/workers/vars-workers-drain.auto.tfvars
@@ -4,6 +4,7 @@
 worker_pool_mode = "node-pool"
 worker_pool_size = 1
 
+# Configuration for draining nodes through operator
 worker_drain_ignore_daemonsets = true
 worker_drain_delete_local_data = true
 worker_drain_timeout_seconds   = 900
@@ -14,11 +15,16 @@ worker_pools = {
     size        = 2,
   },
   oke-vm-draining = {
-    description = "Node pool with scheduling disabled and draining",
+    description = "Node pool with scheduling disabled and draining through operator",
     drain       = true,
   },
   oke-vm-disabled = {
     description = "Node pool with resource creation disabled (destroyed)",
     create      = false,
+  },
+  oke-managed-drain = {
+    description                          = "Node pool with custom settings for managed cordon & drain",
+    eviction_grace_duration              = 30, # specified in seconds
+    is_force_delete_after_grace_duration = true
   },
 }

--- a/module-workers.tf
+++ b/module-workers.tf
@@ -84,16 +84,21 @@ module "workers" {
 }
 
 output "worker_pools" {
-  description = "Enabled worker pools"
-  value       = var.output_detail && local.worker_count_expected > 0 ? one(module.workers[*].worker_pools) : null
+  description = "Created worker pools (mode != 'instance')"
+  value       = var.output_detail && local.worker_count_expected > 0 ? try(one(module.workers[*].worker_pools), null) : null
+}
+
+output "worker_instances" {
+  description = "Created worker pools (mode == 'instance')"
+  value       = var.output_detail && local.worker_count_expected > 0 ? try(one(module.workers[*].worker_instances), null) : null
 }
 
 output "worker_pool_ids" {
   description = "Enabled worker pool IDs"
-  value       = local.worker_count_expected > 0 ? one(module.workers[*].worker_pool_ids) : null
+  value       = local.worker_count_expected > 0 ? try(one(module.workers[*].worker_pool_ids), null) : null
 }
 
-output "worker_instance_ids" {
-  description = "Created worker instance IDs (mode == 'instance'). Excludes pool-managed instances."
-  value       = one(module.workers[*].worker_instance_ids)
+output "worker_pool_ips" {
+  description = "Created worker instance private IPs by pool for available modes ('node-pool', 'instance')."
+  value       = local.worker_count_expected > 0 ? try(one(module.workers[*].worker_pool_ips), null) : null
 }

--- a/modules/workers/nodepools.tf
+++ b/modules/workers/nodepools.tf
@@ -80,7 +80,7 @@ resource "oci_containerengine_node_pool" "workers" {
   )
 
   node_eviction_node_pool_settings {
-    eviction_grace_duration              = format("PT%sM", each.value.eviction_grace_duration)
+    eviction_grace_duration              = format("PT%sS", each.value.eviction_grace_duration)
     is_force_delete_after_grace_duration = tobool(each.value.force_node_delete)
   }
 

--- a/modules/workers/outputs.tf
+++ b/modules/workers/outputs.tf
@@ -2,8 +2,13 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl
 
 output "worker_pools" {
-  description = "Created worker pools"
+  description = "Created worker pools (mode != 'instance')"
   value       = local.worker_pools_output
+}
+
+output "worker_instances" {
+  description = "Created worker pools (mode == 'instance')"
+  value       = local.worker_instances
 }
 
 output "worker_pool_ids" {
@@ -11,9 +16,9 @@ output "worker_pool_ids" {
   value       = local.worker_pool_ids
 }
 
-output "worker_instance_ids" {
-  description = "Created worker instance IDs (mode == 'instance'). Excludes pool-managed instances."
-  value       = local.worker_instance_ids
+output "worker_pool_ips" {
+  description = "Created worker instance private IPs by pool for available modes ('node-pool', 'instance')."
+  value       = local.worker_pool_ips
 }
 
 output "worker_count_expected" {


### PR DESCRIPTION
* Updated worker outputs for instance IDs => IPs where available
```
Outputs:

worker_pool_ips = {
  "example-mode-instance" = {
    "ocid1.instance..." = "10.x.x.x"
  }
  "example-mode-nodepool" = {
    "ocid1.instance..." = "10.x.x.x"
  }
}
```

* Managed node pool cordon & drain eviction grace period in seconds; fixes reported change:
```
  # module.workers.module.workers[0].oci_containerengine_node_pool.workers["..."] will be updated in-place                                                                      
  ~ resource "oci_containerengine_node_pool" "workers" {                                                                                                                                
...
      ~ node_eviction_node_pool_settings {
          ~ eviction_grace_duration              = "PT0S" -> "PT0M"
            # (1 unchanged attribute hidden)
        }
```