### PR TITLE
5.x:  fix tag_namespace delimiter is a dot.

### DIFF
--- a/modules/workers/locals.tf
+++ b/modules/workers/locals.tf
@@ -104,7 +104,7 @@ locals {
             "${var.tag_namespace}.pool"               = pool_name,
             "${var.tag_namespace}.cluster_autoscaler" = pool.allow_autoscaler ? "allowed" : "disabled",
           },
-          pool.autoscale ? { "${var.tag_namespace}/cluster_autoscaler" = "managed" } : {},
+          pool.autoscale ? { "${var.tag_namespace}.cluster_autoscaler" = "managed" } : {},
         ) : {},
         var.defined_tags,
         lookup(pool, "defined_tags", {})


### PR DESCRIPTION
fix: #808 and inconsistency introduced in PR https://github.com/oracle-terraform-modules/terraform-oci-oke/pull/814

cc. @devoncrouse and @robo-cap 

and RC-5 contains the issue: https://github.com/oracle-terraform-modules/terraform-oci-oke/releases/tag/v5.0.0-RC5