### PR TITLE
fix: 5.x Add null handling for bastion, operator image locals

### DIFF
--- a/module-bastion.tf
+++ b/module-bastion.tf
@@ -19,13 +19,13 @@ data "oci_core_images" "bastion" {
 }
 
 locals {
-  bastion_public_ip = (var.create_bastion
-    ? one(module.bastion[*].public_ip)
+  bastion_public_ip = (var.create_bastion && length(module.bastion) > 0
+    ? lookup(element(module.bastion, 0), "public_ip", var.bastion_public_ip)
     : var.bastion_public_ip
   )
 
-  bastion_images    = one(data.oci_core_images.bastion[*].images) # Data source result or null
-  bastion_image_ids = local.bastion_images[*].id                  # Image OCIDs from data source
+  bastion_images    = try(data.oci_core_images.bastion[0].images, tolist([])) # Data source result or empty
+  bastion_image_ids = local.bastion_images[*].id                              # Image OCIDs from data source
   bastion_image_id = (var.bastion_image_type == "custom"
     ? var.bastion_image_id : element(coalescelist(local.bastion_image_ids, ["none"]), 0)
   )

--- a/modules/operator/variables.tf
+++ b/modules/operator/variables.tf
@@ -20,7 +20,7 @@ variable "install_kubectx" { type = bool }
 variable "kubeconfig" { type = string }
 variable "kubernetes_version" { type = string }
 variable "nsg_ids" { type = list(string) }
-variable "operator_image_os_version" { type = string}
+variable "operator_image_os_version" { type = string }
 variable "pv_transit_encryption" { type = bool }
 variable "shape" { type = map(any) }
 variable "ssh_private_key" {

--- a/modules/workers/locals.tf
+++ b/modules/workers/locals.tf
@@ -168,11 +168,11 @@ locals {
     for k, v in local.enabled_worker_pools : tobool(v.drain) ? lookup(v, "size", var.worker_pool_size) : 0
   ])
 
-   # Number of work pools in the worker pools with autoscale enabled
+  # Number of work pools in the worker pools with autoscale enabled
   expected_autoscale_worker_pools = length(local.enabled_worker_pools) == 0 ? 0 : sum([
     for k, v in local.enabled_worker_pools : tobool(v.autoscale) ? 1 : 0
   ])
- 
+
   # Enabled worker_pool map entries for node pools
   enabled_node_pools = {
     for k, v in local.enabled_worker_pools : k => v

--- a/variables-cluster.tf
+++ b/variables-cluster.tf
@@ -8,7 +8,7 @@ variable "create_cluster" {
 }
 
 variable "cluster_name" {
-  default     = null
+  default     = "oke"
   description = "The name of oke cluster."
   type        = string
 }


### PR DESCRIPTION
* Handle nulls/errors evaluating local variables for bastion, operator images (Fixes #854)
* Specify default `cluster_name` value