### PR TITLE
Karpenter - IAM update

### DIFF
--- a/docs/terraformoptions.md
+++ b/docs/terraformoptions.md
@@ -68,7 +68,6 @@ Configuration Terraform Options:
 | `create_iam_worker_policy` | Create IAM policy for worker nodes. | `"never"` / `"auto"` / `"always"` | `"auto"` |
 | `create_iam_karpenter_policy` | Create IAM dynamic group and policy rules for Karpenter management. Ignored when `create_iam_resources` is `false`. | `"never"` / `"auto"` / `"always"` | `"auto"` |
 | `karpenter_optional_policies` | Create optional IAM policies for Karpenter management. Ignored when `create_iam_resources` is `false`. | object({ capacity_reservation, compute_clusters, cluster_placement_groups, defined_tags }) | `{}` |
-| `karpenter_worker_compartments` | Compartments where Karpenter creates worker nodes. Ignored when `create_iam_resources` is `false`. | list(string) | `[]` |
 | `create_iam_tag_namespace` | Create IAM tag namespace and tags. | `true` / `false` | `false` |
 | `create_iam_defined_tags` | Create IAM defined tags in the tag namespace. | `true` / `false` | `false` |
 | `use_defined_tags` | Apply defined tags to created resources. | `true` / `false` | `false` |

--- a/examples/iam/vars-iam-policies.auto.tfvars
+++ b/examples/iam/vars-iam-policies.auto.tfvars
@@ -13,5 +13,3 @@ karpenter_optional_policies = {
   cluster_placement_groups = false
   defined_tags             = false
 }
-
-karpenter_worker_compartments = []

