### PR TITLE
remove defined tags from iam.tagging to avoid chicken-egg problem

### DIFF
--- a/modules/iam/tagging.tf
+++ b/modules/iam/tagging.tf
@@ -63,7 +63,7 @@ resource "oci_identity_tag_namespace" "oke" {
   compartment_id = var.compartment_id
   description    = "Tag namespace for OKE resources"
   name           = var.tag_namespace
-  defined_tags   = local.defined_tags
+  # defined_tags   = local.defined_tags
   freeform_tags  = local.freeform_tags
   lifecycle {
     ignore_changes = [defined_tags, freeform_tags]
@@ -75,7 +75,7 @@ resource "oci_identity_tag" "oke" {
   for_each         = local.create_iam_tag_namespace ? local.tags : {} #{ for k, v in oci_identity_tag_namespace.oke : k => local.tags } # local.create_iam_tag_namespace ? local.tags : {}
   description      = each.value
   name             = each.key
-  defined_tags     = local.defined_tags
+  # defined_tags     = local.defined_tags
   freeform_tags    = local.freeform_tags
   tag_namespace_id = one(oci_identity_tag_namespace.oke[*].id)
 


### PR DESCRIPTION
There are two options to avoid an error on `terraform apply`:
1. Comment out the defined_tags attributes, as the tag namespace and the tags may not be present when we try to attach
the defined tags to the resource.
2. Apply only a set of the defined tags on initial apply (based on the existing tag namespace and tags already present) and apply the rest on the subsequent apply, but this will involve removing `defined_tags` from the ignore_changes lifecycle block and will also overwrite any defined tags added by default at the compartment level.

To avoid any error on apply, we can go with the 1st solution.
Fixes: #863 