### PR TITLE
Fix : Wrong control_plane_is_public behavior for OKE cluster 

### DIFF
--- a/docs/src/guide/cluster.md
+++ b/docs/src/guide/cluster.md
@@ -5,6 +5,7 @@ See also:
 
 The OKE parameters concern mainly the following:
 * whether you want your OKE control plane to be public or private
+* whether to assign a public IP address to the API endpoint for public access
 * whether you want to deploy public or private worker nodes
 * whether you want to allow NodePort or ssh access to the worker nodes
 * Kubernetes options such as dashboard, networking

--- a/examples/cluster/vars-cluster-enhanced.auto.tfvars
+++ b/examples/cluster/vars-cluster-enhanced.auto.tfvars
@@ -1,14 +1,15 @@
 # Copyright (c) 2017, 2023 Oracle Corporation and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl
 
-create_cluster     = true // *true/false
-cluster_dns        = null
-cluster_kms_key_id = null
-cluster_name       = "oke"
-cluster_type       = "enhanced" // *basic/enhanced
-cni_type           = "flannel"  // *flannel/npn
-image_signing_keys = []
-kubernetes_version = "v1.26.2"
-pods_cidr          = "10.244.0.0/16"
-services_cidr      = "10.96.0.0/16"
-use_signed_images  = false // true/*false
+create_cluster                    = true // *true/false
+cluster_dns                       = null
+cluster_kms_key_id                = null
+cluster_name                      = "oke"
+cluster_type                      = "enhanced" // *basic/enhanced
+cni_type                          = "flannel"  // *flannel/npn
+assign_public_ip_to_control_plane = true // true/*false
+image_signing_keys                = []
+kubernetes_version                = "v1.26.2"
+pods_cidr                         = "10.244.0.0/16"
+services_cidr                     = "10.96.0.0/16"
+use_signed_images                 = false // true/*false

