### PR TITLE
Improve operator pkg installation

### DIFF
--- a/module-operator.tf
+++ b/module-operator.tf
@@ -60,8 +60,10 @@ module "operator" {
   image_id                  = local.operator_image_id
   install_cilium            = var.cilium_install
   install_helm              = var.operator_install_helm
+  install_istioctl          = var.operator_install_istioctl
   install_k9s               = var.operator_install_k9s
   install_kubectx           = var.operator_install_kubectx
+  install_kubectl_from_repo = var.operator_install_kubectl_from_repo
   kubeconfig                = yamlencode(local.kubeconfig_private)
   kubernetes_version        = var.kubernetes_version
   nsg_ids                   = compact(flatten([var.operator_nsg_ids, try(module.network.operator_nsg_id, null)]))
@@ -75,6 +77,7 @@ module "operator" {
   upgrade                   = var.operator_upgrade
   user                      = var.operator_user
   volume_kms_key_id         = var.operator_volume_kms_key_id
+
 
   # Standard tags as defined if enabled for use, or freeform
   # User-provided tags are merged last and take precedence

--- a/modules/operator/cloudinit.tf
+++ b/modules/operator/cloudinit.tf
@@ -103,7 +103,7 @@ data "cloudinit_config" "operator" {
 
   # kubectl installation
   dynamic "part" {
-    for_each = var.install_kubectl_from_repo ? [0] : [1]
+    for_each = var.install_kubectl_from_repo ? [] : [1]
     content {
       content_type = "text/cloud-config"
       content = jsonencode({

--- a/modules/operator/cloudinit.tf
+++ b/modules/operator/cloudinit.tf
@@ -10,11 +10,10 @@ locals {
 
   baserepo        = "ol${var.operator_image_os_version}"
   developer_EPEL  = "${local.baserepo}_developer_EPEL"
-  olcne17         = "${local.baserepo}_olcne17"
+  olcne18         = "${local.baserepo}_olcne18"
   developer_olcne = "${local.baserepo}_developer_olcne"
   arch_amd        = "amd64"
   arch_arm        = "aarch64"
-
 }
 
 # https://registry.terraform.io/providers/hashicorp/template/latest/docs/data-sources/cloudinit_config.html
@@ -32,9 +31,10 @@ data "cloudinit_config" "operator" {
       packages = compact([
         "git",
         "jq",
-        "kubectl",
         "python3-oci-cli",
         var.install_helm ? "helm" : null,
+        var.install_istioctl ? "istio-istioctl" : null,
+        var.install_kubectl_from_repo ? "kubectl": null,
       ])
       yum_repos = {
         "${local.developer_EPEL}" = {
@@ -44,9 +44,9 @@ data "cloudinit_config" "operator" {
           gpgcheck = true
           enabled  = true
         }
-        "${local.olcne17}" = {
-          name     = "Oracle Linux Cloud Native Environment 1.7 ($basearch)"
-          baseurl  = "https://yum$ociregion.$ocidomain/repo/OracleLinux/OL${var.operator_image_os_version}/olcne17/$basearch/"
+        "${local.olcne18}" = {
+          name     = "Oracle Linux Cloud Native Environment 1.8 ($basearch)"
+          baseurl  = "https://yum$ociregion.$ocidomain/repo/OracleLinux/OL${var.operator_image_os_version}/olcne18/$basearch/"
           gpgkey   = "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-oracle"
           gpgcheck = true
           enabled  = true
@@ -99,6 +99,24 @@ data "cloudinit_config" "operator" {
     })
     filename   = "10-growpart.yml"
     merge_type = local.default_cloud_init_merge_type
+  }
+
+  # kubectl installation
+  dynamic "part" {
+    for_each = var.install_kubectl_from_repo ? [0] : [1]
+    content {
+      content_type = "text/cloud-config"
+      content = jsonencode({
+        runcmd = [
+          "CLI_ARCH='${local.arch_amd}'",
+          "if [ \"$(uname -m)\" = ${local.arch_arm} ]; then CLI_ARCH='arm64'; fi",
+          "curl -LO https://dl.k8s.io/release/${var.kubernetes_version}/bin/linux/$CLI_ARCH/kubectl",
+          "install -o root -g root -m 0755 kubectl /usr/bin/kubectl"
+        ]
+      })
+      filename   = "20-kubectl.yml"
+      merge_type = local.default_cloud_init_merge_type
+    }
   }
 
   # kubectx/kubens installation
@@ -164,8 +182,8 @@ data "cloudinit_config" "operator" {
       content = jsonencode({
         runcmd = [
           "CILIUM_CLI_VERSION=$(curl -s https://raw.githubusercontent.com/cilium/cilium-cli/master/stable.txt)",
-          "CLI_ARCH=${local.arch_amd}",
-          "if [ '$(uname -m)' = ${local.arch_arm} ]; then CLI_ARCH=${local.arch_arm}; fi",
+          "CLI_ARCH='${local.arch_amd}'",
+          "if [ \"$(uname -m)\" = ${local.arch_arm} ]; then CLI_ARCH='arm64'; fi",
           "curl -L --fail --remote-name-all https://github.com/cilium/cilium-cli/releases/download/$CILIUM_CLI_VERSION/cilium-linux-$CLI_ARCH.tar.gz",
           "tar xzvfC cilium-linux-$CLI_ARCH.tar.gz /usr/local/bin"
         ]

--- a/modules/operator/variables.tf
+++ b/modules/operator/variables.tf
@@ -16,7 +16,12 @@ variable "cloud_init" { type = list(map(string)) }
 variable "image_id" { type = string }
 variable "install_cilium" { type = bool }
 variable "install_helm" { type = bool }
+variable "install_istioctl" { type = bool }
 variable "install_k9s" { type = bool }
+variable "install_kubectl_from_repo" { 
+  type    = bool
+  default = true
+}
 variable "install_kubectx" { type = bool }
 variable "kubeconfig" { type = string }
 variable "kubernetes_version" { type = string }

--- a/variables-operator.tf
+++ b/variables-operator.tf
@@ -65,9 +65,21 @@ variable "operator_install_helm" {
   type        = bool
 }
 
+variable "operator_install_istioctl" {
+  default     = false
+  description = "Whether to install istioctl on the created operator host."
+  type        = bool
+}
+
 variable "operator_install_k9s" {
   default     = false
   description = "Whether to install k9s on the created operator host. NOTE: Provided only as a convenience and not supported by or sourced from Oracle - use at your own risk."
+  type        = bool
+}
+
+variable "operator_install_kubectl_from_repo" {
+  default     = true
+  description = "Whether to install kubectl on the created operator host from olcne repo."
   type        = bool
 }
 


### PR DESCRIPTION
- upgrade to operator olcne reppo to version 1.8 
- ability to install kubectl using curl from [k8s.io](https://kubernetes.io/docs/tasks/tools/install-kubectl-linux/#install-kubectl-on-linux)