### PR TITLE
Add support for Ubuntu images

### DIFF
--- a/modules/cluster/cluster.tf
+++ b/modules/cluster/cluster.tf
@@ -69,8 +69,11 @@ resource "oci_containerengine_cluster" "k8s_cluster" {
       }
     }
 
-    open_id_connect_discovery {
-      is_open_id_connect_discovery_enabled = var.oidc_discovery_enabled
+    dynamic "open_id_connect_discovery" {
+      for_each = var.oidc_discovery_enabled ? [1] : []
+      content {
+        is_open_id_connect_discovery_enabled = var.oidc_discovery_enabled
+      }
     }
 
     kubernetes_network_config {


### PR DESCRIPTION
Add support for Ubuntu images when using the `instance-pool` and `instance` mode in nodepools.

Here you can find the supported Ubuntu and Kubernetes versions:
https://docs.oracle.com/en-us/iaas/Content/ContEng/Tasks/contengcreatingubuntubasedworkernodes.htm#contengcreatingubuntubasedworkernodes_availabilitycompatibility