--- a/module-cluster.tf
+++ b/module-cluster.tf
@@ -40,13 +40,14 @@ module "cluster" {
   state_id       = local.state_id
 
   # Network
-  vcn_id                  = local.vcn_id
-  cni_type                = var.cni_type
-  control_plane_is_public = var.control_plane_is_public
-  control_plane_nsg_ids   = compact(flatten([var.control_plane_nsg_ids, try(module.network.control_plane_nsg_id, null)]))
-  control_plane_subnet_id = try(module.network.control_plane_subnet_id, "") # safe destroy; validated in submodule
-  pods_cidr               = var.pods_cidr
-  services_cidr           = var.services_cidr
+  vcn_id                            = local.vcn_id
+  cni_type                          = var.cni_type
+  control_plane_is_public           = var.control_plane_is_public
+  assign_public_ip_to_control_plane = var.assign_public_ip_to_control_plane
+  control_plane_nsg_ids             = compact(flatten([var.control_plane_nsg_ids, try(module.network.control_plane_nsg_id, null)]))
+  control_plane_subnet_id           = try(module.network.control_plane_subnet_id, "") # safe destroy; validated in submodule
+  pods_cidr                         = var.pods_cidr
+  services_cidr                     = var.services_cidr
   service_lb_subnet_id = (var.preferred_load_balancer == "public"
     ? try(module.network.pub_lb_subnet_id, "") # safe destroy; validated in submodule
     : try(module.network.int_lb_subnet_id, "")

--- a/modules/cluster/cluster.tf
+++ b/modules/cluster/cluster.tf
@@ -16,7 +16,7 @@ resource "oci_containerengine_cluster" "k8s_cluster" {
   }
 
   endpoint_config {
-    is_public_ip_enabled = var.control_plane_is_public ? var.assign_public_ip_to_control_plane : var.control_plane_is_public
+    is_public_ip_enabled = var.control_plane_is_public && var.assign_public_ip_to_control_planeßß
     nsg_ids              = var.control_plane_nsg_ids
     subnet_id            = var.control_plane_subnet_id
   }

--- a/modules/cluster/cluster.tf
+++ b/modules/cluster/cluster.tf
@@ -16,7 +16,7 @@ resource "oci_containerengine_cluster" "k8s_cluster" {
   }
 
   endpoint_config {
-    is_public_ip_enabled = var.control_plane_is_public
+    is_public_ip_enabled = var.control_plane_is_public ? var.assign_public_ip_to_control_plane : var.control_plane_is_public
     nsg_ids              = var.control_plane_nsg_ids
     subnet_id            = var.control_plane_subnet_id
   }

--- a/modules/cluster/cluster.tf
+++ b/modules/cluster/cluster.tf
@@ -16,7 +16,7 @@ resource "oci_containerengine_cluster" "k8s_cluster" {
   }
 
   endpoint_config {
-    is_public_ip_enabled = var.control_plane_is_public && var.assign_public_ip_to_control_planeßß
+    is_public_ip_enabled = var.control_plane_is_public && var.assign_public_ip_to_control_plane
     nsg_ids              = var.control_plane_nsg_ids
     subnet_id            = var.control_plane_subnet_id
   }

--- a/modules/cluster/variables.tf
+++ b/modules/cluster/variables.tf
@@ -12,6 +12,7 @@ variable "cluster_type" { type = string }
 variable "cni_type" { type = string }
 variable "control_plane_is_public" { type = bool }
 variable "control_plane_nsg_ids" { type = set(string) }
+variable "assign_public_ip_to_control_plane" { type = bool }
 variable "control_plane_subnet_id" { type = string }
 variable "image_signing_keys" { type = set(string) }
 variable "kubernetes_version" { type = string }

--- a/variables-cluster.tf
+++ b/variables-cluster.tf
@@ -29,6 +29,12 @@ variable "control_plane_is_public" {
   type        = bool
 }
 
+variable "assign_public_ip_to_control_plane" {
+  default     = false
+  description = "An additional variable to toggle public IP on Kubernetes control plane endpoint when its public."
+  type        = bool
+}
+
 variable "control_plane_nsg_ids" {
   default     = []
   description = "An additional list of network security groups (NSG) ids for the cluster endpoint."

--- a/variables-cluster.tf
+++ b/variables-cluster.tf
@@ -31,7 +31,7 @@ variable "control_plane_is_public" {
 
 variable "assign_public_ip_to_control_plane" {
   default     = false
-  description = "An additional variable to toggle public IP on Kubernetes control plane endpoint when its public."
+  description = "Whether to assign a public IP address to the API endpoint for public access. Requires the control plane subnet to be public to assign a public IP address."
   type        = bool
 }
 


### PR DESCRIPTION
Resolves[https://github.com/oracle-terraform-modules/terraform-oci-oke/issues/869]

@Noksa / @hyder / @devoncrouse
With public subnets, we have option to either assign public IP or defer it for assignment at a later point of time. This is the feature that is being used to assign or unassign the public IP to Control plane API endpoint in OCI console. So if the cluster has been created with public subnet with/without actually assigning the public IP at the time off creation, there should be an option to toggle the public IP after cluster is provisioned.

The variable control_plane_is_public is being used in code to decide the subnet type (public or private). If we toggle this variable, the subnet recreation will kick off which will recreate the cluster and nodepools.

For solution to toggle the public ip , we need to introduce a new boolean variable (assign_public_ip_to_control_plane) to toggle public ip on control plan API endpoint.

With control_plane_is_public set to true, assign_public_ip_to_control_plane can be set to either true or false.

When assign_public_ip_to_control_plane is set to true, the public IP will be assigned to Control plane API endpoint.
When assign_public_ip_to_control_plane set to false, although the subnet is public, the public IP will not be assigned to the API endpoint.
With control_plane_is_public set to false, public ip will not be allocated to API endpoint irrespective of value set for assign_public_ip_to_control_plane