### PR TITLE
fix: 5.x Evaluation for auto NSG creation with defaults

### DIFF
--- a/module-operator.tf
+++ b/module-operator.tf
@@ -105,5 +105,6 @@ output "operator_private_ip" {
 output "ssh_to_operator" {
   description = "SSH command for operator host"
   value = local.operator_enabled ? join(" ", concat(["ssh"],
-    local.bastion_proxy_command, local.operator_ssh_args)) : null
+    local.bastion_proxy_command, local.operator_ssh_args)
+  ) : null
 }

--- a/modules/network/nsg-bastion.tf
+++ b/modules/network/nsg-bastion.tf
@@ -3,10 +3,11 @@
 
 locals {
   bastion_nsg_config = try(var.nsgs.bastion, { create = "never" })
+  bastion_nsg_create = coalesce(lookup(local.bastion_nsg_config, "create", null), "auto")
   bastion_nsg_enabled = anytrue([
-    lookup(local.bastion_nsg_config, "create", "auto") == "always",
+    local.bastion_nsg_create == "always",
     alltrue([
-      lookup(local.bastion_nsg_config, "create", "auto") == "auto",
+      local.bastion_nsg_create == "auto",
       coalesce(lookup(local.bastion_nsg_config, "id", null), "none") == "none",
       var.create_cluster, var.create_bastion,
     ]),

--- a/modules/network/nsg-controlplane.tf
+++ b/modules/network/nsg-controlplane.tf
@@ -3,10 +3,11 @@
 
 locals {
   control_plane_nsg_config = try(var.nsgs.cp, { create = "never" })
+  control_plane_nsg_create = coalesce(lookup(local.control_plane_nsg_config, "create", null), "auto")
   control_plane_nsg_enabled = anytrue([
-    lookup(local.control_plane_nsg_config, "create", "auto") == "always",
+    local.control_plane_nsg_create == "always",
     alltrue([
-      lookup(local.control_plane_nsg_config, "create", "auto") == "auto",
+      local.control_plane_nsg_create == "auto",
       coalesce(lookup(local.control_plane_nsg_config, "id", null), "none") == "none",
       var.create_cluster,
     ]),

--- a/modules/network/nsg-fss.tf
+++ b/modules/network/nsg-fss.tf
@@ -3,10 +3,11 @@
 
 locals {
   fss_nsg_config = try(var.nsgs.fss, { create = "never" })
+  fss_nsg_create = coalesce(lookup(local.fss_nsg_config, "create", null), "auto")
   fss_nsg_enabled = anytrue([
-    lookup(local.fss_nsg_config, "create", "auto") == "always",
+    local.fss_nsg_create == "always",
     alltrue([
-      lookup(local.fss_nsg_config, "create", "auto") == "auto",
+      local.fss_nsg_create == "auto",
       coalesce(lookup(local.fss_nsg_config, "id", null), "none") == "none",
       var.create_cluster,
     ]),

--- a/modules/network/nsg-loadbalancers-int.tf
+++ b/modules/network/nsg-loadbalancers-int.tf
@@ -3,10 +3,11 @@
 
 locals {
   int_lb_nsg_config = try(var.nsgs.int_lb, { create = "never" })
+  int_lb_nsg_create = coalesce(lookup(local.int_lb_nsg_config, "create", null), "auto")
   int_lb_nsg_enabled = anytrue([
-    lookup(local.int_lb_nsg_config, "create", "auto") == "always",
+    local.int_lb_nsg_create == "always",
     alltrue([
-      lookup(local.int_lb_nsg_config, "create", "auto") == "auto",
+      local.int_lb_nsg_create == "auto",
       coalesce(lookup(local.int_lb_nsg_config, "id", null), "none") == "none",
       var.create_cluster, var.load_balancers == "internal" || var.load_balancers == "both",
     ]),

--- a/modules/network/nsg-loadbalancers-pub.tf
+++ b/modules/network/nsg-loadbalancers-pub.tf
@@ -3,10 +3,11 @@
 
 locals {
   pub_lb_nsg_config = try(var.nsgs.pub_lb, { create = "never" })
+  pub_lb_nsg_create = coalesce(lookup(local.pub_lb_nsg_config, "create", null), "auto")
   pub_lb_nsg_enabled = anytrue([
-    lookup(local.pub_lb_nsg_config, "create", "auto") == "always",
+    local.pub_lb_nsg_create == "always",
     alltrue([
-      lookup(local.pub_lb_nsg_config, "create", "auto") == "auto",
+      local.pub_lb_nsg_create == "auto",
       coalesce(lookup(local.pub_lb_nsg_config, "id", null), "none") == "none",
       var.create_cluster, var.load_balancers == "public" || var.load_balancers == "both",
     ]),

--- a/modules/network/nsg-operator.tf
+++ b/modules/network/nsg-operator.tf
@@ -3,10 +3,11 @@
 
 locals {
   operator_nsg_config = try(var.nsgs.operator, { create = "never" })
+  operator_nsg_create = coalesce(lookup(local.operator_nsg_config, "create", null), "auto")
   operator_nsg_enabled = anytrue([
-    lookup(local.operator_nsg_config, "create", "auto") == "always",
+    local.operator_nsg_create == "always",
     alltrue([
-      lookup(local.operator_nsg_config, "create", "auto") == "auto",
+      local.operator_nsg_create == "auto",
       coalesce(lookup(local.operator_nsg_config, "id", null), "none") == "none",
       var.create_cluster, var.create_operator,
     ]),

--- a/modules/network/nsg-pods.tf
+++ b/modules/network/nsg-pods.tf
@@ -3,10 +3,11 @@
 
 locals {
   pod_nsg_config = try(var.nsgs.pods, { create = "never" })
+  pod_nsg_create = coalesce(lookup(local.pod_nsg_config, "create", null), "auto")
   pod_nsg_enabled = anytrue([
-    lookup(local.pod_nsg_config, "create", "auto") == "always",
+    local.pod_nsg_create == "always",
     alltrue([
-      lookup(local.pod_nsg_config, "create", "auto") == "auto",
+      local.pod_nsg_create == "auto",
       coalesce(lookup(local.pod_nsg_config, "id", null), "none") == "none",
       var.create_cluster, var.cni_type == "npn",
     ]),

--- a/modules/network/nsg-workers.tf
+++ b/modules/network/nsg-workers.tf
@@ -3,10 +3,11 @@
 
 locals {
   worker_nsg_config = try(var.nsgs.workers, { create = "never" })
+  worker_nsg_create = coalesce(lookup(local.worker_nsg_config, "create", null), "auto")
   worker_nsg_enabled = anytrue([
-    lookup(local.worker_nsg_config, "create", "auto") == "always",
+    local.worker_nsg_create == "always",
     alltrue([
-      lookup(local.worker_nsg_config, "create", "auto") == "auto",
+      local.worker_nsg_create == "auto",
       coalesce(lookup(local.worker_nsg_config, "id", null), "none") == "none",
       var.create_cluster,
     ]),


### PR DESCRIPTION
The fallback to "auto" was not working properly as a value of `null` was found:
```
lookup(local.bastion_nsg_config, "create", "auto") == "always",
```

This is now coalesced to the default value "auto" as expected.