### PR TITLE
Improve cluster add-ons documentation

### DIFF
--- a/docs/src/guide/cluster_addons.md
+++ b/docs/src/guide/cluster_addons.md
@@ -6,6 +6,8 @@ This module provides the option to remove [Essential addons](https://docs.oracle
 
 Cluster add-on removal (using the `cluster_addons_to_remove` variable) requires the creation of the operator host.
 
+If the operator host is not provisioned, it is possible to customize the essential add-ons configuration and prevent the pods from being scheduled. For example, using this approach you can install a custom CNI & KubeProxy replacement.
+
 **Note**: For the cluster autoscaler you should choose **only one** of the options:
 - the stand-alone cluster-autoscaler deployment, using the [extension module](./extensions_cluster_autoscaler.md)
 - the cluster-autoscaler add-on

--- a/examples/cluster-addons/vars-cluster-addons.auto.tfvars
+++ b/examples/cluster-addons/vars-cluster-addons.auto.tfvars
@@ -13,6 +13,28 @@ cluster_addons = {
       }
     ]
   }
+  # Prevent Flannel pods from being scheduled using a non-existing label as nodeSelector
+  "Flannel" = {
+    remove_addon_resources_on_delete = true
+    override_existing = true # Override the existing configuration with this one, if Flannel addon in already enabled
+    configurations = [
+      {
+        key   = "nodeSelectors"
+        value = "{\"addon\":\"no-schedule\"}"
+      }
+    ],
+  },
+  # Prevent Kube-Proxy pods from being scheduled using a non-existing label as nodeSelector
+  "KubeProxy" = {
+    remove_addon_resources_on_delete = true
+    override_existing = true # Override the existing configuration with this one, if KubeProxy addon in already enabled
+    configurations = [
+      {
+        key   = "nodeSelectors"
+        value = "{\"addon\":\"no-schedule\"}"
+      }
+    ],
+  }
 }
 
 cluster_addons_to_remove = {

--- a/modules/cluster-addons/versions.tf
+++ b/modules/cluster-addons/versions.tf
@@ -7,7 +7,7 @@ terraform {
   required_providers {
     oci = {
       source  = "oracle/oci"
-      version = ">= 4.119.0"
+      version = ">= 6.17.0"
     }
   }
 }


### PR DESCRIPTION
Provide example about how we can use `nodeSelector` addon configuration and the `override_existing` attribute of the `oci_containerengine_addon` terraform resource, to prevent the pods associated with the essential addons from being scheduled.