### PR TITLE
feat: Bump oracle/oci dependency to ">= 4.119.0"

### DIFF
--- a/docs/src/dependencies.md
+++ b/docs/src/dependencies.md
@@ -7,7 +7,7 @@
 | <a name="requirement_cloudinit"></a> [cloudinit](#requirement\_cloudinit) | >= 2.2.0 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 2.9.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >= 3.2.1 |
-| <a name="requirement_oci"></a> [oci](#requirement\_oci) | >= 4.115.0 |
+| <a name="requirement_oci"></a> [oci](#requirement\_oci) | >= 4.119.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.4.3 |
 | <a name="requirement_time"></a> [time](#requirement\_time) | >= 0.9.1 |
 
@@ -15,7 +15,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_oci"></a> [oci](#provider\_oci) | >= 4.115.0 |
+| <a name="provider_oci"></a> [oci](#provider\_oci) | >= 4.119.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | >= 3.4.3 |
 
 ## Modules

--- a/examples/profiles/cluster-workers-only/versions.tf
+++ b/examples/profiles/cluster-workers-only/versions.tf
@@ -7,7 +7,7 @@ terraform {
   required_providers {
     oci = {
       source  = "oracle/oci"
-      version = ">= 4.115.0"
+      version = ">= 4.119.0"
     }
   }
 }

--- a/examples/profiles/network-cluster-workers/versions.tf
+++ b/examples/profiles/network-cluster-workers/versions.tf
@@ -7,7 +7,7 @@ terraform {
   required_providers {
     oci = {
       source  = "oracle/oci"
-      version = ">= 4.115.0"
+      version = ">= 4.119.0"
     }
   }
 }

--- a/examples/profiles/network-only/versions.tf
+++ b/examples/profiles/network-only/versions.tf
@@ -7,7 +7,7 @@ terraform {
   required_providers {
     oci = {
       source  = "oracle/oci"
-      version = ">= 4.115.0"
+      version = ">= 4.119.0"
     }
   }
 }

--- a/examples/profiles/workers-only/versions.tf
+++ b/examples/profiles/workers-only/versions.tf
@@ -7,7 +7,7 @@ terraform {
   required_providers {
     oci = {
       source  = "oracle/oci"
-      version = ">= 4.115.0"
+      version = ">= 4.119.0"
     }
   }
 }

--- a/examples/rms/oke-cluster-only/versions.tf
+++ b/examples/rms/oke-cluster-only/versions.tf
@@ -9,7 +9,7 @@ terraform {
     oci = {
       configuration_aliases = [oci.home]
       source                = "oracle/oci"
-      version               = ">= 4.115.0"
+      version               = ">= 4.119.0"
     }
   }
 }

--- a/examples/rms/oke-network-only/versions.tf
+++ b/examples/rms/oke-network-only/versions.tf
@@ -9,7 +9,7 @@ terraform {
     oci = {
       configuration_aliases = [oci.home]
       source                = "oracle/oci"
-      version               = ">= 4.115.0"
+      version               = ">= 4.119.0"
     }
   }
 }

--- a/examples/rms/oke-workers-only/versions.tf
+++ b/examples/rms/oke-workers-only/versions.tf
@@ -9,7 +9,7 @@ terraform {
     oci = {
       configuration_aliases = [oci.home]
       source                = "oracle/oci"
-      version               = ">= 4.115.0"
+      version               = ">= 4.119.0"
     }
   }
 }

--- a/modules/bastion/versions.tf
+++ b/modules/bastion/versions.tf
@@ -17,7 +17,7 @@ terraform {
 
     oci = {
       source  = "oracle/oci"
-      version = ">= 4.115.0"
+      version = ">= 4.119.0"
     }
   }
 }

--- a/modules/operator/versions.tf
+++ b/modules/operator/versions.tf
@@ -22,7 +22,7 @@ terraform {
 
     oci = {
       source  = "oracle/oci"
-      version = ">= 4.115.0"
+      version = ">= 4.119.0"
     }
   }
 }

--- a/modules/utilities/versions.tf
+++ b/modules/utilities/versions.tf
@@ -12,7 +12,7 @@ terraform {
 
     oci = {
       source  = "oracle/oci"
-      version = ">= 4.115.0"
+      version = ">= 4.119.0"
     }
   }
 }

--- a/modules/workers/versions.tf
+++ b/modules/workers/versions.tf
@@ -12,7 +12,7 @@ terraform {
 
     oci = {
       source  = "oracle/oci"
-      version = ">= 4.115.0"
+      version = ">= 4.119.0"
     }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -23,7 +23,7 @@ terraform {
     oci = {
       configuration_aliases = [oci.home]
       source                = "oracle/oci"
-      version               = ">= 4.115.0"
+      version               = ">= 4.119.0"
     }
 
     random = {


### PR DESCRIPTION
oracle/oci 4.119.0 is the minimum version which supports node pool cycling:
https://github.com/oracle/terraform-provider-oci/commit/eb4f26a294665e05da819df30279159d5922cb26