### PR TITLE
Add example for node-cycling & improve operator life-cycle

### DIFF
--- a/examples/workers/vars-workers-node-cycling.auto.tfvars
+++ b/examples/workers/vars-workers-node-cycling.auto.tfvars
@@ -1,0 +1,14 @@
+# Copyright (c) 2017, 2023 Oracle Corporation and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl
+
+# Example worker pool node-cycle configuration.
+
+worker_pools = {
+  cycled-node-pool = {
+    description                  = "Cycling nodes in a node_pool.",
+    size                         = 4,
+    node_cycling_enabled         = true
+    node_cycling_max_surge       = "25%"
+    node_cycling_max_unavailable = 0
+  }
+}

--- a/modules/operator/compute.tf
+++ b/modules/operator/compute.tf
@@ -94,6 +94,7 @@ resource "oci_core_instance" "operator" {
 
 resource "null_resource" "operator_changed" {
   triggers = {
+    cloud_init      = jsonencode(var.cloud_init)
     image_id        = var.image_id
     install_helm    = var.install_helm
     install_k9s     = var.install_k9s


### PR DESCRIPTION
1. Sample code on how to use nodepool node-cycling.
2. Add support to recreate the operator instance when the cloud-init provided by the user is changed.