### PR TITLE
Update operator and bastion cloud inits to support different operating systems

### DIFF
--- a/module-bastion.tf
+++ b/module-bastion.tf
@@ -46,6 +46,7 @@ module "bastion" {
   compartment_id = local.compartment_id
 
   # Bastion
+  await_cloudinit          = var.bastion_await_cloudinit
   assign_dns               = var.assign_dns
   availability_domain      = coalesce(var.bastion_availability_domain, lookup(local.ad_numbers_to_names, local.ad_numbers[0]))
   bastion_image_os_version = var.bastion_image_os_version

--- a/module-operator.tf
+++ b/module-operator.tf
@@ -54,12 +54,15 @@ module "operator" {
   bastion_user = var.bastion_user
 
   # Operator
+  await_cloudinit           = var.operator_await_cloudinit
   assign_dns                = var.assign_dns
   availability_domain       = coalesce(var.operator_availability_domain, lookup(local.ad_numbers_to_names, local.ad_numbers[0]))
   cloud_init                = var.operator_cloud_init
   image_id                  = local.operator_image_id
   install_cilium            = var.cilium_install
   install_helm              = var.operator_install_helm
+  install_helm_from_repo    = var.operator_install_helm_from_repo
+  install_oci_cli_from_repo = var.operator_install_oci_cli_from_repo
   install_istioctl          = var.operator_install_istioctl
   install_k9s               = var.operator_install_k9s
   install_kubectx           = var.operator_install_kubectx

--- a/modules/bastion/cloudinit.tf
+++ b/modules/bastion/cloudinit.tf
@@ -38,6 +38,7 @@ data "cloudinit_config" "bastion" {
 }
 
 resource "null_resource" "await_cloudinit" {
+  count = var.await_cloudinit ? 1 : 0
   connection {
     host        = oci_core_instance.bastion.public_ip
     user        = var.user

--- a/modules/bastion/variables.tf
+++ b/modules/bastion/variables.tf
@@ -6,6 +6,7 @@ variable "compartment_id" { type = string }
 variable "state_id" { type = string }
 
 # Bastion
+variable "await_cloudinit" { type = string }
 variable "assign_dns" { type = bool }
 variable "availability_domain" { type = string }
 variable "bastion_image_os_version" {type = string}

--- a/modules/operator/cloudinit.tf
+++ b/modules/operator/cloudinit.tf
@@ -255,6 +255,7 @@ data "cloudinit_config" "operator" {
           content = <<-EOT
             export OCI_CLI_AUTH=instance_principal
             export TERM=xterm-256color
+            export OCI_PYTHON_SDK_NO_SERVICE_IMPORTS=True
             source <(kubectl completion bash)
             alias k='kubectl'
             alias ktx='kubectx'

--- a/modules/operator/variables.tf
+++ b/modules/operator/variables.tf
@@ -10,12 +10,15 @@ variable "bastion_host" { type = string }
 variable "bastion_user" { type = string }
 
 # Operator
+variable "await_cloudinit" { type = string }
 variable "assign_dns" { type = bool }
 variable "availability_domain" { type = string }
 variable "cloud_init" { type = list(map(string)) }
 variable "image_id" { type = string }
 variable "install_cilium" { type = bool }
+variable "install_oci_cli_from_repo" { type = bool }
 variable "install_helm" { type = bool }
+variable "install_helm_from_repo" { type = bool }
 variable "install_istioctl" { type = bool }
 variable "install_k9s" { type = bool }
 variable "install_kubectl_from_repo" { 

--- a/variables-bastion.tf
+++ b/variables-bastion.tf
@@ -87,3 +87,9 @@ variable "bastion_upgrade" {
   description = "Whether to upgrade bastion packages after provisioning."
   type        = bool
 }
+
+variable "bastion_await_cloudinit" {
+  default     = true
+  description = "Whether to block until successful connection to bastion and completion of cloud-init."
+  type        = bool
+}

--- a/variables-operator.tf
+++ b/variables-operator.tf
@@ -67,7 +67,7 @@ variable "operator_install_helm" {
 
 variable "operator_install_helm_from_repo" {
   default     = false
-  description = "Whether to install Helm on the created operator host."
+  description = "Whether to install Helm from the repo on the created operator host."
   type        = bool
 }
 
@@ -91,7 +91,7 @@ variable "operator_install_k9s" {
 
 variable "operator_install_kubectl_from_repo" {
   default     = true
-  description = "Whether to install kubectl on the created operator host from olcne repo."
+  description = "Whether to install kubectl from the repo on the created operator host."
   type        = bool
 }
 

--- a/variables-operator.tf
+++ b/variables-operator.tf
@@ -65,6 +65,18 @@ variable "operator_install_helm" {
   type        = bool
 }
 
+variable "operator_install_helm_from_repo" {
+  default     = false
+  description = "Whether to install Helm on the created operator host."
+  type        = bool
+}
+
+variable "operator_install_oci_cli_from_repo" {
+  default     = false
+  description = "Whether to install OCI from repo on the created operator host."
+  type        = bool
+}
+
 variable "operator_install_istioctl" {
   default     = false
   description = "Whether to install istioctl on the created operator host."
@@ -90,9 +102,9 @@ variable "operator_install_kubectx" {
 }
 
 variable "operator_install_stern" {
-  default = false
+  default     = false
   description = "Whether to install stern on the created operator host. NOTE: Provided only as a convenience and not supported by or sourced from Oracle - use at your own risk."
-  type = bool
+  type        = bool
 }
 
 variable "operator_shape" {
@@ -128,4 +140,10 @@ variable "operator_private_ip" {
   default     = null
   description = "The IP address of an existing operator host. Ignored when create_operator = true."
   type        = string
+}
+
+variable "operator_await_cloudinit" {
+  default     = true
+  description = "Whether to block until successful connection to operator and completion of cloud-init."
+  type        = bool
 }


### PR DESCRIPTION
- Add option to install OCI CLI and Helm from repos to support OSs like Ubuntu that does not have packages in the default repos.
- Add option to not wait for bastion and operator cloud inits (`operator_await_cloudinit` and `bastion_await_cloudinit`).
- Update `k9s` version.
- Fix a typo for `stern`.