### PR TITLE
fix: Remove unknown resource counts from derived inputs

### DIFF
--- a/module-iam.tf
+++ b/module-iam.tf
@@ -2,7 +2,7 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl
 
 data "oci_identity_availability_domains" "all" {
-  compartment_id = local.compartment_id
+  compartment_id = local.tenancy_id != "unknown" ? local.tenancy_id : local.compartment_id
 }
 
 locals {

--- a/module-network.tf
+++ b/module-network.tf
@@ -2,7 +2,7 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl
 
 data "oci_core_vcn" "oke" {
-  count  = coalesce(var.vcn_id, "none") != "none" ? 1 : 0
+  count  = var.create_vcn ? 0 : 1
   vcn_id = coalesce(var.vcn_id, "none")
 }
 

--- a/modules/network/subnets.tf
+++ b/modules/network/subnets.tf
@@ -79,7 +79,7 @@ locals {
   # - Subnet is configured with newbits and/or netnum/cidr
   # - Not configured with create == 'never'
   # - Not configured with an existing 'id'
-  subnets_to_create = length(var.vcn_cidrs) > 0 ? merge(
+  subnets_to_create = merge(
     { for k, v in local.subnet_info : k =>
       # Override `create = true` if configured with "always"
       merge(v, lookup(try(lookup(var.subnets, k), { create = "never" }), "create", "auto") == "always" ? { "create" = true } : {})
@@ -92,7 +92,7 @@ locals {
         ]),
       ])
     }
-  ) : {}
+  )
 
   subnet_output = { for k, v in var.subnets :
     k => lookup(v, "id", null) != null ? v.id : lookup(lookup(oci_core_subnet.oke, k, {}), "id", null)

--- a/modules/network/subnets.tf
+++ b/modules/network/subnets.tf
@@ -79,7 +79,7 @@ locals {
   # - Subnet is configured with newbits and/or netnum/cidr
   # - Not configured with create == 'never'
   # - Not configured with an existing 'id'
-  subnets_to_create = merge(
+  subnets_to_create = try(merge(
     { for k, v in local.subnet_info : k =>
       # Override `create = true` if configured with "always"
       merge(v, lookup(try(lookup(var.subnets, k), { create = "never" }), "create", "auto") == "always" ? { "create" = true } : {})
@@ -92,7 +92,7 @@ locals {
         ]),
       ])
     }
-  )
+  ), {})
 
   subnet_output = { for k, v in var.subnets :
     k => lookup(v, "id", null) != null ? v.id : lookup(lookup(oci_core_subnet.oke, k, {}), "id", null)


### PR DESCRIPTION
Terraform plan and apply throw errors if a Compartment is created in the same configuration using this module and passed in through `var.compartment_id`. Same for VCNs created in the same configuration but not created by this module directly (i.e. passed in through `var.vcn_id` with `var.create_vcn = false`)

Fixes for #883 