### PR TITLE
Fix #980: Add pod NSG to instance configuration metadata #981

### DIFF
--- a/modules/workers/instanceconfig.tf
+++ b/modules/workers/instanceconfig.tf
@@ -64,6 +64,7 @@ resource "oci_core_instance_configuration" "workers" {
           oke-native-pod-networking = var.cni_type == "npn" ? true : false
           oke-max-pods              = var.max_pods_per_node
           pod-subnets               = coalesce(var.pod_subnet_id, var.worker_subnet_id, "none")
+          pod-nsgids                = join(",", each.value.pod_nsg_ids)
         },
 
         # Only provide cluster DNS service address if set explicitly; determined automatically in practice.

--- a/modules/workers/instanceconfig.tf
+++ b/modules/workers/instanceconfig.tf
@@ -64,7 +64,7 @@ resource "oci_core_instance_configuration" "workers" {
           oke-native-pod-networking = var.cni_type == "npn" ? true : false
           oke-max-pods              = var.max_pods_per_node
           pod-subnets               = coalesce(var.pod_subnet_id, var.worker_subnet_id, "none")
-          pod-nsgids                = join(",", each.value.pod_nsg_ids)
+          pod-nsgids                = var.cni_type == "npn" ? join(",", each.value.pod_nsg_ids) : null
         },
 
         # Only provide cluster DNS service address if set explicitly; determined automatically in practice.


### PR DESCRIPTION
Resolves #980 

Fix for pod NSGs are not attached to VNICs created by the VCN-native CNI when using self-managed nodes.