### PR TITLE
update conditions

### DIFF
--- a/module-cluster.tf
+++ b/module-cluster.tf
@@ -99,10 +99,10 @@ module "cluster" {
     local.cluster_defined_tags,
   )
   cluster_freeform_tags = merge(
-    var.use_defined_tags ? {} : {
+    var.use_defined_tags ? {
       "state_id" = local.state_id,
       "role"     = "cluster",
-    },
+    } : {},
     local.cluster_freeform_tags,
   )
   persistent_volume_defined_tags = merge(
@@ -113,10 +113,10 @@ module "cluster" {
     local.persistent_volume_defined_tags,
   )
   persistent_volume_freeform_tags = merge(
-    var.use_defined_tags ? {} : {
+    var.use_defined_tags ? {
       "state_id" = local.state_id,
       "role"     = "persistent_volume",
-    },
+    } : {},
     local.persistent_volume_freeform_tags,
   )
   service_lb_defined_tags = merge(
@@ -127,10 +127,10 @@ module "cluster" {
     local.service_lb_defined_tags,
   )
   service_lb_freeform_tags = merge(
-    var.use_defined_tags ? {} : {
+    var.use_defined_tags ? {
       "state_id" = local.state_id,
       "role"     = "service_lb"
-    },
+    } : {},
     local.service_lb_freeform_tags,
   )
 

--- a/module-operator.tf
+++ b/module-operator.tf
@@ -26,7 +26,7 @@ locals {
   )
 
   // Whether the operator is enabled, i.e. created in this TF state or existing provided by ID
-  operator_enabled = anytrue([
+  operator_enabled = alltrue([
     (local.cluster_enabled || coalesce(var.cluster_id, "none") != "none"),
     (var.create_operator || coalesce(var.operator_private_ip, "none") != "none"),
   ])

--- a/modules/workers/locals.tf
+++ b/modules/workers/locals.tf
@@ -140,7 +140,7 @@ locals {
       # Standard tags as freeform if defined tags are disabled
       # User-provided freeform tags are merged and take precedence
       freeform_tags = merge(
-        var.use_defined_tags ? {} : merge(
+        var.use_defined_tags ? merge(
           {
             "state_id"           = var.state_id,
             "role"               = "worker",
@@ -148,7 +148,7 @@ locals {
             "cluster_autoscaler" = pool.allow_autoscaler ? "allowed" : "disabled",
           },
           pool.autoscale ? { "cluster_autoscaler" = "managed" } : {},
-        ),
+        ) : {},
         var.freeform_tags,
         lookup(pool, "freeform_tags", {})
       )


### PR DESCRIPTION
- Correct "use_defined_tags" conditional statements that are in reverse.
- Change "local.operator_enabled" collection function from "anytrue" to "alltrue" as the operator should not be created if "var.create_operator" is set to "false" regardless of "local.cluster_enabled" value.