### PR TITLE
Feat: Ability to customize block volume for instance-pool

### DIFF
--- a/examples/workers/vars-workers-instancepool.auto.tfvars
+++ b/examples/workers/vars-workers-instancepool.auto.tfvars
@@ -19,5 +19,18 @@ worker_pools = {
     mode        = "instance-pool",
     size        = 1,
     burst       = "BASELINE_1_8",   # Valid values BASELINE_1_8,BASELINE_1_2
-  }
+  },
+  oke-vm-instance-pool-with-block-volume = {
+    description = "Self-managed Instance Pool with block volume",
+    mode        = "instance-pool",
+    size        = 1,
+    disable_block_volume = false,
+    block_volume_size_in_gbs = 60,
+  },
+  oke-vm-instance-pool-without-block-volume = {
+    description = "Self-managed Instance Pool without block volume",
+    mode        = "instance-pool",
+    size        = 1,
+    disable_block_volume = true,
+  },
 }


### PR DESCRIPTION
Added the ability to customize block volume creation when worker pool mode is instance-pool
Fixes issue: [969](https://github.com/oracle-terraform-modules/terraform-oci-oke/issues/969)

Reason for this fix, if customer wants to create thousands of node added as instance-pool, it will end up creating thousands of block volume which customer may or may not need. This creates a potentially unnecessary resource cost.


When worker nodes are added as instance pool, we need an option whether to provision a block volume or not. If we choose to provision a block volume, we should be able to customize the size of the block volume.

Define the worker_pools variable for oke like

```
module "k8s_infra" {
  source                             = "oracle-terraform-modules/oke/oci"
  version                            = "xxxx"
....
worker_pools                       = local.worker_pools
....
}
locals {
  oke-vm-instance-pool-with-block-volume = {
    description = "Self-managed Instance Pool with block volume",
    mode        = "instance-pool",
    size        = 1,
    disable_block_volume = false,
    block_volume_size_in_gbs = 60,
  },
  oke-vm-instance-pool-without-block-volume = {
    description = "Self-managed Instance Pool without block volume",
    mode        = "instance-pool",
    size        = 1,
    disable_block_volume = true,
  },
  }
```

if block_volume_size_in_gbs is not specified the default will be 50gb.

### Type of Change
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [ ] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

