### PR TITLE
Add several fixes

### DIFF
--- a/module-iam.tf
+++ b/module-iam.tf
@@ -77,8 +77,8 @@ module "iam_cluster_prerequisites" {
   operator_volume_kms_key_id = var.operator_volume_kms_key_id
   worker_volume_kms_key_id   = var.worker_volume_kms_key_id
 
-  autoscaler_compartments = local.autoscaler_compartments
-  worker_compartments     = local.worker_compartments
+  autoscaler_compartments = []
+  worker_compartments     = []
 
   providers = {
     oci.home = oci.home

--- a/modules/workers/clusternetworks.tf
+++ b/modules/workers/clusternetworks.tf
@@ -36,7 +36,7 @@ resource "oci_core_cluster_network" "workers" {
     ignore_changes = [
       display_name, defined_tags, freeform_tags,
       instance_pools[0].defined_tags,
-      instance_pools[0].freeform_tags,
+      instance_pools[0].freeform_tags
     ]
 
     precondition {

--- a/modules/workers/instanceconfig.tf
+++ b/modules/workers/instanceconfig.tf
@@ -161,7 +161,6 @@ resource "oci_core_instance_configuration" "workers" {
     create_before_destroy = true
     ignore_changes = [
       defined_tags, freeform_tags, display_name,
-      instance_details[0].launch_details[0].metadata,
       instance_details[0].launch_details[0].defined_tags,
       instance_details[0].launch_details[0].freeform_tags,
       instance_details[0].launch_details[0].create_vnic_details[0].defined_tags,

--- a/modules/workers/locals.tf
+++ b/modules/workers/locals.tf
@@ -157,7 +157,7 @@ locals {
         {
           "oke.oraclecloud.com/tf.module"          = "terraform-oci-oke"
           "oke.oraclecloud.com/tf.state_id"        = var.state_id
-          "oke.oraclecloud.com/tf.workspace"       = terraform.workspace
+          # "oke.oraclecloud.com/tf.workspace"       = terraform.workspace
           "oke.oraclecloud.com/pool.name"          = pool_name
           "oke.oraclecloud.com/pool.mode"          = pool.mode
           "oke.oraclecloud.com/cluster_autoscaler" = pool.allow_autoscaler ? "allowed" : "disabled"
@@ -232,11 +232,11 @@ locals {
   }
 
   # Maps of worker pool OCI resources by pool name enriched with desired/custom parameters for various modes
-  worker_node_pools         = { for k, v in merge(oci_containerengine_node_pool.tfscaled_workers, oci_containerengine_node_pool.autoscaled_workers) : k => merge(v, lookup(local.worker_pools_final, k, {})) }
-  worker_virtual_node_pools = { for k, v in oci_containerengine_virtual_node_pool.workers : k => merge(v, lookup(local.worker_pools_final, k, {})) }
-  worker_instance_pools     = { for k, v in merge(oci_core_instance_pool.tfscaled_workers, oci_core_instance_pool.autoscaled_workers) : k => merge(v, lookup(local.worker_pools_final, k, {})) }
-  worker_cluster_networks   = { for k, v in oci_core_cluster_network.workers : k => merge(v, lookup(local.worker_pools_final, k, {})) }
-  worker_instances          = { for k, v in oci_core_instance.workers : k => merge(v, lookup(local.worker_pools_final, k, {})) }
+  worker_node_pools         = { for k, v in merge(oci_containerengine_node_pool.tfscaled_workers, oci_containerengine_node_pool.autoscaled_workers) : k => merge(lookup(local.worker_pools_final, k, {}), v) }
+  worker_virtual_node_pools = { for k, v in oci_containerengine_virtual_node_pool.workers : k => merge(lookup(local.worker_pools_final, k, {}), v) }
+  worker_instance_pools     = { for k, v in merge(oci_core_instance_pool.tfscaled_workers, oci_core_instance_pool.autoscaled_workers) : k => merge(lookup(local.worker_pools_final, k, {}), v) }
+  worker_cluster_networks   = { for k, v in oci_core_cluster_network.workers : k => merge(lookup(local.worker_pools_final, k, {}), v) }
+  worker_instances          = { for k, v in oci_core_instance.workers : k => merge(lookup(local.worker_pools_final, k, {}), v) }
 
   # Combined map of outputs by pool name for all modes excluding 'instance' (output separately)
   worker_pools_output = merge(

--- a/modules/workers/nodepools.tf
+++ b/modules/workers/nodepools.tf
@@ -119,7 +119,6 @@ resource "oci_containerengine_node_pool" "tfscaled_workers" {
     ignore_changes = [
       # kubernetes_version, # e.g. if changed as part of an upgrade
       name, defined_tags, freeform_tags,
-      node_metadata["user_data"],               # templated cloud-init
       node_config_details[0].placement_configs, # dynamic placement configs
       # node_source_details[0],                   # dynamic image lookup
     ]
@@ -274,7 +273,6 @@ resource "oci_containerengine_node_pool" "autoscaled_workers" {
     ignore_changes = [
       # kubernetes_version, # e.g. if changed as part of an upgrade
       name, defined_tags, freeform_tags,
-      node_metadata["user_data"],               # templated cloud-init
       node_config_details[0].placement_configs, # dynamic placement configs
       node_config_details[0].size               # size
     ]


### PR DESCRIPTION
1. Add support to update cloud-init for resources using instance_config: instance_pools and clusternetworks.
2. Fix output for workers resources.
3. Fix cluster IAM prerequisite dependency.
4. Remove "oke.oraclecloud.com/tf.workspace" label from worker nodes because of inconsistent behavior.