### PR TITLE
Add support for node-cycling and improve control over node_pool kubernetes version

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -25,6 +25,7 @@
     - [Scaling](./guide/workers_scaling.md)
     - [Storage](./guide/workers_storage.md)
     - [Draining](./guide/workers_drain.md)
+    - [Node-Cycle](./guide/workers_node_cycle.md)
   - [Load balancers](./guide/loadbalancers.md)    
   - [Bastion](./guide/bastion.md)
     - [SSH](./guide/bastion_ssh.md)

--- a/docs/src/guide/rms_nodepool.md
+++ b/docs/src/guide/rms_nodepool.md
@@ -6,5 +6,14 @@ A standard OKE-managed pool of worker nodes with enhanced feature support.
 Configured with `mode = "node-pool"` on a `worker_pools` entry, or with `worker_pool_mode = "node-pool"` to use as the default for all pools unless otherwise specified.
 </p>
 
+You can set the `image_type` attribute to one of the following values: 
+  - `oke` (default)
+  - `platform`
+  - `custom`.
+
+When the `image_type` is equal to `oke` or `platform` there is a high risk for the node-pool image to be updated on subsequent `terraform apply` executions because the module is using a [datasource](https://registry.terraform.io/providers/oracle/oci/latest/docs/data-sources/containerengine_node_pool_option) to fetch the latest images available.
+
+To avoid this situation, you can set the `image_type` to `custom` and the `image_id` to the OCID of the image you want to use for the node-pool. 
+
 The following resources may be created depending on provided configuration:
 * <a href=https://registry.terraform.io/providers/oracle/oci/latest/docs/resources/containerengine_node_pool>containerengine_node_pool</a>

--- a/docs/src/guide/workers_node_cycle.md
+++ b/docs/src/guide/workers_node_cycle.md
@@ -1,0 +1,43 @@
+
+# Workers: Node Cycle
+
+Cycling nodes simplifies both the upgrading of the Kubernetes and host OS versions running on the managed worker nodes, and the updating of other worker node properties.
+
+When you set `node_cycling_enabled` to `true` for a node pool, Container Engine for Kubernetes will compare the properties of the existing nodes in the node pool with the properties of the node_pool. If any of the following attributes is not aligned, the node is marked for replacement:
+  - `kubernetes_version`
+  - `node_labels`
+  - `compute_shape` (`shape`, `ocpus`, `memory`)
+  - `boot_volume_size`
+  - `image_id`
+  - `node_metadata`
+  - `ssh_public_key`
+  - `cloud_init`
+  - `nsg_ids`
+  - `volume_kms_key_id`
+  - `pv_transit_encryption`
+
+The `node_cycling_max_surge` (default: `1`) and `node_cycling_max_unavailable` (default: `0`) node_pool attributes can be configured with absolute values or percentage values, calculated relative to the node_pool `size`. These attributes determine how the Container Engine for Kubernetes will replace the nodes with a stale config in the node_pool.
+
+When cycling nodes, the Container Engine for Kubernetes cordons, drains, and terminates nodes according to the node pool's cordon and drain options.
+
+**Notes:**
+- It's strongly recommended to use [readiness probes](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-readiness-probes) and [PodDisruptionBudgets](https://kubernetes.io/docs/tasks/run-application/configure-pdb/) to reduce the impact of the node replacement operation.
+- This operation is supported only with the `enhanced` OKE clusters.
+- New nodes will be created within the same AD/FD as the ones they replace.
+- Node cycle requests can be canceled but can't be reverted.
+- When setting a high `node_cycling_max_surge` value, check your [tenancy compute limits](https://docs.oracle.com/en-us/iaas/Content/General/Concepts/servicelimits.htm#computelimits) to confirm availability of resources for the new worker nodes.
+- Compatible with the cluster_autoscaler. During node-cycling execution, the request to reduce node_pool size is rejected, and all the worker nodes within the cycled node_pool are annotated with `"cluster-autoscaler.kubernetes.io/scale-down-disabled": "true"` to prevent the termination of the newly created nodes.
+- `node_cycling_enabled = true` is incompatible with changes to the node_pool `placement_config` (subnet_id, availability_domains, placement_fds, etc.)
+- If the `kubernetes_version` attribute is changed when `image_type = custom`, ensure a compatible `image_id` with the new Kubernetes version is provided.
+
+
+## Usage
+
+```javascript
+{{#include ../../../examples/workers/vars-workers-node-cycling.auto.tfvars:4:}}
+```
+
+## References
+* [oci_containerengine_node_pool](https://registry.terraform.io/providers/oracle/oci/latest/docs/resources/containerengine_node_pool)
+* [Performing an In-Place Worker Node Update by Cycling Nodes in an Existing Node Pool](https://docs.oracle.com/en-us/iaas/Content/ContEng/Tasks/contengupgradingimageworkernode_topic-Performing_an_InPlace_Worker_Node_Update_By_Cycling_an_Existing_Node_Pool.htm)
+* [Introducing On Demand Node Cycling for Oracle Container Engine for Kubernetes](https://blogs.oracle.com/cloud-infrastructure/post/node-cycling-container-engine-kubernetes-oke)

--- a/modules/workers/nodepools.tf
+++ b/modules/workers/nodepools.tf
@@ -9,7 +9,7 @@ resource "oci_containerengine_node_pool" "workers" {
   compartment_id     = each.value.compartment_id
   defined_tags       = each.value.defined_tags
   freeform_tags      = each.value.freeform_tags
-  kubernetes_version = var.kubernetes_version
+  kubernetes_version = each.value.kubernetes_version
   name               = each.key
   node_shape         = each.value.shape
   ssh_public_key     = var.ssh_public_key
@@ -103,6 +103,12 @@ resource "oci_containerengine_node_pool" "workers" {
     }
   }
 
+  node_pool_cycling_details {
+      is_node_cycling_enabled = each.value.node_cycling_enabled
+      maximum_surge           = each.value.node_cycling_max_surge
+      maximum_unavailable     = each.value.node_cycling_max_unavailable
+  }
+
   node_source_details {
     boot_volume_size_in_gbs = each.value.boot_volume_size
     image_id                = each.value.image_id
@@ -111,11 +117,11 @@ resource "oci_containerengine_node_pool" "workers" {
 
   lifecycle { # prevent resources changes for changed fields
     ignore_changes = [
-      kubernetes_version, # e.g. if changed as part of an upgrade
+      # kubernetes_version, # e.g. if changed as part of an upgrade
       name, defined_tags, freeform_tags,
       node_metadata["user_data"],               # templated cloud-init
       node_config_details[0].placement_configs, # dynamic placement configs
-      node_source_details[0],                   # dynamic image lookup
+      # node_source_details[0],                   # dynamic image lookup
     ]
 
     precondition {


### PR DESCRIPTION
Node pool node-cycling is a feature supported only with the OKE Enhanced clusters that facilitates the replacement of nodes with a stale configuration within a node pool.

The feature is described [here](https://blogs.oracle.com/cloud-infrastructure/post/node-cycling-container-engine-kubernetes-oke) and [here](https://docs.oracle.com/en-us/iaas/Content/ContEng/Tasks/contengupgradingimageworkernode_topic-Performing_an_InPlace_Worker_Node_Update_By_Cycling_an_Existing_Node_Pool.htm).

The parameters re quired to request node_cycling on a node pool must be defined for each node_pool individually in the variable `worker_pools`:
- `node_cycling_enabled` | default value: `false`
- `node_cycling_max_surge` | default value: `1`
- `node_cycling_max_unavailable` | default value: `0`

By default, the control plane and node_pool Kubernetes version is configured via a single variable `kuberetes_version`. This PR adds support for `kubernetes_version` at the node_pool level.

If you are willing to preserve the previous Kubernetes version on the worker nodes, set the variable `kubernetes_version` for the particular node pool in the variable `worker_pools`.

When `node_cycling_enabled` is set to `true`, the nodes will automatically be upgraded to the new version after the upgrade of the control plane.

If you are using a custom image for the worker nodes instead of the images OCI provides for OKE, it is **strongly** recommended to validate the compatibility of the custom image with the new Kubernetes control plane version.

To support in-place node-pool Kubernetes version upgrade using the node-cycle operation, we need to remove `node_source_details[0]` from the `lifecycle.ignore_changes` list of the `oci_containerengine_node_pool.workers` resource. This **may impact existing users** of the module when the node_pool `image_id` attribute is fetched dynamically. The workaround for this might be to leave `node_source_details[0]` in the `lifecycle.ignore_changes` list and support node_cycling only with "custom" and "platform" image_types.

This resolves #828 & #823.