### PR TITLE
fix: VCN module -> 3.5.5, lifecycle ignore changed for existing resources

### DIFF
--- a/module-network.tf
+++ b/module-network.tf
@@ -25,7 +25,7 @@ locals {
 module "vcn" {
   count          = var.create_vcn ? 1 : 0
   source         = "oracle-terraform-modules/vcn/oci"
-  version        = "3.5.4"
+  version        = "3.5.5"
   compartment_id = coalesce(var.network_compartment_id, local.compartment_id)
 
   # Standard tags as defined if enabled for use, or freeform

--- a/modules/network/nsg-bastion.tf
+++ b/modules/network/nsg-bastion.tf
@@ -51,7 +51,7 @@ resource "oci_core_network_security_group" "bastion" {
   defined_tags   = var.defined_tags
   freeform_tags  = var.freeform_tags
   lifecycle {
-    ignore_changes = [defined_tags, freeform_tags, display_name]
+    ignore_changes = [defined_tags, freeform_tags, display_name, vcn_id]
   }
 }
 

--- a/modules/network/nsg-controlplane.tf
+++ b/modules/network/nsg-controlplane.tf
@@ -88,7 +88,7 @@ resource "oci_core_network_security_group" "cp" {
   defined_tags   = var.defined_tags
   freeform_tags  = var.freeform_tags
   lifecycle {
-    ignore_changes = [defined_tags, freeform_tags, display_name]
+    ignore_changes = [defined_tags, freeform_tags, display_name, vcn_id]
   }
 }
 

--- a/modules/network/nsg-fss.tf
+++ b/modules/network/nsg-fss.tf
@@ -51,7 +51,7 @@ resource "oci_core_network_security_group" "fss" {
   defined_tags   = var.defined_tags
   freeform_tags  = var.freeform_tags
   lifecycle {
-    ignore_changes = [defined_tags, freeform_tags, display_name]
+    ignore_changes = [defined_tags, freeform_tags, display_name, vcn_id]
   }
 }
 

--- a/modules/network/nsg-loadbalancers-int.tf
+++ b/modules/network/nsg-loadbalancers-int.tf
@@ -39,7 +39,7 @@ resource "oci_core_network_security_group" "int_lb" {
   defined_tags   = var.defined_tags
   freeform_tags  = var.freeform_tags
   lifecycle {
-    ignore_changes = [defined_tags, freeform_tags, display_name]
+    ignore_changes = [defined_tags, freeform_tags, display_name, vcn_id]
   }
 }
 

--- a/modules/network/nsg-loadbalancers-pub.tf
+++ b/modules/network/nsg-loadbalancers-pub.tf
@@ -39,7 +39,7 @@ resource "oci_core_network_security_group" "pub_lb" {
   defined_tags   = var.defined_tags
   freeform_tags  = var.freeform_tags
   lifecycle {
-    ignore_changes = [defined_tags, freeform_tags, display_name]
+    ignore_changes = [defined_tags, freeform_tags, display_name, vcn_id]
   }
 }
 

--- a/modules/network/nsg-operator.tf
+++ b/modules/network/nsg-operator.tf
@@ -46,7 +46,7 @@ resource "oci_core_network_security_group" "operator" {
   defined_tags   = var.defined_tags
   freeform_tags  = var.freeform_tags
   lifecycle {
-    ignore_changes = [defined_tags, freeform_tags, display_name]
+    ignore_changes = [defined_tags, freeform_tags, display_name, vcn_id]
   }
 }
 

--- a/modules/network/nsg-pods.tf
+++ b/modules/network/nsg-pods.tf
@@ -64,7 +64,7 @@ resource "oci_core_network_security_group" "pods" {
   defined_tags   = var.defined_tags
   freeform_tags  = var.freeform_tags
   lifecycle {
-    ignore_changes = [defined_tags, freeform_tags, display_name]
+    ignore_changes = [defined_tags, freeform_tags, display_name, vcn_id]
   }
 }
 

--- a/modules/network/nsg-workers.tf
+++ b/modules/network/nsg-workers.tf
@@ -123,7 +123,7 @@ resource "oci_core_network_security_group" "workers" {
   defined_tags   = var.defined_tags
   freeform_tags  = var.freeform_tags
   lifecycle {
-    ignore_changes = [defined_tags, freeform_tags, display_name]
+    ignore_changes = [defined_tags, freeform_tags, display_name, vcn_id]
   }
 }
 

--- a/modules/network/subnets.tf
+++ b/modules/network/subnets.tf
@@ -137,7 +137,7 @@ resource "oci_core_subnet" "oke" {
   lifecycle {
     ignore_changes = [
       freeform_tags, defined_tags, display_name,
-      cidr_block, dns_label, security_list_ids,
+      cidr_block, dns_label, security_list_ids, vcn_id, route_table_id,
     ]
   }
 }
@@ -158,7 +158,7 @@ resource "oci_core_security_list" "oke" {
 
   lifecycle {
     ignore_changes = [
-      freeform_tags, defined_tags, display_name,
+      freeform_tags, defined_tags, display_name, vcn_id,
       ingress_security_rules, egress_security_rules, # ignore for CCM-management
     ]
   }

--- a/modules/workers/instance.tf
+++ b/modules/workers/instance.tf
@@ -110,6 +110,7 @@ resource "oci_core_instance" "workers" {
     }
 
     ignore_changes = [
+      agent_config, # TODO Not updateable; remove when supported
       defined_tags, freeform_tags, display_name,
       metadata["cluster_ca_cert"], metadata["user_data"],
       create_vnic_details[0].defined_tags,

--- a/modules/workers/instance.tf
+++ b/modules/workers/instance.tf
@@ -52,8 +52,8 @@ resource "oci_core_instance" "workers" {
     dynamic "plugins_config" {
       for_each = each.value.agent_config.plugins_config
       content {
-        name          = each.key
-        desired_state = each.value
+        name          = plugins_config.key
+        desired_state = plugins_config.value
       }
     }
   }

--- a/modules/workers/instanceconfig.tf
+++ b/modules/workers/instanceconfig.tf
@@ -20,8 +20,8 @@ resource "oci_core_instance_configuration" "workers" {
         dynamic "plugins_config" {
           for_each = each.value.agent_config.plugins_config
           content {
-            name          = each.key
-            desired_state = each.value
+            name          = plugins_config.key
+            desired_state = plugins_config.value
           }
         }
       }

--- a/modules/workers/locals.tf
+++ b/modules/workers/locals.tf
@@ -91,6 +91,8 @@ locals {
         }
       ]
 
+      agent_config = coalesce(var.agent_config, pool.agent_config, local.worker_pool_defaults.agent_config)
+
       # Translate configured + available AD numbers e.g. 2 into tenancy/compartment-specific names
       availability_domains = compact([for ad_number in tolist(setintersection(pool.placement_ads, var.ad_numbers)) :
         lookup(var.ad_numbers_to_names, ad_number, null)

--- a/modules/workers/variables.tf
+++ b/modules/workers/variables.tf
@@ -304,7 +304,6 @@ variable "platform_config" {
 }
 
 variable "agent_config" {
-  default     = null
   description = "Default agent_config for self-managed worker pools created with mode: 'instance', 'instance-pool', or 'cluster-network'. See <a href=https://docs.oracle.com/en-us/iaas/api/#/en/iaas/20160918/datatypes/InstanceAgentConfig for more information."
   type = object({
     are_all_plugins_disabled = bool,


### PR DESCRIPTION
* Latest VCN module 3.5.5
* Ignore changes non-updateable [agent_config](https://registry.terraform.io/providers/oracle/oci/latest/docs/data-sources/core_instance_configuration#agent_config) on existing worker pools
* Fixes plan from full VCN recreation between versions to remaining valid diff:
```
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # module.oke.module.network.oci_core_network_security_group_security_rule.oke["Allow TCP egress from bastion to OCI services"] will be created
  + resource "oci_core_network_security_group_security_rule" "oke" {
      + description               = "Allow TCP egress from bastion to OCI services"
      + destination               = "all-iad-services-in-oracle-services-network"
      + destination_type          = "SERVICE_CIDR_BLOCK"
      + direction                 = "EGRESS"
      + id                        = (known after apply)
      + is_valid                  = (known after apply)
      + network_security_group_id = "ocid1.networksecuritygroup.oc1.iad."
      + protocol                  = "6"
      + source_type               = (known after apply)
      + stateless                 = false
      + time_created              = (known after apply)
    }

  # module.oke.module.vcn[0].oci_core_route_table.service_gw[0] will be created
  + resource "oci_core_route_table" "service_gw" {
      + compartment_id = "ocid1.compartment.oc1.."
      + defined_tags   = (known after apply)
      + display_name   = "service-gw-route"
      + freeform_tags  = {
          + "role"     = "network"
          + "state_id" = ""
        }
      + id             = (known after apply)
      + state          = (known after apply)
      + time_created   = (known after apply)
      + vcn_id         = "ocid1.vcn.oc1.iad."

      + route_rules {
          + cidr_block        = (known after apply)
          + description       = "Terraformed - Auto-generated at Service Gateway creation: All Services in region to Service Gateway"
          + destination       = "all-iad-services-in-oracle-services-network"
          + destination_type  = "SERVICE_CIDR_BLOCK"
          + network_entity_id = "ocid1.servicegateway.oc1.iad."
          + route_type        = (known after apply)
        }
    }

Plan: 2 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  ~ oke              = {
      ~ ig_route_table_id         = "ocid1.routetable.oc1.iad." -> (known after apply)
      ~ nat_route_table_id        = "ocid1.routetable.oc1.iad." -> (known after apply)
      ~ vcn_id                    = "ocid1.vcn.oc1.iad." -> (known after apply)
        # (44 unchanged attributes hidden)
    }
```