### PR TITLE
Added support for Ubuntu Minimal versions

### DIFF
--- a/modules/workers/cloudinit.tf
+++ b/modules/workers/cloudinit.tf
@@ -184,7 +184,7 @@ data "cloudinit_config" "workers" {
     precondition {
       condition = lookup(local.ubuntu_worker_pools, each.key, null) == null || (
         lookup(local.ubuntu_worker_pools, each.key, null) != null &&
-          contains(["22.04", "24.04"], lookup(lookup(local.ubuntu_worker_pools, each.key, {}), "ubuntu_release", ""))
+          contains(local.ubuntu_supported_versions, lookup(lookup(local.ubuntu_worker_pools, each.key, {}), "ubuntu_release", ""))
       )
       error_message = <<-EOT
       Supported Ubuntu versions are "22.04" and "24.04".

--- a/modules/workers/locals.tf
+++ b/modules/workers/locals.tf
@@ -292,6 +292,9 @@ locals {
   worker_pool_ips = merge(local.worker_instance_ips, local.worker_nodepool_ips)
   
   # Map of nodepools using Ubuntu images.
+
+  ubuntu_supported_versions = ["22.04", "24.04", "22.04 Minimal", "24.04 Minimal"]
+
   ubuntu_worker_pools = {
     for k, v in local.enabled_worker_pools : k => {
       kubernetes_major_version = substr(lookup(v, "kubernetes_version", ""), 1, 4)


### PR DESCRIPTION
For Ubuntu worker nodes custom images, the recommendation is to have OKE Worker Nodes images created using Ubuntu 22.04 and 24.04 Minimal. Even Canonical provides OKE pre-built images based on Ubuntu Minimal.
In the Terraform module there was a precondition to check supported Ubuntu versions that was incorrect.
Ubuntu Minimal versions are marked with a different ubuntu_release tag, specifically "22.04 Minimal" and "24.04 Minimal"

To further enhance readability, I have added a local variable "ubuntu_supported_versions" with a list of all the correct supported versions for Ubuntu OKE Nodes.