### PR TITLE
Fix: Ignore prohibit_public_ip_on_vnic changes in control plane subnet

### DIFF
--- a/modules/network/subnets.tf
+++ b/modules/network/subnets.tf
@@ -12,7 +12,7 @@ resource "oci_core_subnet" "cp" {
   vcn_id                     = var.vcn_id
 
   lifecycle {
-    ignore_changes = [dns_label]
+    ignore_changes = [dns_label, prohibit_public_ip_on_vnic]
   }
 }
 


### PR DESCRIPTION
If `prohibit_public_ip_on_vnic` isn't ignored, then changing the k8s API endpoint between public and private requires recreating the entire cluster.