### PR TITLE
feat: networking module - bump  to v3.6.0

### DIFF
--- a/docs/src/dependencies.md
+++ b/docs/src/dependencies.md
@@ -30,7 +30,7 @@
 | <a name="module_network"></a> [network](#module\_network) | ./modules/network | n/a |
 | <a name="module_operator"></a> [operator](#module\_operator) | ./modules/operator | n/a |
 | <a name="module_utilities"></a> [utilities](#module\_utilities) | ./modules/utilities | n/a |
-| <a name="module_vcn"></a> [vcn](#module\_vcn) | oracle-terraform-modules/vcn/oci | 3.5.4 |
+| <a name="module_vcn"></a> [vcn](#module\_vcn) | oracle-terraform-modules/vcn/oci | 3.6.0 |
 | <a name="module_workers"></a> [workers](#module\_workers) | ./modules/workers | n/a |
 
 ## Resources

--- a/module-network.tf
+++ b/module-network.tf
@@ -25,7 +25,7 @@ locals {
 module "vcn" {
   count          = var.create_vcn ? 1 : 0
   source         = "oracle-terraform-modules/vcn/oci"
-  version        = "3.5.5"
+  version        = "3.6.0"
   compartment_id = coalesce(var.network_compartment_id, local.compartment_id)
 
   # Standard tags as defined if enabled for use, or freeform


### PR DESCRIPTION
This PR is bumping the internal dependency on `terraform-oci-vcn` to its latest version `v3.6.0` which [integrates the following changes](https://github.com/oracle-terraform-modules/terraform-oci-vcn/compare/v3.5.5...v3.6.0).

This also resolves issue #514.

