### PR TITLE
feat: Configurable boot volume VPUs/GB on self-managed

### DIFF
--- a/examples/workers/vars-workers.auto.tfvars
+++ b/examples/workers/vars-workers.auto.tfvars
@@ -24,9 +24,13 @@ worker_volume_kms_key_id     = null
 
 worker_shape = {
   shape            = "VM.Standard.E4.Flex",
-  ocpus            = 2,  # Ignored for non-Flex shapes
-  memory           = 16, # Ignored for non-Flex shapes
+  ocpus            = 2  # Ignored for non-Flex shapes
+  memory           = 16 # Ignored for non-Flex shapes
   boot_volume_size = 50
+
+  # https://docs.oracle.com/en-us/iaas/Content/Block/Concepts/blockvolumeperformance.htm
+  # Supported for mode = "cluster-network" | "instance-pool" | "instance" (self-managed) only
+  boot_volume_vpus_per_gb = 10 # 10: Balanced, 20: High, 30-120: Ultra High (requires multipath)
 }
 
 worker_pools = {}

--- a/modules/workers/instance.tf
+++ b/modules/workers/instance.tf
@@ -94,6 +94,7 @@ resource "oci_core_instance" "workers" {
 
   source_details {
     boot_volume_size_in_gbs = each.value.boot_volume_size
+    boot_volume_vpus_per_gb = each.value.boot_volume_vpus_per_gb
     source_id               = each.value.image_id
     source_type             = "image"
   }

--- a/modules/workers/instanceconfig.tf
+++ b/modules/workers/instanceconfig.tf
@@ -108,6 +108,7 @@ resource "oci_core_instance_configuration" "workers" {
 
       source_details {
         boot_volume_size_in_gbs = each.value.boot_volume_size
+        boot_volume_vpus_per_gb = each.value.boot_volume_vpus_per_gb
         image_id                = each.value.image_id
         source_type             = "image"
       }

--- a/modules/workers/locals.tf
+++ b/modules/workers/locals.tf
@@ -2,10 +2,11 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl
 
 locals {
-  boot_volume_size = lookup(var.shape, "boot_volume_size", 50)
-  memory           = lookup(var.shape, "memory", 4)
-  ocpus            = max(1, lookup(var.shape, "ocpus", 1))
-  shape            = lookup(var.shape, "shape", "VM.Standard.E4.Flex")
+  boot_volume_size        = lookup(var.shape, "boot_volume_size", 50)
+  boot_volume_vpus_per_gb = lookup(var.shape, "boot_volume_vpus_per_gb", 10)
+  memory                  = lookup(var.shape, "memory", 4)
+  ocpus                   = max(1, lookup(var.shape, "ocpus", 1))
+  shape                   = lookup(var.shape, "shape", "VM.Standard.E4.Flex")
 
   # Used for default values of required input for virtual node pools
   fault_domains_all = formatlist("FD-%v", [1, 2, 3])
@@ -25,6 +26,7 @@ locals {
     autoscale                    = false
     block_volume_type            = var.block_volume_type
     boot_volume_size             = local.boot_volume_size
+    boot_volume_vpus_per_gb      = local.boot_volume_vpus_per_gb
     capacity_reservation_id      = var.capacity_reservation_id
     cloud_init                   = [] # empty pool-specific default
     compartment_id               = var.compartment_id

--- a/variables-workers.tf
+++ b/variables-workers.tf
@@ -144,10 +144,14 @@ variable "worker_image_os_version" {
 
 variable "worker_shape" {
   default = {
-    shape            = "VM.Standard.E4.Flex",
-    ocpus            = 2,
-    memory           = 16,
+    shape            = "VM.Standard.E4.Flex"
+    ocpus            = 2
+    memory           = 16
     boot_volume_size = 50
+
+    # https://docs.oracle.com/en-us/iaas/Content/Block/Concepts/blockvolumeperformance.htm
+    # Supported for mode = "cluster-network" | "instance-pool" | "instance" (self-managed) only
+    boot_volume_vpus_per_gb = 10 # 10: Balanced, 20: High, 30-120: Ultra High (requires multipath)
   }
   description = "Default shape of the created worker instance when unspecified on a pool."
   type        = map(any)


### PR DESCRIPTION
- Support `boot_volume_vpus_per_gb` in `worker_shape` and entries of `worker_pools` for self-managed modes