### PR TITLE
fix: operator custom cloud-init error

### DIFF
--- a/modules/operator/cloudinit.tf
+++ b/modules/operator/cloudinit.tf
@@ -260,7 +260,7 @@ data "cloudinit_config" "operator" {
     content {
       # Load content from file if local path, attempt base64 decode, or use raw value
       content = contains(keys(part.value), "content") ? (
-        fileexists(lookup(part.value, "content")) ? file(lookup(part.value, "content"))
+        try(fileexists(lookup(part.value, "content")), false) ? file(lookup(part.value, "content"))
         : try(base64decode(lookup(part.value, "content")), lookup(part.value, "content"))
       ) : ""
       content_type = lookup(part.value, "content_type", local.default_cloud_init_content_type)


### PR DESCRIPTION
### Fixes [Issue #949](https://github.com/oracle-terraform-modules/terraform-oci-oke/issues/949)

**Problem:**
- When a custom cloud-init script with very long content is used, the operator throws a filesystem exception. This occurs because the script attempts to use the full content of the cloud-init as the filename.

**Solution:**
- Added a `try` function to catch the exception and handle it appropriately, preventing the filesystem error.

Signed-off-by: Marcelo Couto <mcouto@sossego.com.br>
