### PR TITLE
fix: Remove sensitive mask

### DIFF
--- a/modules/extensions/rdma_cni_plugin.tf
+++ b/modules/extensions/rdma_cni_plugin.tf
@@ -9,7 +9,7 @@ locals {
   )
   rdma_cni_plugin_manifest_path        = join("/", [local.yaml_manifest_path, "rdma-cni-daemonset.yaml"])
   rdma_cni_plugin_manifest_status_code = one(data.http.rdma_cni_plugin[*].status_code)
-  rdma_cni_plugin_manifest_content     = sensitive(one(data.http.rdma_cni_plugin[*].response_body))
+  rdma_cni_plugin_manifest_content     = one(data.http.rdma_cni_plugin[*].response_body)
 }
 
 data "http" "rdma_cni_plugin" {


### PR DESCRIPTION
This value is an HTTP response to a publicly accessible daemonset
manifest but it's being marked as sensitive.

It's marked as sensitive, but then it's used in the body of an error
message for a `precondition`:
https://github.com/oracle-terraform-modules/terraform-oci-oke/blob/main/modules/extensions/rdma_cni_plugin.tf#L61

Because of this variable being in the error message, `terraform plan`
will exit with exit code `1` even though the plan itself actually
succeeded.

This variable shouldn't be marked sensitive anyways, as its holding the
value for an already public yaml file.
