### PR TITLE
Fix IAM policies for separate network compartment and autoscaler + bump extension versions

### DIFF
--- a/docs/terraformoptions.md
+++ b/docs/terraformoptions.md
@@ -618,7 +618,7 @@ operator_shape = {
 | --- | --- | --- | --- |
 | `cluster_autoscaler_install` | Whether to install the standalone Cluster Autoscaler. | `true` / `false` | `false` |
 | `cluster_autoscaler_namespace` | Kubernetes namespace. | string | `"kube-system"` |
-| `cluster_autoscaler_helm_version` | Helm chart version. | string | `"9.24.0"` |
+| `cluster_autoscaler_helm_version` | Helm chart version. | string | `"9.53.0"` |
 | `cluster_autoscaler_helm_values` | Helm values. | map(string) | `{}` |
 | `cluster_autoscaler_helm_values_files` | List of Helm values files. | list(string) | `[]` |
 
@@ -700,7 +700,7 @@ service_accounts = {
 | --- | --- | --- | --- |
 | `karpenter_install` | Whether to install Karpenter. | `true` / `false` | `false` |
 | `karpenter_namespace` | Kubernetes namespace. | string | `kube-system` |
-| `karpenter_version` | Karpenter version. | string | `v1.1.0` |
+| `karpenter_version` | Karpenter version. | string | `v1.2.0` |
 | `karpenter_helm_values` | Helm values. | map(string) | `{}` |
 | `karpenter_helm_values_files` | List of Helm values files. | list(string) | `[]` |
 

--- a/examples/extensions/vars-extensions-karpenter.auto.tfvars
+++ b/examples/extensions/vars-extensions-karpenter.auto.tfvars
@@ -3,6 +3,6 @@
 
 karpenter_install           = true
 karpenter_namespace         = "kube-system"
-karpenter_version           = "v1.1.0"
+karpenter_version           = "v1.2.0"
 karpenter_helm_values       = {}
 karpenter_helm_values_files = []

--- a/examples/rms/oke-cluster-only/variables-extensions.tf
+++ b/examples/rms/oke-cluster-only/variables-extensions.tf
@@ -29,7 +29,7 @@ variable "metrics_server_helm_values_files" {
 
 variable "cluster_autoscaler_install" { default = false }
 variable "cluster_autoscaler_namespace" { default = "kube-system" }
-variable "cluster_autoscaler_helm_version" { default = "9.24.0" }
+variable "cluster_autoscaler_helm_version" { default = "9.53.0" }
 variable "cluster_autoscaler_helm_values" {
   default = {}
   type    = map(string)

--- a/module-iam.tf
+++ b/module-iam.tf
@@ -65,6 +65,7 @@ module "iam_cluster_prerequisites" {
   state_id                     = local.state_id
   tenancy_id                   = local.tenancy_id
   cluster_id                   = var.cluster_id
+  cni_type                     = var.cni_type
   create_iam_resources         = var.create_iam_resources
   create_iam_autoscaler_policy = false
   create_iam_kms_policy        = local.create_iam_kms_policy
@@ -106,6 +107,7 @@ module "iam" {
   state_id                     = local.state_id
   tenancy_id                   = local.tenancy_id
   cluster_id                   = local.cluster_id
+  cni_type                     = var.cni_type
   create_iam_resources         = var.create_iam_resources
   create_iam_autoscaler_policy = local.create_iam_autoscaler_policy
   create_iam_kms_policy        = false

--- a/modules/extensions/autoscaler.tf
+++ b/modules/extensions/autoscaler.tf
@@ -19,7 +19,7 @@ locals {
   cluster_autoscaler_manifest      = sensitive(one(data.helm_template.cluster_autoscaler[*].manifest))
   cluster_autoscaler_manifest_path = join("/", [local.yaml_manifest_path, "cluster_autoscaler.yaml"])
   cluster_autoscaler_defaults = {
-    "cloudProvider"                              = "oci-oke",
+    "cloudProvider"                              = "oci",
     "extraArgs.logtostderr"                      = "true",
     "extraArgs.v"                                = "4",
     "extraArgs.stderrthreshold"                  = "info",
@@ -36,7 +36,7 @@ locals {
     "extraEnv.OKE_USE_INSTANCE_PRINCIPAL"        = "true",
     "extraEnv.OCI_SDK_APPEND_USER_AGENT"         = "oci-oke-cluster-autoscaler",
     "image.repository"                           = "iad.ocir.io/oracle/oci-cluster-autoscaler",
-    "image.tag"                                  = "1.26.2-7",
+    "image.tag"                                  = "1.34.2-252",
   }
 }
 

--- a/modules/iam/group-autoscaling.tf
+++ b/modules/iam/group-autoscaling.tf
@@ -14,22 +14,36 @@ locals {
     # "tag.${var.tag_namespace}.state_id.value='${var.state_id}'", # TODO optional use w/ config
   ])) : local.autoscaler_compartment_rule
 
-  autoscaler_templates = [
+  autoscaler_nodepool_policy_templates = [
     "Allow dynamic-group %v to manage cluster-node-pools in compartment id %v",
-    "Allow dynamic-group %v to manage compute-management-family in compartment id %v",
     "Allow dynamic-group %v to manage instance-family in compartment id %v",
-    "Allow dynamic-group %v to manage volume-family in compartment id %v",
+  ]
+
+  autoscaler_shared_network_policy_templates = [
     "Allow dynamic-group %v to use subnets in compartment id %v",
-    "Allow dynamic-group %v to read virtual-network-family in compartment id %v",
     "Allow dynamic-group %v to use vnics in compartment id %v",
     "Allow dynamic-group %v to inspect compartments in compartment id %v",
   ]
 
-  autoscaler_policy_statements = var.create_iam_autoscaler_policy ? tolist([
-    for statement in local.autoscaler_templates : formatlist(statement,
-      local.autoscaler_group_name, local.worker_compartments,
+  autoscaler_vcn_read_policy_template = "Allow dynamic-group %v to read virtual-network-family in compartment id %v"
+
+  autoscaler_policy_templates = concat(
+    local.autoscaler_nodepool_policy_templates,
+    local.autoscaler_shared_network_policy_templates,
+    var.network_compartment_id == null ? [local.autoscaler_vcn_read_policy_template] : [],
+  )
+
+  autoscaler_policy_statements = var.create_iam_autoscaler_policy ? flatten([
+    for statement in local.autoscaler_policy_templates : formatlist(
+      statement, local.autoscaler_group_name, local.worker_compartments,
     )
   ]) : []
+
+  autoscaler_network_policy_statements = var.create_iam_autoscaler_policy && var.network_compartment_id != null ? [
+    for statement in concat(
+      local.autoscaler_shared_network_policy_templates, [local.autoscaler_vcn_read_policy_template],
+    ) : format(statement, local.autoscaler_group_name, var.network_compartment_id)
+  ] : []
 }
 
 resource "oci_identity_dynamic_group" "autoscaling" {

--- a/modules/iam/policy.tf
+++ b/modules/iam/policy.tf
@@ -39,13 +39,16 @@ resource "oci_identity_policy" "networking_policies" {
   compartment_id = var.network_compartment_id != null ? var.network_compartment_id : var.compartment_id
   description    = format("Policies for OKE Terraform state %v", var.state_id)
   name           = format("%v-network", var.policy_name)
-  statements     = compact([
+  statements     = concat(compact([
     var.enable_ipv6 ? format("Allow any-user to use ipv6s in compartment id %v where all { request.principal.type = 'cluster' }", coalesce(var.network_compartment_id, var.compartment_id)) : null,
     format("Allow any-user to manage network-security-groups in compartment id %v where request.principal.type = 'cluster'", coalesce(var.network_compartment_id, var.compartment_id)),
-    var.create_iam_karpenter_policy && var.network_compartment_id != null ? format("Allow any-user to manage virtual-network-family in compartment id %v where all { request.principal.type='workload', request.principal.cluster_id = '%v', request.principal.namespace = '%v', request.principal.service_account = 'karpenter' }", coalesce(var.network_compartment_id, var.compartment_id), var.cluster_id, var.karpenter_namespace) : null
-  ])
-  defined_tags   = local.defined_tags
-  freeform_tags  = local.freeform_tags
+    var.create_iam_karpenter_policy && var.network_compartment_id != null ? format("Allow any-user to manage virtual-network-family in compartment id %v where all { request.principal.type='workload', request.principal.cluster_id = '%v', request.principal.namespace = '%v', request.principal.service_account = 'karpenter' }", coalesce(var.network_compartment_id, var.compartment_id), var.cluster_id, var.karpenter_namespace) : null,
+    var.cni_type == "npn" && var.network_compartment_id != null && var.network_compartment_id != var.compartment_id ? format("Allow any-user to use private-ips in compartment id %v where all { request.principal.type = 'cluster' }", var.network_compartment_id) : null,
+    ]),
+    local.autoscaler_network_policy_statements
+  )
+  defined_tags  = local.defined_tags
+  freeform_tags = local.freeform_tags
   lifecycle {
     ignore_changes = [defined_tags, freeform_tags]
   }

--- a/modules/iam/variables.tf
+++ b/modules/iam/variables.tf
@@ -9,6 +9,7 @@ variable "state_id" { type = string }
 variable "tenancy_id" { type = string }
 variable "worker_compartments" { type = list(string) }
 variable "enable_ipv6" { type = bool }
+variable "cni_type" { type = string }
 # Tags
 variable "create_iam_defined_tags" { type = bool }
 variable "create_iam_tag_namespace" { type = bool }

--- a/variables-extensions.tf
+++ b/variables-extensions.tf
@@ -190,7 +190,7 @@ variable "cluster_autoscaler_namespace" {
 }
 
 variable "cluster_autoscaler_helm_version" {
-  default     = "9.24.0"
+  default     = "9.53.0"
   description = "Version of the Helm chart to install. List available releases using `helm search repo [keyword] --versions`."
   type        = string
 }
@@ -434,7 +434,7 @@ variable "karpenter_namespace" {
 }
 
 variable "karpenter_version" {
-  default     = "v1.1.0"
+  default     = "v1.2.0"
   description = "Version of the Helm chart to install. List available releases using `helm search repo [keyword] --versions`."
   type        = string
 }


### PR DESCRIPTION
## Summary
- Bump Karpenter from `v1.1.0` to `v1.2.0`.
- Bump Cluster Autoscaler Helm chart version from `9.24.0` to `9.53.0` and CA image (fixes #1063).
- _[Fix]_ Add [missing IAM policy support for VCN-native CNI](https://docs.oracle.com/en-us/iaas/Content/ContEng/Concepts/contengpodnetworking_topic-OCI_CNI_plugin.htm) when network resources are in a different compartment.
- Refactor Cluster Autoscaler IAM permissions to match [OCI’s documented compartment-specific policy requirements](https://docs.oracle.com/en-us/iaas/Content/ContEng/Tasks/contengusingclusterautoscaler_topic-Working_with_the_Cluster_Autoscaler.htm#contengusingclusterautoscaler_topic-Working_with_the_Cluster_Autoscaler-setup-access).

## Details
- When `network_compartment_id` is set, Cluster Autoscaler requires permissions in both the node pool compartment and the network compartment.
- In the Cluster Autoscaler Helm chart 1.29.0 release, the [cloud provider name changed](https://github.com/kubernetes/autoscaler/commit/c80205bdede75d714a05e4f2da44f555e39d69f0) from `oci-oke` to `oci`.