### PR TITLE
fix: Allow cloud-init update for self-managed instance configurations

### DIFF
--- a/modules/workers/instanceconfig.tf
+++ b/modules/workers/instanceconfig.tf
@@ -161,7 +161,6 @@ resource "oci_core_instance_configuration" "workers" {
     create_before_destroy = true
     ignore_changes = [
       defined_tags, freeform_tags, display_name,
-      instance_details[0].launch_details[0].metadata,
       instance_details[0].launch_details[0].defined_tags,
       instance_details[0].launch_details[0].freeform_tags,
       instance_details[0].launch_details[0].create_vnic_details[0].defined_tags,


### PR DESCRIPTION
Similar update to #951, unblocking cloud-init updates for self-managed pools. The instance configuration resource can be safely replaced and updated in-place on an Instance Pool/Cluster Network, and will apply to only new launched instances.