### PR TITLE
fix: 5.x Subnet dns_label, cloud_init error handling, SSH command cleanup

### DIFF
--- a/modules/bastion/compute.tf
+++ b/modules/bastion/compute.tf
@@ -63,7 +63,11 @@ resource "oci_core_instance" "bastion" {
   }
 
   lifecycle {
-    ignore_changes = [availability_domain, defined_tags, freeform_tags, metadata, source_details, display_name]
+    ignore_changes = [
+      availability_domain,
+      defined_tags, freeform_tags, display_name,
+      create_vnic_details, metadata, source_details,
+    ]
 
     precondition {
       condition     = coalesce(var.image_id, "none") != "none"

--- a/modules/operator/compute.tf
+++ b/modules/operator/compute.tf
@@ -74,7 +74,12 @@ resource "oci_core_instance" "operator" {
   }
 
   lifecycle {
-    ignore_changes       = [defined_tags, freeform_tags, metadata, display_name]
+    ignore_changes = [
+      availability_domain,
+      defined_tags, freeform_tags, display_name,
+      create_vnic_details, metadata, source_details,
+    ]
+
     replace_triggered_by = [null_resource.operator_changed]
     precondition {
       condition     = coalesce(var.image_id, "none") != "none"

--- a/modules/workers/locals.tf
+++ b/modules/workers/locals.tf
@@ -72,7 +72,7 @@ locals {
         {
           # Load content from file if local path, attempt base64 decode, or use raw value
           content = contains(keys(part), "content") ? (
-            fileexists(lookup(part, "content")) ? file(lookup(part, "content"))
+            try(fileexists(lookup(part, "content")), false) ? file(lookup(part, "content"))
             : try(base64decode(lookup(part, "content")), lookup(part, "content"))
           ) : ""
           content_type = lookup(part, "content_type", local.default_cloud_init_content_type)

--- a/variables-common.tf
+++ b/variables-common.tf
@@ -3,7 +3,8 @@
 
 locals {
   # SSH key precedence: base64-encoded PEM > raw PEM > file PEM > null
-  ssh_key_arg = coalesce(var.ssh_private_key_path, "none") != "none" ? " -i ${var.ssh_private_key_path}" : ""
+  ssh_key_arg = (coalesce(var.ssh_private_key_path, "none") != "none"
+  ? join(" ", ["-i", var.ssh_private_key_path]) : null)
   ssh_private_key = sensitive(
     coalesce(var.ssh_private_key, "none") != "none"
     ? try(base64decode(var.ssh_private_key), var.ssh_private_key)

--- a/variables-network.tf
+++ b/variables-network.tf
@@ -121,7 +121,7 @@ variable "subnets" {
   }
   description = "Configuration for standard subnets. The 'create' parameter of each entry defaults to 'auto', creating subnets when other enabled components are expected to utilize them, and may be configured with 'never' or 'always' to force disabled/enabled."
   type = map(object({
-    create    = optional(string, "auto")
+    create    = optional(string)
     id        = optional(string)
     newbits   = optional(string)
     netnum    = optional(string)
@@ -156,7 +156,7 @@ variable "nsgs" {
   }
   description = "Configuration for standard network security groups (NSGs).  The 'create' parameter of each entry defaults to 'auto', creating NSGs when other enabled components are expected to utilize them, and may be configured with 'never' or 'always' to force disabled/enabled."
   type = map(object({
-    create = optional(string, "auto")
+    create = optional(string)
     id     = optional(string)
   }))
   validation {


### PR DESCRIPTION
- Fix evaluation of `dns_label` in `var.subnets` to use specified/generated values when `var.assign_dns = true` (Fixes #780)
- Consistent lifecycle ignore of `dns_label` with bastion/operator `hostname_label`
- Add error handling for `cloud_init.content` when attempting evaluation as file path
- Cosmetic fixes and safe interpolation for bastion/operator SSH commands (Fixes #782)