### PR TITLE
fix: 5.x Update Cluster Autoscaler docs, image tag

### DIFF
--- a/docs/src/guide/extensions_cluster_autoscaler.md
+++ b/docs/src/guide/extensions_cluster_autoscaler.md
@@ -5,8 +5,8 @@ Deployed using the [cluster-autoscaler Helm chart](https://github.com/kubernetes
 The following parameters may be added on each pool definition to enable management or scheduling of the cluster autoscaler:
 * `allow_autoscaler`: Enable scheduling of the cluster autoscaler deployment on a pool by adding a node label matching the deployment's nodeSelector, and an OCI tag for use with [IAM tag-based policies](https://docs.oracle.com/en-us/iaas/Content/Tagging/Tasks/managingaccesswithtags.htm) granting access to the instances.
 * `autoscale`: Enable cluster autoscaler management of the pool by including a `--nodes` argument for it.
-* `minSize`: Define the minimum scale of a pool managed by the cluster autoscaler. Defaults to `size` when not provided.
-* `maxSize`: Define the minimum scale of a pool managed by the cluster autoscaler. Defaults to `size` when not provided.
+* `min_size`: Define the minimum scale of a pool managed by the cluster autoscaler. Defaults to `size` when not provided.
+* `max_size`: Define the maximum scale of a pool managed by the cluster autoscaler. Defaults to `size` when not provided.
 
 ### Usage
 ```javascript

--- a/examples/workers/vars-workers-autoscaling.auto.tfvars
+++ b/examples/workers/vars-workers-autoscaling.auto.tfvars
@@ -6,8 +6,9 @@
 worker_pools = {
   np-autoscaled = {
     description = "Node pool managed by cluster autoscaler",
-    size        = 1,
-    size_max    = 2,
+    size        = 2,
+    min_size    = 1,
+    max_size    = 3,
     autoscale   = true,
   },
   np-autoscaler = {

--- a/modules/extensions/autoscaler.tf
+++ b/modules/extensions/autoscaler.tf
@@ -36,7 +36,7 @@ locals {
     "extraEnv.OKE_USE_INSTANCE_PRINCIPAL"        = "true",
     "extraEnv.OCI_SDK_APPEND_USER_AGENT"         = "oci-oke-cluster-autoscaler",
     "image.repository"                           = "iad.ocir.io/oracle/oci-cluster-autoscaler",
-    "image.tag"                                  = "1.24.0-5",
+    "image.tag"                                  = "1.26.2-7",
   }
 }
 


### PR DESCRIPTION
- Update Cluster Autoscaler docs/examples with correct `min_size`/`max_size` parameters
- Update Cluster Autoscaler deployment image tag version -> `1.26.2-7` ([reference](https://docs.oracle.com/en-us/iaas/Content/ContEng/Tasks/contengusingclusterautoscaler.htm))