### PR TITLE
Refactor helm datasources

### DIFF
--- a/modules/extensions/dcgm_exporter.tf
+++ b/modules/extensions/dcgm_exporter.tf
@@ -47,14 +47,14 @@ data "helm_template" "dcgm_exporter" {
     for path in var.dcgm_exporter_helm_values_files : file(path)
   ] : null
 
-  dynamic "set" {
-    for_each = var.dcgm_exporter_helm_values
-    iterator = helm_value
-    content {
-      name  = helm_value.key
-      value = helm_value.value
-    }
-  }
+  set = concat(
+    [ for k, v in var.dcgm_exporter_helm_values:
+      {
+        name  = k,
+        value = v
+      }
+    ]
+  )
 
   lifecycle {
     precondition {

--- a/modules/extensions/gatekeeper.tf
+++ b/modules/extensions/gatekeeper.tf
@@ -23,26 +23,14 @@ data "helm_template" "gatekeeper" {
     for path in var.gatekeeper_helm_values_files : file(path)
   ] : null
 
-  # TODO Remove after merge: https://github.com/open-policy-agent/gatekeeper/pull/2593
-  set {
-    name  = "postInstall.labelNamespace.enabled"
-    value = "false"
-  }
-
-  # TODO Remove after merge: https://github.com/open-policy-agent/gatekeeper/pull/2593
-  set {
-    name  = "postInstall.probeWebhook.enabled"
-    value = "false"
-  }
-
-  dynamic "set" {
-    for_each = var.gatekeeper_helm_values
-    iterator = helm_value
-    content {
-      name  = helm_value.key
-      value = helm_value.value
-    }
-  }
+  set = concat(
+    [ for k, v in var.gatekeeper_helm_values:
+      {
+        name  = k,
+        value = v
+      }
+    ]
+  )
 
   lifecycle {
     precondition {

--- a/modules/extensions/metricserver.tf
+++ b/modules/extensions/metricserver.tf
@@ -23,14 +23,14 @@ data "helm_template" "metrics_server" {
     for path in var.metrics_server_helm_values_files : file(path)
   ] : null
 
-  dynamic "set" {
-    for_each = var.metrics_server_helm_values
-    iterator = helm_value
-    content {
-      name  = helm_value.key
-      value = helm_value.value
-    }
-  }
+  set = concat(
+    [ for k, v in var.metrics_server_helm_values:
+      {
+        name  = k,
+        value = v
+      }
+    ]
+  )
 
   lifecycle {
     precondition {

--- a/modules/extensions/prometheus.tf
+++ b/modules/extensions/prometheus.tf
@@ -32,19 +32,20 @@ data "helm_template" "prometheus" {
     [for path in var.prometheus_helm_values_files : file(path)],
   )
 
-  set {
-    name  = "podSecurityPolicy.enabled"
-    value = "false"
-  }
-
-  dynamic "set" {
-    for_each = var.prometheus_helm_values
-    iterator = helm_value
-    content {
-      name  = helm_value.key
-      value = helm_value.value
-    }
-  }
+  set = concat(
+    [
+      {
+        name  = "podSecurityPolicy.enabled"
+        value = "false"
+      },
+    ],
+    [ for k, v in var.prometheus_helm_values:
+      {
+        name  = k,
+        value = v
+      }
+    ]
+  )
 
   lifecycle {
     precondition {

--- a/modules/extensions/versions.tf
+++ b/modules/extensions/versions.tf
@@ -7,7 +7,7 @@ terraform {
   required_providers {
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 2.9.0"
+      version = ">= 3.0.1"
     }
 
     http = {

--- a/versions.tf
+++ b/versions.tf
@@ -12,7 +12,7 @@ terraform {
 
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 2.9.0"
+      version = ">= 3.0.1"
     }
 
     null = {


### PR DESCRIPTION
Fixes #1018 .

The helm terraform provider introduced breaking changes starting with the version [v3.0.0](https://github.com/hashicorp/terraform-provider-helm/releases/tag/v3.0.0):

> - Blocks to Nested Objects: Blocks like kubernetes, registry, and experiments are now represented as nested objects.
> - List Syntax for Nested Attributes: Attributes like set, set_list, and set_sensitive in helm_release and helm_template are now lists of nested objects instead of blocks

In this PR (specific for 5.1.8 release), I'm changing the `set` attributes from dynamic block to list.