### PR TITLE
feat: add autoscaler local exec option

### DIFF
--- a/modules/extensions/variables.tf
+++ b/modules/extensions/variables.tf
@@ -72,6 +72,7 @@ variable "cluster_autoscaler_helm_version" { type = string }
 variable "cluster_autoscaler_helm_values" { type = map(string) }
 variable "cluster_autoscaler_helm_values_files" { type = list(string) }
 variable "expected_autoscale_worker_pools" { type = number }
+variable "cluster_autoscaler_remote_exec" { type = bool }
 
 # Prometheus
 variable "prometheus_install" { type = bool }

--- a/variables-extensions.tf
+++ b/variables-extensions.tf
@@ -207,6 +207,12 @@ variable "cluster_autoscaler_helm_values_files" {
   type        = list(string)
 }
 
+variable "cluster_autoscaler_remote_exec" {
+  default     = true
+  description = "Whether to execute deploy the cluster autoscaler remotely via the operator server. If false, the cluster autoscaler helm chart will be installed on the same machine you are running Terraform from."
+  type        = bool
+}
+
 # Prometheus
 
 variable "prometheus_install" {


### PR DESCRIPTION
This commit adds the ability to deploy the k8s cluster autoscaler using local-exec rather than remote-exec.  Using local-exec is helpful when you don't use the operator/bastion features of this module.  Now if you set cluster_autoscaler_remote_exec variable to false terraform will run a `kubectl apply` command on the same machine where you are running Terraform.

More info in this issue: #894

Signed-off-by: Chris Wiggins(5607419+cwiggs@users.noreply.github.com)