### PR TITLE
Ability to install argocd as an extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@ provider.tf
 *.tfstate.*
 
 # .tfvars files
-*.tfvars
+# *.tfvars
 
 generated/**
 

--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@ provider.tf
 *.tfstate.*
 
 # .tfvars files
-# *.tfvars
+*.tfvars
 
 generated/**
 

--- a/examples/extensions/vars-extensions-argocd.auto.tfvars
+++ b/examples/extensions/vars-extensions-argocd.auto.tfvars
@@ -1,0 +1,8 @@
+# Copyright (c) 2017, 2023 Oracle Corporation and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl
+
+argocd_install           = true
+argocd_namespace         = "argocd"
+argocd_helm_version      = "8.1.2"
+argocd_helm_values       = {}
+argocd_helm_values_files = []

--- a/module-extensions.tf
+++ b/module-extensions.tf
@@ -122,4 +122,11 @@ module "extensions" {
   # Service Account
   create_service_account = var.create_service_account
   service_accounts       = var.service_accounts
+
+  # Argocd
+  argocd_install           = var.argocd_install
+  argocd_namespace         = var.argocd_namespace
+  argocd_helm_version      = var.argocd_helm_version
+  argocd_helm_values       = var.argocd_helm_values
+  argocd_helm_values_files = var.argocd_helm_values_files
 }

--- a/modules/extensions/argocd.tf
+++ b/modules/extensions/argocd.tf
@@ -70,10 +70,6 @@ resource "null_resource" "argocd" {
   }
 
   provisioner "remote-exec" {
-    inline = ["kubectl apply --force-conflicts=true --server-side -f ${local.argocd_manifest_path}"]
-  }
-
-  provisioner "remote-exec" {
     inline = [for c in compact([
       (contains(["kube-system", "default"], var.argocd_namespace) ? null
       : format(local.kubectl_create_missing_ns, var.argocd_namespace)),

--- a/modules/extensions/argocd.tf
+++ b/modules/extensions/argocd.tf
@@ -72,4 +72,13 @@ resource "null_resource" "argocd" {
   provisioner "remote-exec" {
     inline = ["kubectl apply --force-conflicts=true --server-side -f ${local.argocd_manifest_path}"]
   }
+
+  provisioner "remote-exec" {
+    inline = [for c in compact([
+      (contains(["kube-system", "default"], var.argocd_namespace) ? null
+      : format(local.kubectl_create_missing_ns, var.argocd_namespace)),
+      format(local.kubectl_apply_server_file, local.argocd_manifest_path),
+      ]) : format(local.output_log, c, "argocd")
+    ]
+  }
 }

--- a/modules/extensions/argocd.tf
+++ b/modules/extensions/argocd.tf
@@ -1,0 +1,75 @@
+# Copyright (c) 2021, 2023 Oracle Corporation and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl
+
+locals {
+  argocd_enabled       = var.argocd_install && var.expected_node_count > 0
+  argocd_manifest      = sensitive(one(data.helm_template.argocd[*].manifest))
+  argocd_manifest_path = join("/", [local.yaml_manifest_path, "argocd.yaml"])
+}
+
+data "helm_template" "argocd" {
+  count        = local.argocd_enabled ? 1 : 0
+  chart        = "argo-cd"
+  repository   = "https://argoproj.github.io/argo-helm"
+  version      = var.argocd_helm_version
+  kube_version = var.kubernetes_version
+
+  name             = "argocd"
+  namespace        = var.argocd_namespace
+  create_namespace = true
+  include_crds     = true
+  skip_tests       = true
+  values = length(var.argocd_helm_values_files) > 0 ? [
+    for path in var.argocd_helm_values_files : file(path)
+  ] : null
+
+  set = concat(
+    [ for k, v in var.argocd_helm_values:
+      {
+        name  = k,
+        value = v
+      }
+    ]
+  )
+
+  lifecycle {
+    precondition {
+      condition = alltrue([for path in var.argocd_helm_values_files : fileexists(path)])
+      error_message = format("Missing Helm values files in configuration: %s",
+        jsonencode([for path in var.argocd_helm_values_files : path if !fileexists(path)])
+      )
+    }
+  }
+}
+
+resource "null_resource" "argocd" {
+  count = local.argocd_enabled ? 1 : 0
+
+  triggers = {
+    manifest_md5 = try(md5(local.argocd_manifest), null)
+  }
+
+  connection {
+    bastion_host        = var.bastion_host
+    bastion_user        = var.bastion_user
+    bastion_private_key = var.ssh_private_key
+    host                = var.operator_host
+    user                = var.operator_user
+    private_key         = var.ssh_private_key
+    timeout             = "40m"
+    type                = "ssh"
+  }
+
+  provisioner "remote-exec" {
+    inline = ["mkdir -p ${local.yaml_manifest_path}"]
+  }
+
+  provisioner "file" {
+    content     = local.argocd_manifest
+    destination = local.argocd_manifest_path
+  }
+
+  provisioner "remote-exec" {
+    inline = ["kubectl apply --force-conflicts=true --server-side -f ${local.argocd_manifest_path}"]
+  }
+}

--- a/modules/extensions/variables.tf
+++ b/modules/extensions/variables.tf
@@ -106,3 +106,10 @@ variable "gatekeeper_helm_values_files" { type = list(string) }
 # Service Account
 variable "create_service_account" { type = bool }
 variable "service_accounts" { type = map(any) }
+
+# Argocd
+variable "argocd_install" { type = bool }
+variable "argocd_namespace" { type = string }
+variable "argocd_helm_version" { type = string }
+variable "argocd_helm_values" { type = map(string) }
+variable "argocd_helm_values_files" { type = list(string) }

--- a/variables-extensions.tf
+++ b/variables-extensions.tf
@@ -387,3 +387,35 @@ variable "service_accounts" {
   description = "Map of service accounts and associated parameters."
   type        = map(any)
 }
+
+# Argocd
+
+variable "argocd_install" {
+  default     = false
+  description = "Whether to deploy the Argocd Helm chart. See https://github.com/argoproj/argo-cd. NOTE: Provided only as a convenience and not supported by or sourced from Oracle - use at your own risk."
+  type        = bool
+}
+
+variable "argocd_namespace" {
+  default     = "argocd"
+  description = "Kubernetes namespace for deployed resources."
+  type        = string
+}
+
+variable "argocd_helm_version" {
+  default     = "8.1.2"
+  description = "Version of the Helm chart to install. List available releases using `helm search repo [keyword] --versions`."
+  type        = string
+}
+
+variable "argocd_helm_values" {
+  default     = {}
+  description = "Map of individual Helm chart values. See <a href=https://registry.terraform.io/providers/hashicorp/helm/latest/docs/data-sources/template>data.helm_template</a>."
+  type        = map(string)
+}
+
+variable "argocd_helm_values_files" {
+  default     = []
+  description = "Paths to a local YAML files with Helm chart values (as with `helm install -f` which supports multiple). Generate with defaults using `helm show values [CHART] [flags]`."
+  type        = list(string)
+}


### PR DESCRIPTION
### Description

Added the feature to  install argocd as an extension
Fixes issue: [1029](https://github.com/oracle-terraform-modules/terraform-oci-oke/issues/1029)


```
module "k8s_infra" {
  source                             = "oracle-terraform-modules/oke/oci"
  version                            = "xxxx"
....
  argocd_install          = true
....
}

```


### Type of Change
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [ ] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)



