### PR TITLE
Fix default value for `bastion_image_os`

### DIFF
--- a/variables-bastion.tf
+++ b/variables-bastion.tf
@@ -54,7 +54,7 @@ variable "bastion_image_type" {
 }
 
 variable "bastion_image_os" {
-  default     = "Oracle Autonomous Linux"
+  default     = "Oracle Linux"
   description = "Bastion image operating system name when bastion_image_type = 'platform'."
   type        = string
 }


### PR DESCRIPTION
`Oracle Autonomous Linux` does not seem to be a thing anymore, and we can use `Oracle Linux` instead.

This makes the "out-of-the-box" experience a little better. But the lack of correct feedback and error propagation for invalid credentials is where multiple days were lost.