### PR TITLE
feat: Ability to define taints for nodepool, instance and instance pool mode

### DIFF
--- a/examples/workers/vars-workers-instance.auto.tfvars
+++ b/examples/workers/vars-workers-instance.auto.tfvars
@@ -20,4 +20,21 @@ worker_pools = {
     size        = 1,
     burst       = "BASELINE_1_8", # Valid values BASELINE_1_8,BASELINE_1_2
   },
+  oke-vm-instance-taint = {
+    description = "Self-managed Instance With taint",
+    mode        = "instance",
+    size        = 1,
+    taints = [
+      "project=workload-taint:NoSchedule"
+    ]
+  },
+  oke-vm-instance-multi-taint = {
+    description = "Self-managed Instance With multiple taint",
+    mode        = "instance",
+    size        = 1,
+    taints = [
+      "project=workload:NoSchedule",
+      "oke.oraclecloud.com/pool.name=oke-vm-instance-multi-taint:NoSchedule"
+    ]
+  },
 }

--- a/examples/workers/vars-workers-instancepool.auto.tfvars
+++ b/examples/workers/vars-workers-instancepool.auto.tfvars
@@ -33,4 +33,17 @@ worker_pools = {
     size                 = 1,
     disable_block_volume = true,
   },
+  oke-vm-instance-pool-taint = {
+    description = "Self-managed Instance Pool with taint",
+    mode        = "instance-pool",
+    size        = 1,
+    node_labels = {
+      "keya" = "valuea",
+      "keyb" = "valueb"
+    },
+    taints = [
+      "keya=valuea:NoSchedule",
+      "keyb=valueb:NoSchedule"
+    ]
+  },
 }

--- a/examples/workers/vars-workers-nodepool.auto.tfvars
+++ b/examples/workers/vars-workers-nodepool.auto.tfvars
@@ -38,4 +38,25 @@ worker_pools = {
     size        = 1,
     create      = false,
   },
+  oke-vm-standard-ol7-taint = {
+    description = "OKE-managed Node Pool with OKE Oracle Linux 7 image with taints",
+    size        = 1,
+    os          = "Oracle Linux",
+    os_version  = "7",
+    create      = true,
+    taints = [
+      "project=workload-taint:NoSchedule"
+    ]
+  },
+  oke-vm-standard-ol8-multiple-taints = {
+    description = "OKE-managed Node Pool with OKE Oracle Linux 8 image with multiple taints",
+    size        = 1,
+    os          = "Oracle Linux",
+    os_version  = "8",
+    create      = true,
+    taints = [
+      "project=workload-multi-taint:NoSchedule",
+      "oke.oraclecloud.com/pool.name=oke-vm-standard-ol8-multiple-taints:NoSchedule"
+    ]
+  },
 }


### PR DESCRIPTION
Added the ability to define taints for worker node in mode , node-pool, instance and instance-pool
Fixes issue: https://github.com/oracle-terraform-modules/terraform-oci-oke/issues/1010

When worker nodes are added as nodepool, instance pool or instance , we need an ability to define taints

Define the worker_pools variable for oke like below as example

```
module "k8s_infra" {
  source                             = "oracle-terraform-modules/oke/oci"
  version                            = "xxxx"
....
worker_pools                       = local.worker_pools
....
}
locals {
    oke-vm-instance-pool= {
      mode             = "instance-pool",
      size             = 1,
      shape            = "VM.Standard.E4.Flex",
      create           = true,
      ocpus            = 1,
      memory           = 16,

    },
    oke-vm-instance    = {
      mode             = "instance",
      size             = 1,
      shape            = "VM.Standard.E4.Flex",
      create           = true,
      ocpus            = 1,
      memory           = 16,
    },
    oke-vm-node-pool   = {
      mode             = "node-pool",
      size             = 1,
      os               = "Oracle Linux",
      os_version       = "7",
      create           = true,
      taints = [
        "project=workload-taint:NoSchedule"
      ]
    },
  }
```