--- a/module-iam.tf
+++ b/module-iam.tf
@@ -92,7 +92,6 @@ module "iam_cluster_prerequisites" {
   network_compartment_id = var.network_compartment_id
 
   karpenter_namespace           = var.karpenter_namespace
-  karpenter_worker_compartments = var.karpenter_worker_compartments
   karpenter_optional_policies   = var.karpenter_optional_policies
 
   providers = {
@@ -134,7 +133,6 @@ module "iam" {
   network_compartment_id = var.network_compartment_id
 
   karpenter_namespace           = var.karpenter_namespace
-  karpenter_worker_compartments = var.karpenter_worker_compartments
   karpenter_optional_policies   = var.karpenter_optional_policies
 
   providers = {

--- a/modules/iam/group-karpenter.tf
+++ b/modules/iam/group-karpenter.tf
@@ -3,25 +3,19 @@
 
 locals {
   karpenter_group_name          = format("oke-karpenter-%v", var.state_id)
-  karpenter_worker_compartments = coalescelist(var.karpenter_worker_compartments, [var.compartment_id])
-  karpenter_compartment_matches = formatlist("instance.compartment.id = '%v'", local.karpenter_worker_compartments)
-  karpenter_group_rules         = format("ANY {%v}", join(", ", local.karpenter_compartment_matches))
+  karpenter_group_rules         = format("ANY {instance.compartment.id = '%v'}", var.compartment_id)
 
-  karpenter_dynamic_group_templates = [
+  karpenter_cluster_join_statement = format(
     "Allow dynamic-group %v to {CLUSTER_JOIN} in compartment id %v",
-  ]
-
-  karpenter_dynamic_group_policy_statements = var.create_iam_karpenter_policy ? tolist([
-    for statement in local.karpenter_dynamic_group_templates : formatlist(statement,
-      local.karpenter_group_name, local.karpenter_worker_compartments,
-    )
-  ]) : []
+    local.karpenter_group_name,
+    var.compartment_id
+  )
 
   karpenter_workload_identity_templates = compact([
     "Allow any-user to manage instance-family in compartment id %v where all { request.principal.type='workload', request.principal.cluster_id = '%v', request.principal.namespace = '%v', request.principal.service_account = 'karpenter' }",
     "Allow any-user to manage volumes in compartment id %v where all { request.principal.type='workload', request.principal.cluster_id = '%v', request.principal.namespace = '%v', request.principal.service_account = 'karpenter' }",
     "Allow any-user to manage volume-attachments in compartment id %v where all { request.principal.type='workload', request.principal.cluster_id = '%v', request.principal.namespace = '%v', request.principal.service_account = 'karpenter' }",
-    "Allow any-user to manage virtual-network-family in compartment id %v where all { request.principal.type='workload', request.principal.cluster_id = '%v', request.principal.namespace = '%v', request.principal.service_account = 'karpenter' }",
+    var.network_compartment_id == null ? "Allow any-user to manage virtual-network-family in compartment id %v where all { request.principal.type='workload', request.principal.cluster_id = '%v', request.principal.namespace = '%v', request.principal.service_account = 'karpenter' }" : "",
     "Allow any-user to inspect compartments in compartment id %v where all { request.principal.type='workload', request.principal.cluster_id = '%v', request.principal.namespace = '%v', request.principal.service_account = 'karpenter' }",
     var.karpenter_optional_policies.capacity_reservation ? "Allow any-user to use compute-capacity-reservations in compartment id %v where all { request.principal.type='workload', request.principal.cluster_id = '%v', request.principal.namespace = '%v', request.principal.service_account = 'karpenter' }" : "",
     var.karpenter_optional_policies.compute_clusters ? "Allow any-user to use compute-clusters in compartment id %v where all { request.principal.type='workload', request.principal.cluster_id = '%v', request.principal.namespace = '%v', request.principal.service_account = 'karpenter' }" : "",
@@ -31,11 +25,13 @@ locals {
 
   karpenter_workload_identity_policy_statements = var.create_iam_karpenter_policy ? tolist([
     for statement in local.karpenter_workload_identity_templates : formatlist(statement,
-      local.karpenter_worker_compartments, var.cluster_id, var.karpenter_namespace
+      var.compartment_id, var.cluster_id, var.karpenter_namespace
     )
   ]) : []
 
-  karpenter_policy_statements = concat(local.karpenter_dynamic_group_policy_statements, local.karpenter_workload_identity_policy_statements)
+  karpenter_policy_statements = concat(
+    [local.karpenter_cluster_join_statement],
+    local.karpenter_workload_identity_policy_statements)
 }
 
 resource "oci_identity_dynamic_group" "karpenter" {

--- a/modules/iam/policy.tf
+++ b/modules/iam/policy.tf
@@ -42,6 +42,7 @@ resource "oci_identity_policy" "networking_policies" {
   statements     = compact([
     var.enable_ipv6 ? format("Allow any-user to use ipv6s in compartment id %v where all { request.principal.type = 'cluster' }", coalesce(var.network_compartment_id, var.compartment_id)) : null,
     format("Allow any-user to manage network-security-groups in compartment id %v where request.principal.type = 'cluster'", coalesce(var.network_compartment_id, var.compartment_id)),
+    var.create_iam_karpenter_policy && var.network_compartment_id != null ? format("Allow any-user to manage virtual-network-family in compartment id %v where all { request.principal.type='workload', request.principal.cluster_id = '%v', request.principal.namespace = '%v', request.principal.service_account = 'karpenter' }", coalesce(var.network_compartment_id, var.compartment_id), var.cluster_id, var.karpenter_namespace) : null
   ])
   defined_tags   = local.defined_tags
   freeform_tags  = local.freeform_tags

--- a/modules/iam/variables.tf
+++ b/modules/iam/variables.tf
@@ -35,5 +35,4 @@ variable "worker_volume_kms_key_id" { type = string }
 
 # Karpenter
 variable "karpenter_namespace" { type = string }
-variable "karpenter_worker_compartments" { type = list(string) }
 variable "karpenter_optional_policies" { type = map(string) }

--- a/variables-iam.tf
+++ b/variables-iam.tf
@@ -205,12 +205,6 @@ variable "karpenter_optional_policies" {
   })
 }
 
-variable "karpenter_worker_compartments" {
-  default     = []
-  description = "Compartments where karpenter will create worker nodes. Ignored when 'create_iam_resources' is false."
-  type        = list(string)
-}
-
 # Tagging
 
 variable "create_iam_tag_namespace" {


### PR DESCRIPTION
## Summary
  Refines Karpenter IAM policy generation by removing support for custom worker compartments and scoping permissions to the expected OCI compartments.

## Changes
  - Removed support for `karpenter_worker_compartments` because generating IAM policies across arbitrary worker compartments adds complexity.
  - Scoped Karpenter `CLUSTER_JOIN` and workload identity permissions to the cluster compartment.
  - Moved `virtual-network-family` permissions into the networking IAM policy when `network_compartment_id` is configured.