### PR TITLE
Add option to allow operator image drift

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -107,7 +107,7 @@ worker_pools = {
 - Workers: `worker_shape`, `worker_image_type`, `worker_image_os`, `worker_image_os_version`
 - Network: `vcn_cidrs`, `subnets`, `nsgs`, `load_balancers`
 - Bastion: `create_bastion`, `bastion_shape`, `bastion_allowed_cidrs`
-- Operator: `create_operator`, `operator_shape`, `operator_upgrade`
+- Operator: `create_operator`, `operator_shape`, `operator_upgrade`, `operator_allow_image_drift`
 
 7. Run Terraform:
 

--- a/docs/terraformoptions.md
+++ b/docs/terraformoptions.md
@@ -611,13 +611,15 @@ The operator instance provides an environment within the VCN from which the OKE 
 | `operator_private_ip` | IP address of an existing operator. Ignored when `create_operator = true`. | string | `null` |
 | `operator_await_cloudinit` | Block Terraform until cloud-init completes on the operator. | `true` / `false` | `true` |
 | `operator_legacy_imds_endpoints_disabled` | Disable IMDSv1 endpoint on the operator. | `true` / `false` | `true` |
+| `operator_allow_image_drift` | When true, newer platform images will not force operator replacement. | `true` / `false` | `false` |
 
 Example with cloud-init:
 
 ```hcl
-create_operator     = true
-operator_upgrade    = false
-operator_user       = "opc"
+create_operator            = true
+operator_upgrade           = false
+operator_user              = "opc"
+operator_allow_image_drift = true
 
 operator_cloud_init = [
   {

--- a/examples/rms/oke-cluster-only/main.tf
+++ b/examples/rms/oke-cluster-only/main.tf
@@ -61,6 +61,7 @@ module "oke" {
   operator_upgrade               = var.operator_upgrade
   operator_user                  = var.operator_user
   operator_volume_kms_key_id     = var.operator_volume_kms_key_id
+  operator_allow_image_drift     = var.operator_allow_image_drift
 
   # SSH
   ssh_public_key  = local.ssh_public_key

--- a/examples/rms/oke-cluster-only/schema.yaml
+++ b/examples/rms/oke-cluster-only/schema.yaml
@@ -76,6 +76,7 @@ variableGroups:
       - operator_install_k9s
       - operator_install_kubectx
       - operator_tags
+      - operator_allow_image_drift
 
   - title: "Cluster"
     variables:
@@ -595,6 +596,13 @@ variables:
     description: Tag values for created resources.
     dependsOn:
       compartmentId: ${compartment_ocid}
+    visible: ${create_operator}
+  operator_allow_image_drift:
+    title: Allow the operator instance image to drift
+    description: Allow the operator instance image to drift from the latest resolved image without forcing replacement.
+    type: boolean
+    default: false
+    required: true
     visible: ${create_operator}
 
   # Cluster

--- a/examples/rms/oke-cluster-only/variables-operator.tf
+++ b/examples/rms/oke-cluster-only/variables-operator.tf
@@ -56,3 +56,4 @@ variable "operator_tags" {
   default = {}
   type    = map(any)
 }
+variable "operator_allow_image_drift" { default = false }

--- a/module-operator.tf
+++ b/module-operator.tf
@@ -83,6 +83,7 @@ module "operator" {
   upgrade                        = var.operator_upgrade
   user                           = var.operator_user
   volume_kms_key_id              = var.operator_volume_kms_key_id
+  allow_image_drift              = var.operator_allow_image_drift
 
 
   # Standard tags as defined if enabled for use, or freeform

--- a/modules/operator/compute.tf
+++ b/modules/operator/compute.tf
@@ -105,12 +105,14 @@ resource "oci_core_instance" "operator" {
 }
 
 resource "null_resource" "operator_changed" {
-  triggers = {
-    cloud_init      = jsonencode(var.cloud_init)
-    image_id        = var.image_id
-    install_helm    = var.install_helm
-    install_k9s     = var.install_k9s
-    install_kubectx = var.install_kubectx
-    ssh_public_key  = var.ssh_public_key
-  }
+  triggers = merge(
+    {
+      cloud_init      = jsonencode(var.cloud_init)
+      install_helm    = var.install_helm
+      install_k9s     = var.install_k9s
+      install_kubectx = var.install_kubectx
+      ssh_public_key  = var.ssh_public_key
+    },
+    var.allow_image_drift ? {} : { image_id = var.image_id }
+  )
 }

--- a/modules/operator/variables.tf
+++ b/modules/operator/variables.tf
@@ -54,3 +54,7 @@ variable "defined_tags" { type = map(string) }
 variable "freeform_tags" { type = map(string) }
 variable "tag_namespace" { type = string }
 variable "use_defined_tags" { type = bool }
+variable "allow_image_drift" {
+  type    = bool
+  default = false
+}

--- a/variables-operator.tf
+++ b/variables-operator.tf
@@ -160,3 +160,9 @@ variable "operator_legacy_imds_endpoints_disabled" {
   description = "Whether to disable requests to the IMDSv1 endpoint and only allow requests to the IMDSv2 endpoint for the operator instance."
   type        = bool
 }
+
+variable "operator_allow_image_drift" {
+  default     = false
+  description = "Allow the operator instance image to drift from the latest resolved image without forcing replacement."
+  type        = bool
+}


### PR DESCRIPTION
## Summary

Adds `operator_allow_image_drift` to control whether changes to the resolved operator image ID should force operator replacement.

When enabled, the operator instance can drift from the latest resolved platform image without triggering `null_resource.operator_changed`, avoiding unexpected operator redeployments during unrelated applies.

## Motivation

The operator instance already ignores `source_details`, but `null_resource.operator_changed` included `image_id` in its triggers. As a result, when a newer platform image became available, Terraform could replace the operator even if the user did not intentionally change operator configuration.

## Changes

- Added root variable `operator_allow_image_drift`, defaulting to `false` to preserve existing behavior.
- Passed the setting into the operator submodule as `allow_image_drift`.
- Updated `null_resource.operator_changed` to include `image_id` only when image drift is not allowed.
- Updated docs and the RMS cluster-only example schema.

## Validation

- `terraform fmt -check -recursive`
- `git diff --check`
- `terraform init -backend=false && terraform validate` in `modules/operator`

Fixes https://github.com/oracle-terraform-modules/terraform-oci-oke/issues/1073