### PR TITLE
5.x: add lpg_all_attributes output from inner vcn module

### DIFF
--- a/module-network.tf
+++ b/module-network.tf
@@ -242,3 +242,9 @@ output "network_security_rules" {
 #   description = "Dynamic routing gateway ID"
 #   value       = try(one(module.drg[*].drg_id), null)
 # }
+
+# LPG
+output "lpg_all_attributes" {
+  description = "all attributes of created lpg"
+  value       = try(one(module.vcn[*].lpg_all_attributes), null)
+}


### PR DESCRIPTION
This PR resolves #864 and propose to output the inner `oci-vcn` `lpg_all_attributes`.