### PR TITLE
fix(network): guard IPv6 attribute lookups with try() on BYO VCN

### DIFF
--- a/module-network.tf
+++ b/module-network.tf
@@ -14,7 +14,7 @@ locals {
   vcn_lookup             = coalesce(one(data.oci_core_vcn.oke[*].cidr_blocks), [])
   vcn_lookup_cidr_blocks = flatten(local.vcn_lookup)
   vcn_cidrs              = var.create_vcn ? var.vcn_cidrs : local.vcn_lookup_cidr_blocks
-  vcn_ipv6_cidrs         = var.create_vcn ? concat(module.vcn[0].vcn_all_attributes["ipv6cidr_blocks"], module.vcn[0].vcn_all_attributes["byoipv6cidr_blocks"], module.vcn[0].vcn_all_attributes["ipv6private_cidr_blocks"]) : concat(data.oci_core_vcn.oke[0].ipv6cidr_blocks, data.oci_core_vcn.oke[0].byoipv6cidr_blocks, data.oci_core_vcn.oke[0].ipv6private_cidr_blocks)
+  vcn_ipv6_cidrs         = var.create_vcn ? concat(module.vcn[0].vcn_all_attributes["ipv6cidr_blocks"], module.vcn[0].vcn_all_attributes["byoipv6cidr_blocks"], module.vcn[0].vcn_all_attributes["ipv6private_cidr_blocks"]) : concat(try(data.oci_core_vcn.oke[0].ipv6cidr_blocks, []), try(data.oci_core_vcn.oke[0].byoipv6cidr_blocks, []), try(data.oci_core_vcn.oke[0].ipv6private_cidr_blocks, []))
   # Created route table if enabled, else var.ig_route_table_id
   ig_route_table_id = var.create_vcn ? try(one(module.vcn[*].ig_route_id), var.ig_route_table_id) : var.ig_route_table_id
 


### PR DESCRIPTION
## Summary

When \`create_vcn = false\`, \`local.vcn_ipv6_cidrs\` concatenates three attributes off the \`oci_core_vcn\` data source. The \`oracle/oci\` provider v8 returns \`null\` (not \`[]\`) for these fields on any VCN that has no IPv6 configured — common for clusters that BYO their VCN through a separate module. The bare \`concat(null, null, null)\` then fatals.

### Diff
\`\`\`
- concat(data.oci_core_vcn.oke[0].ipv6cidr_blocks,
-        data.oci_core_vcn.oke[0].byoipv6cidr_blocks,
-        data.oci_core_vcn.oke[0].ipv6private_cidr_blocks)
+ concat(try(data.oci_core_vcn.oke[0].ipv6cidr_blocks, []),
+        try(data.oci_core_vcn.oke[0].byoipv6cidr_blocks, []),
+        try(data.oci_core_vcn.oke[0].ipv6private_cidr_blocks, []))
\`\`\`

Mirrors the pattern already used two lines up:
\`\`\`
vcn_lookup = coalesce(one(data.oci_core_vcn.oke[*].cidr_blocks), [])
\`\`\`

## Reproducer

\`\`\`hcl
module \"this\" {
  source     = \"oracle-terraform-modules/oke/oci\"
  version    = \"5.4.3\"
  create_vcn = false
  vcn_id     = oci_core_vcn.external.id   # non-IPv6 VCN
  # ...
}
\`\`\`

On \`tofu apply\`:
\`\`\`
Error: Invalid function argument
  on modules/.../module-network.tf line 17, in locals:
  data.oci_core_vcn.oke[0].ipv6cidr_blocks is null
Call to function \"concat\" failed: argument must not be null.
\`\`\`